### PR TITLE
Add sync outbox foundation and Firebase secret onboarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,7 @@ NEXT_PUBLIC_API_URL=http://localhost:4000/api
 # Generate with: openssl rand -hex 32
 ENCRYPTION_KEY=GENERATE_WITH_openssl_rand_hex_32
 
-# ── Sync (Phase 9) ───────────────────────────────────────
+# ── Sync (Phase 6.7) ─────────────────────────────────────
 # URL of the Firebase Cloud Function sync receiver endpoint (set after moneypulse-web deploy)
 FIREBASE_SYNC_ENDPOINT=https://REGION-PROJECT_ID.cloudfunctions.net/syncReceiver
 # HMAC signing secret — must match value in GCP Secret Manager (SYNC_SIGNING_SECRET)

--- a/.env.example
+++ b/.env.example
@@ -38,3 +38,13 @@ NEXT_PUBLIC_API_URL=http://localhost:4000/api
 # ── Encryption ───────────────────────────────
 # Generate with: openssl rand -hex 32
 ENCRYPTION_KEY=GENERATE_WITH_openssl_rand_hex_32
+
+# ── Sync (Phase 9) ───────────────────────────────────────
+# URL of the Firebase Cloud Function sync receiver endpoint (set after moneypulse-web deploy)
+FIREBASE_SYNC_ENDPOINT=https://REGION-PROJECT_ID.cloudfunctions.net/syncReceiver
+# HMAC signing secret — must match value in GCP Secret Manager (SYNC_SIGNING_SECRET)
+# Generate with: openssl rand -base64 48
+SYNC_SIGNING_SECRET=GENERATE_WITH_openssl_rand_base64_48
+# Alias pseudonymization secret — never rotate without a data migration
+# Generate with: openssl rand -base64 48
+ALIAS_SECRET=GENERATE_WITH_openssl_rand_base64_48

--- a/.github/agents/mp-architect.agent.md
+++ b/.github/agents/mp-architect.agent.md
@@ -1,0 +1,14 @@
+---
+name: mp-architect
+description: Review MoneyPulse plans and changes for architecture quality, maintainability, and alignment with the local-first domain model.
+argument-hint: Provide the plan, spec, or change summary to review.
+handoffs:
+  - label: Fix The Spec
+    agent: mp-spec-generator
+    prompt: Update the spec to resolve the architecture issues identified above.
+  - label: Implement The Revised Design
+    agent: mp-implementor
+    prompt: Implement the architecture adjustments identified above.
+---
+
+Focus on domain boundaries, module ownership, schema alignment, and long-term maintainability.

--- a/.github/agents/mp-implementor.agent.md
+++ b/.github/agents/mp-implementor.agent.md
@@ -1,0 +1,14 @@
+---
+name: mp-implementor
+description: Implement MoneyPulse features and fixes as small validated slices grounded in specs and current code.
+argument-hint: Describe the slice to implement and point to the owning phase or spec section.
+handoffs:
+  - label: Run Validation Review
+    agent: mp-tester
+    prompt: Validate the implemented slice and report gaps.
+  - label: Perform Code Review
+    agent: mp-reviewer
+    prompt: Review the implemented change for regressions, risks, and missing tests.
+---
+
+Implement only after grounding in the code and phase spec. Keep API, web, shared, DB, and parser contracts aligned.

--- a/.github/agents/mp-lead.agent.md
+++ b/.github/agents/mp-lead.agent.md
@@ -1,0 +1,28 @@
+---
+name: mp-lead
+description: Orchestrate MoneyPulse work by routing to planning, specs, implementation, testing, review, architecture, security, or research specialists.
+argument-hint: Describe the goal, target phase, and constraints.
+handoffs:
+  - label: Plan The Work
+    agent: mp-planner
+    prompt: Turn the current request into a concrete plan with scope, files, validations, and risks.
+  - label: Expand The Spec
+    agent: mp-spec-generator
+    prompt: Update the owning phase spec before implementation.
+  - label: Start Implementation
+    agent: mp-implementor
+    prompt: Implement the smallest validated slice from the approved plan.
+  - label: Review Architecture
+    agent: mp-architect
+    prompt: Review the plan or implementation for architecture quality and domain alignment.
+  - label: Review Security
+    agent: mp-security-architect
+    prompt: Review the plan or implementation for security, privacy, and least-privilege concerns.
+  - label: Do Research
+    agent: mp-research
+    prompt: Gather missing context from specs, code, and external references.
+---
+
+You are the lead delivery agent for the local-first MoneyPulse repository.
+
+Operate as a routing and synthesis layer. Pass forward the relevant phase, domain module, risks, validations, and any cross-surface implications. Require rubber-duck review before implementation is treated as complete.

--- a/.github/agents/mp-planner.agent.md
+++ b/.github/agents/mp-planner.agent.md
@@ -1,0 +1,14 @@
+---
+name: mp-planner
+description: Produce concrete implementation plans for MoneyPulse with file inventories, validation paths, and cross-surface impact notes.
+argument-hint: Describe the bug, feature, or phase objective to plan.
+handoffs:
+  - label: Update The Spec
+    agent: mp-spec-generator
+    prompt: Convert this plan into a detailed spec update.
+  - label: Start Implementation
+    agent: mp-implementor
+    prompt: Implement the first approved vertical slice from this plan.
+---
+
+Always ground the plan in the owning phase spec and the current code path. If the work touches API, web, shared types, DB, parser, or sync, make that explicit.

--- a/.github/agents/mp-research.agent.md
+++ b/.github/agents/mp-research.agent.md
@@ -1,0 +1,14 @@
+---
+name: mp-research
+description: Gather internal and external context for MoneyPulse work, including codebase facts, domain language, parser behavior, and implementation precedents.
+argument-hint: Describe the question or missing context to research.
+handoffs:
+  - label: Turn Research Into Plan
+    agent: mp-planner
+    prompt: Convert these findings into an actionable plan.
+  - label: Turn Research Into Spec
+    agent: mp-spec-generator
+    prompt: Update the relevant spec using these findings.
+---
+
+Distinguish repo facts from recommendations. Prefer findings that reduce implementation ambiguity.

--- a/.github/agents/mp-reviewer.agent.md
+++ b/.github/agents/mp-reviewer.agent.md
@@ -1,0 +1,14 @@
+---
+name: mp-reviewer
+description: Review MoneyPulse specs, plans, and code with emphasis on bugs, regressions, missing tests, and security risks.
+argument-hint: Provide the plan, spec, or implementation summary to review.
+handoffs:
+  - label: Address Findings
+    agent: mp-implementor
+    prompt: Fix the findings identified in this review.
+  - label: Rework The Spec
+    agent: mp-spec-generator
+    prompt: Update the spec to resolve the issues identified in review.
+---
+
+Present findings first, ordered by severity. Keep summaries brief and actionable.

--- a/.github/agents/mp-security-architect.agent.md
+++ b/.github/agents/mp-security-architect.agent.md
@@ -1,0 +1,14 @@
+---
+name: mp-security-architect
+description: Review MoneyPulse changes for security, privacy, auth, sync signing, ingestion abuse resistance, and least-privilege behavior.
+argument-hint: Describe the change or attach the plan or spec section to review.
+handoffs:
+  - label: Revise The Spec
+    agent: mp-spec-generator
+    prompt: Update the spec to address the security findings above.
+  - label: Implement Fixes
+    agent: mp-implementor
+    prompt: Implement the security fixes identified above.
+---
+
+Treat auth, ingestion, file parsing, AI logging, exports, and sync as primary risk surfaces.

--- a/.github/agents/mp-spec-generator.agent.md
+++ b/.github/agents/mp-spec-generator.agent.md
@@ -1,0 +1,14 @@
+---
+name: mp-spec-generator
+description: Expand or create MoneyPulse specs with decisions tables, file inventories, implementation steps, validations, and handoff-ready detail.
+argument-hint: Describe which phase or domain needs a new or updated spec.
+handoffs:
+  - label: Stress-Test The Spec
+    agent: mp-reviewer
+    prompt: Review this spec using the rubber-duck and code-review checklist.
+  - label: Implement From Spec
+    agent: mp-implementor
+    prompt: Implement the first validated slice from the updated spec.
+---
+
+Specs should be executable by an autonomous agent with minimal repo exploration.

--- a/.github/agents/mp-tester.agent.md
+++ b/.github/agents/mp-tester.agent.md
@@ -1,0 +1,14 @@
+---
+name: mp-tester
+description: Validate MoneyPulse changes with the narrowest decisive checks and identify missing coverage or ambiguous outcomes.
+argument-hint: Describe the changed slice and the expected validation path.
+handoffs:
+  - label: Fix The Change
+    agent: mp-implementor
+    prompt: Repair the change based on these validation results.
+  - label: Final Review
+    agent: mp-reviewer
+    prompt: Review the validated change for risk and completeness.
+---
+
+Prefer focused executable validation first. If local services are required, say exactly which services and commands are prerequisites.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,45 @@
+# Project Overview
+
+MoneyPulse is a privacy-first, self-hosted personal finance application. It runs locally with a NestJS API, Next.js web frontend, PostgreSQL, Redis, a Python PDF parser, and optional local AI categorization via Ollama. This repository is the source of truth for household finance data and the upstream publisher for MoneyPulse Web sync.
+
+## Architecture
+
+- `apps/api` is the main business logic surface. It owns auth, ingestion, accounts, transactions, categories, analytics, budgets, notifications, audit, and jobs.
+- `apps/web` is the local UI surface for dashboards, imports, settings, and management flows.
+- `packages/shared` contains shared types, constants, and Zod validation used across API and web.
+- `services/pdf-parser` is a Python service for PDF extraction.
+- `db` contains migrations, seeds, and related scripts.
+
+## Build And Validation
+
+- Use Node 22 and pnpm 10.32.1.
+- Always run `pnpm install` before `pnpm build`, `pnpm test`, or `pnpm test:e2e`.
+- Repo-level scripts are defined in `package.json` and fan out through Turbo.
+- CI runs build, unit tests, e2e tests, Docker builds, and PDF parser tests.
+- The PDF parser uses Python 3.12 in CI.
+
+## Known Runtime Facts
+
+- Podman is the local container runtime in this environment, even if some docs still mention Docker.
+- The API may need `rm tsconfig.tsbuildinfo` if stale incremental artifacts block emission.
+- The shared package uses ESM and `NodeNext`; the API uses CommonJS.
+- Zod v4 imports use `zod/v4`.
+
+## Editing Expectations
+
+- For cross-cutting features, update the relevant phase spec along with code.
+- For backend features, document schema changes, queue behavior, auth impact, and validation.
+- For frontend features, keep the UI information-dense and task-oriented.
+- For Python parser work, keep tests and parser heuristics explicit.
+- For docs, prefer decisions tables, file inventories, dependency commands, validation commands, and acceptance criteria over broad prose.
+
+## Search Guidance
+
+- Start from `MONEYPULSE-PLAN.md` and the relevant `PHASE*-SPEC.md` file.
+- For DB and validation work, inspect `apps/api/src/db`, `packages/shared/src`, and `db/migrations`.
+- For PDF work, inspect `services/pdf-parser/src` and its tests.
+
+## Required Review Discipline
+
+- Every plan, spec, implementation, and fix must pass a rubber-duck review against `docs/agentic/rule-set.md`.
+- When documentation contains validated commands and repo facts, trust it before broad searching.

--- a/.github/instructions/api-stack.instructions.md
+++ b/.github/instructions/api-stack.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: "apps/api/**/*.ts,packages/shared/**/*.ts,db/**/*.ts"
+---
+
+- Preserve clear module boundaries in NestJS. Add new behavior to the owning domain module instead of creating cross-cutting shortcuts.
+- Keep schema, validation, DTOs, service logic, and tests aligned in the same change.
+- Prefer explicit Zod and Drizzle updates over implicit runtime assumptions.
+- When changing auth, ingestion, categorization, analytics, budgets, jobs, or notifications, update the relevant phase spec or implementation notes.
+- Queue behavior, idempotency, rate limits, and audit logging must be explicit for any background or external-input feature.

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: "README.md,docs/**/*.md,PHASE*-SPEC.md,MONEYPULSE-PLAN.md,AGENTS.md,.github/prompts/*.md,.github/agents/*.md,.github/skills/**/SKILL.md"
+---
+
+- Write docs so an autonomous coding agent can act with minimal repo exploration.
+- Prefer this order when relevant: status, decisions, file inventory, dependencies, implementation steps, validation, risks, handoff.
+- Keep commands copy-pasteable and repo-specific.
+- When a workflow depends on Podman, local services, or optional AI components, say so explicitly.
+- Every plan, spec, and implementation workflow must include a rubber-duck review checkpoint.

--- a/.github/instructions/web-stack.instructions.md
+++ b/.github/instructions/web-stack.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: "apps/web/**/*.ts,apps/web/**/*.tsx"
+---
+
+- Use Next.js App Router conventions that match the existing local web application.
+- Keep finance UI dense, fast to scan, and operationally useful. Avoid decorative layouts that hide primary actions or numbers.
+- Prefer explicit loading, error, empty, and stale-data states.
+- Use shared validation and shared types where they already exist instead of duplicating domain contracts.
+- If a frontend change depends on backend behavior, update the relevant phase spec and call out the contract between API and UI.

--- a/.github/prompts/expand-phase-spec.prompt.md
+++ b/.github/prompts/expand-phase-spec.prompt.md
@@ -1,0 +1,18 @@
+---
+name: mp-expand-phase-spec
+description: Expand a MoneyPulse phase spec into an implementation-ready document.
+agent: mp-spec-generator
+argument-hint: phase=<phase> feature=<feature> current-state=<summary>
+---
+
+Expand the target phase spec using the repository's established structure:
+
+- status and goals
+- decisions summary
+- file inventory by layer
+- dependency commands
+- implementation steps
+- validation and acceptance criteria
+- risks and handoff notes
+
+Ground the spec in existing code and current repo conventions.

--- a/.github/prompts/implement-phase-slice.prompt.md
+++ b/.github/prompts/implement-phase-slice.prompt.md
@@ -1,0 +1,18 @@
+---
+name: mp-implement-phase-slice
+description: Implement the smallest validated MoneyPulse slice from a spec.
+agent: mp-implementor
+argument-hint: phase=<phase> slice=<smallest vertical slice> validation=<command or check>
+---
+
+Inputs:
+- phase: ${input:phase:phase file or number}
+- slice: ${input:slice:smallest deliverable slice}
+- validation: ${input:validation:fastest check to run}
+
+Steps:
+1. Confirm the owning spec and direct code path.
+2. State one falsifiable hypothesis.
+3. Make the smallest edit that tests it.
+4. Run the focused validation.
+5. Perform a rubber-duck review and list remaining risks.

--- a/.github/prompts/phase-orchestrate.prompt.md
+++ b/.github/prompts/phase-orchestrate.prompt.md
@@ -1,0 +1,17 @@
+---
+name: mp-phase-orchestrate
+description: Route a MoneyPulse task through the right specialist agent and phase context.
+agent: mp-lead
+argument-hint: phase=<phase> task=<goal> constraints=<constraints>
+---
+
+Inputs:
+- phase: ${input:phase:phase number or domain}
+- task: ${input:task:goal or request}
+- constraints: ${input:constraints:security, parser, infra, UX, or timeline constraints}
+
+Steps:
+1. Identify the owning phase spec and domain surface.
+2. Decide whether the next step is planning, spec work, implementation, testing, review, architecture, security, or research.
+3. Summarize the next specialist handoff in 5-10 lines.
+4. Include the rubber-duck checkpoint before implementation begins.

--- a/.github/prompts/review-phase-work.prompt.md
+++ b/.github/prompts/review-phase-work.prompt.md
@@ -1,0 +1,14 @@
+---
+name: mp-review-phase-work
+description: Review a MoneyPulse spec or implementation for bugs, regressions, missing tests, and security issues.
+agent: mp-reviewer
+argument-hint: target=<spec or change> focus=<bugs|security|tests|architecture>
+---
+
+Review the target work and present findings first.
+
+Inputs:
+- target: ${input:target:spec section, files, or change summary}
+- focus: ${input:focus:bugs, security, tests, architecture, or all}
+
+Use the repository rule set and relevant phase spec as the baseline.

--- a/.github/prompts/rubber-duck.prompt.md
+++ b/.github/prompts/rubber-duck.prompt.md
@@ -1,0 +1,15 @@
+---
+name: mp-rubber-duck
+description: Run the mandatory rubber-duck review for MoneyPulse plans, specs, fixes, or implementations.
+agent: mp-reviewer
+argument-hint: work=<plan/spec/change> summary=<one line>
+---
+
+Run the rubber-duck checklist from `docs/agentic/rule-set.md`.
+
+Output:
+1. The problem.
+2. The smallest solving change.
+3. The invariant or security consequence if wrong.
+4. The validation that proves success.
+5. The next likely failure mode.

--- a/.github/skills/grill-me/SKILL.md
+++ b/.github/skills/grill-me/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: grill-me
+description: Interview the user relentlessly about a MoneyPulse plan, design, or spec until each branch of the decision tree is resolved.
+---
+
+Ask one question at a time.
+
+- Prefer discovering answers from the codebase or specs instead of asking when possible.
+- For each unresolved branch, provide a recommended answer and the tradeoff.
+- Stop only when scope, file areas, validations, and risks are explicit.

--- a/.github/skills/nest-drizzle-feature/SKILL.md
+++ b/.github/skills/nest-drizzle-feature/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: nest-drizzle-feature
+description: Build or review a MoneyPulse backend slice that spans NestJS modules, Drizzle schema, shared validation, and tests.
+---
+
+When using this skill:
+
+- identify the owning module and domain
+- update schema, DTOs, services, controllers, and tests together when the contract changes
+- keep shared types and shared validation aligned
+- document migration, seed, and e2e implications explicitly
+- validate with the narrowest useful build or test command first

--- a/.github/skills/next-finance-ui-slice/SKILL.md
+++ b/.github/skills/next-finance-ui-slice/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: next-finance-ui-slice
+description: Implement or refine a MoneyPulse frontend slice with dense finance UI, clear states, and alignment to shared contracts.
+---
+
+Use this skill when working in `apps/web`.
+
+- keep layouts data-dense and fast to scan
+- prefer explicit loading, empty, error, and stale states
+- reuse shared types and validation where available
+- call out API dependencies and contract changes
+- validate with the smallest targeted UI test or build step available

--- a/.github/skills/pdf-parser-debug/SKILL.md
+++ b/.github/skills/pdf-parser-debug/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: pdf-parser-debug
+description: Investigate or extend the MoneyPulse Python PDF parser with explicit parser rules, fallback logic, and test coverage.
+---
+
+When using this skill:
+
+- isolate whether the issue is extraction, normalization, parser routing, or AI fallback
+- inspect parser tests before changing heuristics
+- keep bank-specific rules explicit and documented
+- validate with the narrowest parser tests first
+- note any local sample files required to reproduce the issue

--- a/.github/skills/rubber-duck-review/SKILL.md
+++ b/.github/skills/rubber-duck-review/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: rubber-duck-review
+description: Run the mandatory MoneyPulse rubber-duck review on a plan, spec, implementation, or fix before handoff or completion.
+---
+
+Checklist:
+1. State the exact problem.
+2. State the smallest solving change.
+3. State the invariant that must remain true.
+4. State the validation that proves success.
+5. State the next likely failure mode.
+
+If any answer is unclear, keep refining the plan or implementation.

--- a/.github/workflows/validate-ai-customizations.yml
+++ b/.github/workflows/validate-ai-customizations.yml
@@ -1,0 +1,25 @@
+name: Validate AI Customizations
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main, 'feature/**', 'copilot/**']
+
+jobs:
+  validate-ai-customizations:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Validate customization structure
+        run: node scripts/validate-ai-customizations.mjs
+
+      - name: Lint customization markdown
+        run: npx markdownlint-cli2 "AGENTS.md" ".github/**/*.md" "docs/agentic/**/*.md"

--- a/.github/workflows/validate-ai-customizations.yml
+++ b/.github/workflows/validate-ai-customizations.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main, 'feature/**', 'copilot/**']
 
+permissions:
+  contents: read
+
 jobs:
   validate-ai-customizations:
     runs-on: ubuntu-latest

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,10 @@
+{
+  "default": true,
+  "MD013": false,
+  "MD025": false,
+  "MD032": false,
+  "MD034": false,
+  "MD033": false,
+  "MD041": false,
+  "MD047": false
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# MoneyPulse Agent Guide
+
+This repository is the local-first MoneyPulse application: NestJS API, Next.js web UI, shared TypeScript package, Python PDF parser, PostgreSQL, Redis, and MCP tooling. It is the system of record for household finance data and the upstream source for MoneyPulse Web sync.
+
+## Working Rules
+
+- Start from `MONEYPULSE-PLAN.md` and the relevant `PHASE*-SPEC.md` file before implementing or restructuring code.
+- Preserve local-first privacy guarantees. Cloud sync, AI categorization, exports, and integrations must never weaken the primary local data boundary.
+- Prefer vertical slices with explicit file inventories, validation commands, and acceptance criteria.
+- Keep backend, frontend, shared package, and PDF parser changes coordinated in specs when a feature crosses boundaries.
+- Use the rubber-duck loop in `docs/agentic/rule-set.md` for every plan, spec, bug fix, and implementation.
+
+## Key Paths
+
+- `apps/api` — NestJS 11 API and business logic
+- `apps/web` — Next.js 16 local web UI
+- `packages/shared` — shared constants, types, and validation
+- `services/pdf-parser` — Python PDF extraction service
+- `db` — migrations, seeds, scripts
+- `.github/copilot-instructions.md` — repo-wide Copilot guidance
+- `.github/instructions` — path-specific instructions
+- `.github/agents` — custom agents for VS Code and Copilot CLI
+- `.github/prompts` — reusable prompts
+- `.github/skills` — portable Agent Skills
+
+## Validation Defaults
+
+- Install: `pnpm install`
+- Build: `pnpm build`
+- Test: `pnpm test`
+- E2E: `pnpm test:e2e`
+- API migrations: `pnpm db:migrate`
+
+Local runtime notes belong in docs and specs, not only in chat. When a workflow depends on Podman, local Postgres/Redis, or PDF parser setup, document the exact commands.

--- a/MONEYPULSE-PLAN.md
+++ b/MONEYPULSE-PLAN.md
@@ -353,6 +353,7 @@ moneypulse/
 | **Phase 5** | ✅ DONE        | `aa15b99` | Dashboard & visualization: 7 analytics SQL endpoints (user-scoped, camelCase transforms), 8 Recharts chart components, dashboard with KPI cards + PeriodSelector, transactions with bulk select + CSV export, upload with drag-drop + history, accounts + categories CRUD pages, AppShell layout (collapsible sidebar, TopBar with notifications, dark mode). 112 API tests + 11 web tests pass. Security fixes: 13 Dependabot vulnerabilities resolved via pnpm overrides |
 | **Phase 5.5** | ✅ DONE      | —         | Dashboard drill-down UX, ingestion hardening: clickable KPI cards, chart drill-down, URL-driven transaction filters, imports page with error detail modal + delete, CSV preamble stripping (BofA), relax_quotes, failed-upload re-upload bypass, DELETE /uploads/:id endpoint, transaction-level dedup (hash + externalId), CC payment category + seed rules, account column with lastFour, sign convention fix |
 | **Phase 6** | ✅ DONE        | —         | Budgets & alerts: per-category monthly/weekly budgets, savings goals, HA webhook notifications, email digests, 80%/100% thresholds. Security hardening: AES-256-GCM column encryption (last_four, original_description, webhook URLs, AI logs), helmet + CSP headers, JWT HS256 pinned, Redis auth, localhost-bound services, admin-only AI logs, Swagger gated, cookie httpOnly, CSV formula injection fix, audit logging for exports. 67 categories, AI observability dashboard. 147 tests pass |
+| **Phase 6.7** | ⬜ Planned    | —         | Cloud Sync Domain (local -> Firebase projection): outbox events, sanitizer v2, alias mapper, signing service, delivery worker with retries + dead-letter queue, policy tests (no banned fields / no reverse-sync routes), sync audit trail with payload hash + policy decision |
 | **Phase 7** | ⬜ Not started | —         | MCP server                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | **Phase 8** | ⬜ Not started | —         | Investment account tracking                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | **Phase 9** | 🔮 Future      | —         | Microsoft Agent Framework                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
@@ -758,6 +759,29 @@ All queries filter: `WHERE is_split_parent = false AND deleted_at IS NULL`
 - `apps/api/src/notifications/` — webhook + email services
 - `apps/api/src/jobs/budget-check.job.ts` — cron processor
 - `apps/web/src/app/budgets/page.tsx` — budget management page
+
+---
+
+## Phase 6.7: Cloud Sync Domain (Local -> Firebase)
+
+**Dependencies: Phase 6**
+
+| #   | Step                        | Details                                                                                                                                                                                                                                         |
+| --- | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 6.7.1 | Outbox persistence        | Add `outbox_events` table. Domain writes append projection events in the same transaction as local changes. Include payload hash, idempotency key, attempts, status, and policy fields.                                                   |
+| 6.7.2 | Sanitizer v2              | Strict outbound policy engine that enforces allowlist schema and denylist patterns. Reject payloads with banned fields (PII/account identifiers/raw AI text) and persist policy reason codes.                                             |
+| 6.7.3 | Alias mapper              | Deterministic pseudonymous IDs for users, accounts, transactions, categories, and budgets. Local UUIDs never leave the local boundary.                                                                                                      |
+| 6.7.4 | Signing service           | HMAC signature + key id + timestamp + idempotency key headers for each outbound event to Firebase ingestion endpoint.                                                                                                                         |
+| 6.7.5 | Delivery worker + DLQ     | BullMQ processor pulls pending events, retries with exponential backoff + jitter, marks dead-letter after max attempts, and supports safe replay tooling.                                                                                   |
+| 6.7.6 | Policy and boundary tests | Add tests to enforce no banned fields in outbound payloads and verify no reverse sync routes are exposed by local API.                                                                                                                        |
+| 6.7.7 | Sync audit trail          | Add `sync_audit_logs` entries for every attempt: payload hash, policy pass/fail, reason, signature key id, HTTP status, and error details.                                                                                                  |
+
+### Key Files
+
+- `PHASE9-SYNC-SPEC.md` — implementation spec for sync domain
+- `apps/api/src/sync/` — sanitizer v2, alias mapper, signing, policies
+- `apps/api/src/jobs/sync-delivery.processor.ts` — outbox delivery processor
+- `apps/api/test/sync-no-reverse-route.e2e-spec.ts` — boundary test
 
 ---
 

--- a/PHASE9-SYNC-SPEC.md
+++ b/PHASE9-SYNC-SPEC.md
@@ -1,0 +1,302 @@
+# Phase 9 Sync Domain Spec - Local to Firebase Projection
+
+## Purpose
+
+Build a secure, one-way sync domain in the local MoneyPulse API that projects de-identified financial data to the Firebase web app.
+
+## Non-Negotiable Constraints
+
+1. Source of truth stays local.
+2. No reverse-sync endpoint is exposed by local API.
+3. No direct PII or account-number-derived values are sent.
+4. Every outbound event is signed and auditable.
+5. Failed deliveries are retryable and end in a dead-letter queue.
+
+## Scope
+
+### In Scope
+
+- outbox_events table and lifecycle
+- sanitizer-v2 service (strict allowlist and denylist)
+- alias mapper service (deterministic pseudonyms)
+- signing service (HMAC signatures)
+- delivery worker with retry policy and DLQ
+- policy tests and audit trail for sync decisions
+
+### Out of Scope
+
+- bi-directional data synchronization
+- auto-apply cloud-origin edits to local data
+- replication of raw AI prompt text
+
+## Architecture
+
+1. Domain producers write normalized event payloads to outbox_events in the same transaction as domain changes.
+2. Delivery worker polls pending outbox rows in FIFO order.
+3. Payload passes sanitizer-v2 and banned-field policy checks.
+4. Alias mapper rewrites local identifiers to alias identifiers.
+5. Signing service computes payload signature with nonce and timestamp.
+6. Worker sends event to Firebase ingestion endpoint.
+7. Result is recorded in sync audit logs and outbox status is updated.
+8. Permanent failures move to dead-letter state for manual replay.
+
+## Database Design
+
+### Table: outbox_events
+
+Suggested columns:
+
+- id uuid primary key
+- event_type varchar(80) not null
+- aggregate_type varchar(80) not null
+- aggregate_id uuid not null
+- user_id uuid not null
+- household_id uuid null
+- payload_json jsonb not null
+- payload_hash varchar(64) not null
+- schema_version integer not null default 1
+- idempotency_key varchar(128) not null unique
+- status varchar(24) not null default pending
+- policy_passed boolean null
+- policy_reason text null
+- attempts integer not null default 0
+- next_attempt_at timestamptz not null default now()
+- last_error_code varchar(64) null
+- last_error_message text null
+- delivered_at timestamptz null
+- dead_lettered_at timestamptz null
+- created_at timestamptz not null default now()
+- updated_at timestamptz not null default now()
+
+Indexes:
+
+- idx_outbox_status_next_attempt on (status, next_attempt_at)
+- idx_outbox_user_created on (user_id, created_at desc)
+- idx_outbox_aggregate on (aggregate_type, aggregate_id)
+
+### Optional Table: alias_mappings
+
+- id uuid primary key
+- user_id uuid not null
+- entity_type varchar(40) not null
+- local_entity_id uuid not null
+- alias_id varchar(64) not null
+- alias_version integer not null default 1
+- created_at timestamptz not null default now()
+- updated_at timestamptz not null default now()
+- unique(entity_type, local_entity_id)
+- unique(entity_type, alias_id)
+
+### Table: sync_audit_logs
+
+- id bigserial primary key
+- outbox_event_id uuid not null
+- user_id uuid null
+- action varchar(40) not null
+- payload_hash varchar(64) not null
+- policy_passed boolean not null
+- policy_reason text null
+- signature_kid varchar(64) null
+- attempt_no integer not null
+- http_status integer null
+- error_code varchar(64) null
+- error_message text null
+- created_at timestamptz not null default now()
+
+## Service Design
+
+### sanitizer-v2 service
+
+Path suggestion:
+
+- apps/api/src/sync/sanitizer-v2.service.ts
+
+Responsibilities:
+
+1. Enforce outbound schema allowlist by event type.
+2. Remove or reject banned fields.
+3. Run advanced token scrub for:
+- email, phone, account/routing patterns, address-like strings
+- raw merchant free-text with potential identity markers
+- any field tagged as pii in schema metadata
+4. Emit policy decision with reason codes.
+
+Required reason codes:
+
+- POLICY_PASS
+- POLICY_FAIL_BANNED_FIELD
+- POLICY_FAIL_PATTERN_MATCH
+- POLICY_FAIL_SCHEMA
+
+### alias mapper service
+
+Path suggestion:
+
+- apps/api/src/sync/alias-mapper.service.ts
+
+Responsibilities:
+
+1. Map local IDs to deterministic alias IDs.
+2. Never output local UUIDs in outbound payload.
+3. Support alias versioning for key rotation.
+
+Recommended alias formula:
+
+- alias = base32url(HMAC_SHA256(ALIAS_SECRET_vN, entity_type + ':' + local_id))
+
+### signing service
+
+Path suggestion:
+
+- apps/api/src/sync/signing.service.ts
+
+Responsibilities:
+
+1. Create canonical payload string.
+2. Produce HMAC signature with key id.
+3. Attach headers:
+- x-mp-signature
+- x-mp-key-id
+- x-mp-timestamp
+- x-mp-idempotency-key
+
+### delivery worker
+
+Path suggestion:
+
+- apps/api/src/jobs/sync-delivery.processor.ts
+
+Responsibilities:
+
+1. Pull due events where status in (pending, retry).
+2. Backoff strategy: exponential with jitter.
+3. Max attempts: 8 before dead-letter.
+4. Mark delivered on 2xx only.
+5. Persist every attempt in sync_audit_logs.
+
+Retry policy example:
+
+- attempt 1: immediate
+- 2: 30s
+- 3: 2m
+- 4: 10m
+- 5: 30m
+- 6: 2h
+- 7: 8h
+- 8: 24h then dead-letter
+
+## API and Routing Rules
+
+1. Local API must not expose any route that accepts Firebase-origin writes for financial entities.
+2. Any future cloud-edit support must go through command mailbox, never direct mutation route.
+3. Add test guard to fail if route patterns contain:
+- /sync/import
+- /sync/apply
+- /firebase/pull
+
+## Event Contracts
+
+Minimum event types for MVP:
+
+- account.projected.v1
+- transaction.projected.v1
+- category.projected.v1
+- budget.projected.v1
+- notification.projected.v1
+- ai_summary.projected.v1
+
+Each contract must include:
+
+- event_id
+- event_type
+- schema_version
+- occurred_at
+- user_alias_id
+- household_alias_id
+- body
+
+## Test Plan
+
+### Policy tests
+
+Path suggestions:
+
+- apps/api/src/sync/__tests__/sanitizer-v2.spec.ts
+- apps/api/src/sync/__tests__/policy-guard.spec.ts
+
+Required cases:
+
+1. Reject outbound payload containing banned field names:
+- email
+- accountNumber
+- routingNumber
+- lastFour
+- originalDescriptionRaw
+- promptText
+- outputText
+2. Reject outbound payload containing pattern-level PII.
+3. Pass sanitized payload with expected reason POLICY_PASS.
+
+### Routing tests
+
+Path suggestion:
+
+- apps/api/test/sync-no-reverse-route.e2e-spec.ts
+
+Required case:
+
+- Assert no reverse sync write endpoints are reachable.
+
+### Worker tests
+
+Path suggestion:
+
+- apps/api/src/jobs/__tests__/sync-delivery.processor.spec.ts
+
+Required cases:
+
+1. Success path marks delivered and writes audit row.
+2. Transient failure increments attempts and schedules retry.
+3. Max-attempt failure dead-letters and records reason.
+4. Signature header present and valid format.
+
+## Observability
+
+Metrics to expose:
+
+- sync_outbox_pending_count
+- sync_delivery_success_total
+- sync_delivery_failure_total
+- sync_dead_letter_total
+- sync_policy_fail_total
+- sync_delivery_latency_ms
+
+Log fields per attempt:
+
+- outbox_event_id
+- event_type
+- idempotency_key
+- payload_hash
+- policy_passed
+- policy_reason
+- attempt
+- http_status
+- duration_ms
+
+## Implementation Order
+
+1. DB migration for outbox_events and sync_audit_logs.
+2. Add sync module skeleton and interfaces.
+3. Implement sanitizer-v2 and alias mapper.
+4. Implement signing service and outbound client.
+5. Implement delivery processor and retry scheduling.
+6. Add policy tests and no-reverse-route tests.
+7. Add dashboards/metrics and operator runbook.
+
+## Exit Criteria
+
+1. Sync events delivered with signed headers and idempotency keys.
+2. All outbound payloads pass sanitizer-v2 policies.
+3. Banned-field and no-reverse-route tests pass in CI.
+4. Audit log entries exist for every delivery attempt with payload hash and policy result.
+5. Dead-letter workflow and manual replay runbook documented.

--- a/README.md
+++ b/README.md
@@ -453,6 +453,104 @@ pnpm build            # Build all packages
 pnpm lint             # Lint all packages
 ```
 
+---
+
+## AI-Assisted Development
+
+MoneyPulse is configured for GitHub Copilot autonomous development using a full agent, prompt, and skill layer.
+
+→ Full guide: [docs/agentic/README.md](docs/agentic/README.md)  
+→ Rule set and decision-tree checkpoints: [docs/agentic/rule-set.md](docs/agentic/rule-set.md)  
+→ Agent roster: [AGENTS.md](AGENTS.md)
+
+### How to Start
+
+**Always start from the lead agent.** Open GitHub Copilot Chat in VS Code, select the `mp-lead` agent from the agent picker, then describe what you want to work on. The lead agent classifies the work and routes it to the right specialist.
+
+### Step-by-Step Workflow for Any Phase
+
+```
+1. Open VS Code → Copilot Chat → select agent: mp-lead
+2. State: "I want to work on Phase 7 MCP server — [your goal]"
+3. Lead routes to mp-planner (plan) or mp-spec-generator (spec expansion) first
+4. After plan/spec: lead routes to mp-implementor for coding
+5. After coding: mp-tester validates, mp-reviewer checks for regressions
+6. Before handoff: rubber-duck review via mp-reviewer or /mp-rubber-duck prompt
+```
+
+### Phase-by-Phase Quick Commands
+
+Paste these exactly into Copilot Chat after selecting the `mp-lead` agent (or the named specialist directly):
+
+#### Phase 7 — MCP Server for AI Agents
+
+```
+/mp-phase-orchestrate phase=PHASE7 task=Implement MCP server query tools constraints=read-only SQL via existing Drizzle schema
+```
+
+```
+/mp-expand-phase-spec phase=PHASE7 feature=MCP query tools current-state=scaffold planned, no implementation yet
+```
+
+```
+/mp-implement-phase-slice phase=PHASE7 slice=get_transactions MCP tool validation=pnpm --filter=@moneypulse/api test
+```
+
+```
+/mp-review-phase-work target=PHASE7 MCP implementation focus=security
+```
+
+#### Phase 8 — Investment Account Tracking
+
+```
+/mp-phase-orchestrate phase=PHASE8 task=Investment account schema and snapshot history constraints=extend existing Drizzle schema without breaking Phase 1-6 migrations
+```
+
+```
+/mp-expand-phase-spec phase=PHASE8 feature=investment account ingestion current-state=planned only
+```
+
+```
+/mp-implement-phase-slice phase=PHASE8 slice=investment_accounts Drizzle schema and migration validation=DATABASE_URL=... pnpm db:generate
+```
+
+#### For Any Phase — Rubber-Duck Before Handoff
+
+```
+/mp-rubber-duck work=<plan or change summary> summary=<one-line problem statement>
+```
+
+#### Stress-Testing a Spec Before Implementation
+
+```
+/mp-review-phase-work target=PHASE7-SPEC.md focus=all
+```
+
+### Skills Available as Slash Commands
+
+| Slash command | When to use |
+|---|---|
+| `/grill-me` | When a design or spec is vague — forces branch-by-branch resolution |
+| `/rubber-duck-review` | Before any handoff or completion |
+| `/nest-drizzle-feature` | When building a new NestJS module + Drizzle schema slice |
+| `/next-finance-ui-slice` | When adding or updating a finance UI screen |
+| `/pdf-parser-debug` | When debugging or extending the Python PDF parser |
+
+### Pre-commit Hooks
+
+On every commit, the following run automatically:
+
+```bash
+node scripts/validate-ai-customizations.mjs   # checks agent/skill/prompt structure
+npx markdownlint-cli2 ...                      # lints AGENTS.md + .github docs
+```
+
+To re-run manually:
+
+```bash
+node scripts/validate-ai-customizations.mjs
+```
+
 ## License
 
 This project is licensed under the MIT License — see the [LICENSE](LICENSE) file for details.

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -19,6 +19,7 @@ import { BudgetsModule } from './budgets/budgets.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { JobsModule } from './jobs/jobs.module';
 import { AiLogsModule } from './ai-logs/ai-logs.module';
+import { SyncModule } from './sync/sync.module';
 
 @Module({
   imports: [
@@ -57,6 +58,7 @@ import { AiLogsModule } from './ai-logs/ai-logs.module';
     AnalyticsModule,
     BudgetsModule,
     NotificationsModule,
+    SyncModule,
     JobsModule,
     AiLogsModule,
     HealthModule,

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -391,6 +391,77 @@ export const aiPromptLogs = pgTable(
   ],
 );
 
+// ── Sync Outbox (Phase 6.7) ───────────────────────────────
+
+export const outboxEvents = pgTable(
+  'outbox_events',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    eventType: varchar('event_type', { length: 80 }).notNull(),
+    aggregateType: varchar('aggregate_type', { length: 80 }).notNull(),
+    aggregateId: uuid('aggregate_id').notNull(),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id),
+    householdId: uuid('household_id').references(() => households.id),
+    payloadJson: jsonb('payload_json').notNull(),
+    payloadHash: varchar('payload_hash', { length: 64 }).notNull(),
+    schemaVersion: integer('schema_version').notNull().default(1),
+    idempotencyKey: varchar('idempotency_key', { length: 128 })
+      .notNull()
+      .unique(),
+    status: varchar('status', { length: 24 }).notNull().default('pending'),
+    policyPassed: boolean('policy_passed'),
+    policyReason: text('policy_reason'),
+    attempts: integer('attempts').notNull().default(0),
+    nextAttemptAt: timestamp('next_attempt_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    lastErrorCode: varchar('last_error_code', { length: 64 }),
+    lastErrorMessage: text('last_error_message'),
+    deliveredAt: timestamp('delivered_at', { withTimezone: true }),
+    deadLetteredAt: timestamp('dead_lettered_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index('idx_outbox_status_next_attempt').on(table.status, table.nextAttemptAt),
+    index('idx_outbox_user_created').on(table.userId, table.createdAt),
+    index('idx_outbox_aggregate').on(table.aggregateType, table.aggregateId),
+  ],
+);
+
+export const syncAuditLogs = pgTable(
+  'sync_audit_logs',
+  {
+    id: bigserial('id', { mode: 'number' }).primaryKey(),
+    outboxEventId: uuid('outbox_event_id')
+      .notNull()
+      .references(() => outboxEvents.id),
+    userId: uuid('user_id').references(() => users.id),
+    action: varchar('action', { length: 40 }).notNull(),
+    payloadHash: varchar('payload_hash', { length: 64 }).notNull(),
+    policyPassed: boolean('policy_passed').notNull(),
+    policyReason: text('policy_reason'),
+    signatureKid: varchar('signature_kid', { length: 64 }),
+    attemptNo: integer('attempt_no').notNull(),
+    httpStatus: integer('http_status'),
+    errorCode: varchar('error_code', { length: 64 }),
+    errorMessage: text('error_message'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index('idx_sync_audit_outbox').on(table.outboxEventId),
+    index('idx_sync_audit_created').on(table.createdAt),
+  ],
+);
+
 // ── Relations ───────────────────────────────────────────────
 
 export const householdRelations = relations(households, ({ many }) => ({

--- a/apps/api/src/jobs/__tests__/sync-delivery.processor.spec.ts
+++ b/apps/api/src/jobs/__tests__/sync-delivery.processor.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SyncDeliveryProcessor } from '../sync-delivery.processor';
+import type { Job } from 'bullmq';
+
+function makeJob(name: string): Job {
+  return { name, id: 'job-1', data: {} } as unknown as Job;
+}
+
+describe('SyncDeliveryProcessor', () => {
+  let processor: SyncDeliveryProcessor;
+  let syncDeliveryMock: { deliverPending: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    syncDeliveryMock = { deliverPending: vi.fn() };
+    processor = new SyncDeliveryProcessor(syncDeliveryMock as any);
+  });
+
+  it('calls deliverPending and logs result for deliver-pending-sync job', async () => {
+    syncDeliveryMock.deliverPending.mockResolvedValue(5);
+    const logSpy = vi.spyOn(processor['logger'], 'log').mockImplementation(() => undefined);
+
+    await processor.process(makeJob('deliver-pending-sync'));
+
+    expect(syncDeliveryMock.deliverPending).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('5'),
+    );
+  });
+
+  it('skips deliverPending for unknown job names and logs a warning', async () => {
+    const warnSpy = vi.spyOn(processor['logger'], 'warn').mockImplementation(() => undefined);
+
+    await processor.process(makeJob('unknown-job'));
+
+    expect(syncDeliveryMock.deliverPending).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('unknown-job'));
+  });
+
+  it('does not throw when deliverPending returns 0', async () => {
+    syncDeliveryMock.deliverPending.mockResolvedValue(0);
+    vi.spyOn(processor['logger'], 'log').mockImplementation(() => undefined);
+
+    await expect(
+      processor.process(makeJob('deliver-pending-sync')),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/jobs/jobs.module.ts
+++ b/apps/api/src/jobs/jobs.module.ts
@@ -4,19 +4,24 @@ import { Queue } from 'bullmq';
 import { AlertCronProcessor } from './alert-cron.processor';
 import { ReminderProcessor } from './reminder.processor';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { SyncModule } from '../sync/sync.module';
+import { SyncDeliveryProcessor } from './sync-delivery.processor';
 
 @Module({
   imports: [
     BullModule.registerQueue({ name: 'alerts' }),
     BullModule.registerQueue({ name: 'reminders' }),
+    BullModule.registerQueue({ name: 'sync-delivery' }),
     NotificationsModule,
+    SyncModule,
   ],
-  providers: [AlertCronProcessor, ReminderProcessor],
+  providers: [AlertCronProcessor, ReminderProcessor, SyncDeliveryProcessor],
 })
 export class JobsModule implements OnModuleInit {
   constructor(
     @InjectQueue('alerts') private readonly alertsQueue: Queue,
     @InjectQueue('reminders') private readonly remindersQueue: Queue,
+    @InjectQueue('sync-delivery') private readonly syncQueue: Queue,
   ) {}
 
   async onModuleInit() {
@@ -39,6 +44,13 @@ export class JobsModule implements OnModuleInit {
       'monthly-investment',
       { pattern: '0 9 1 * *' },
       { name: 'investment-reminder' },
+    );
+
+    // Frequent sync delivery sweep for outbox events.
+    await this.syncQueue.upsertJobScheduler(
+      'sync-delivery-sweep',
+      { every: 30000 },
+      { name: 'deliver-pending-sync' },
     );
   }
 }

--- a/apps/api/src/jobs/sync-delivery.processor.ts
+++ b/apps/api/src/jobs/sync-delivery.processor.ts
@@ -1,0 +1,23 @@
+import { Processor, WorkerHost } from '@nestjs/bullmq';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bullmq';
+import { SyncDeliveryService } from '../sync/sync-delivery.service';
+
+@Processor('sync-delivery')
+export class SyncDeliveryProcessor extends WorkerHost {
+  private readonly logger = new Logger(SyncDeliveryProcessor.name);
+
+  constructor(private readonly syncDelivery: SyncDeliveryService) {
+    super();
+  }
+
+  async process(job: Job): Promise<void> {
+    if (job.name !== 'deliver-pending-sync') {
+      this.logger.warn(`Unknown sync job: ${job.name}`);
+      return;
+    }
+
+    const delivered = await this.syncDelivery.deliverPending();
+    this.logger.log(`Sync delivery sweep processed ${delivered} events`);
+  }
+}

--- a/apps/api/src/sync/__tests__/policy-guard.spec.ts
+++ b/apps/api/src/sync/__tests__/policy-guard.spec.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { SanitizerV2Service } from '../sanitizer-v2.service';
+
+describe('SanitizerV2Service — policy guard: banned fields', () => {
+  const sanitizer = new SanitizerV2Service();
+
+  const bannedCases: Array<[string, Record<string, unknown>]> = [
+    ['email', { email: 'user@example.com', amountCents: 100 }],
+    ['accountNumber', { accountNumber: '12345678', amountCents: 100 }],
+    ['routingNumber', { routingNumber: '021000021', amountCents: 100 }],
+    ['lastFour', { lastFour: '4242', amountCents: 100 }],
+    ['originalDescriptionRaw', { originalDescriptionRaw: 'raw text', amountCents: 100 }],
+    ['promptText', { promptText: 'what is...', amountCents: 100 }],
+    ['outputText', { outputText: 'categorized as food', amountCents: 100 }],
+  ];
+
+  it.each(bannedCases)(
+    'rejects payload containing banned field: %s',
+    (field, payload) => {
+      const result = sanitizer.sanitizePayload(payload);
+      expect(result.policyPassed).toBe(false);
+      expect(result.policyReason).toBe('POLICY_FAIL_BANNED_FIELD');
+      expect(result.bannedField).toBe(field);
+    },
+  );
+
+  it('rejects banned field nested in object', () => {
+    const result = sanitizer.sanitizePayload({
+      body: { email: 'hidden@example.com' },
+      amountCents: 500,
+    });
+    expect(result.policyPassed).toBe(false);
+    expect(result.policyReason).toBe('POLICY_FAIL_BANNED_FIELD');
+    expect(result.bannedField).toBe('email');
+  });
+
+  it('rejects banned field nested in array', () => {
+    const result = sanitizer.sanitizePayload({
+      items: [{ accountNumber: '9999' }],
+      amountCents: 500,
+    });
+    expect(result.policyPassed).toBe(false);
+    expect(result.policyReason).toBe('POLICY_FAIL_BANNED_FIELD');
+    expect(result.bannedField).toBe('accountNumber');
+  });
+
+  it('rejects payload containing SSN-like pattern', () => {
+    const result = sanitizer.sanitizePayload({
+      note: 'ssn 123-45-6789',
+      amountCents: 100,
+    });
+    expect(result.policyPassed).toBe(false);
+    expect(result.policyReason).toBe('POLICY_FAIL_PATTERN_MATCH');
+  });
+
+  it('rejects payload containing email-like pattern in value', () => {
+    const result = sanitizer.sanitizePayload({
+      note: 'contact user@private.com for info',
+    });
+    expect(result.policyPassed).toBe(false);
+    expect(result.policyReason).toBe('POLICY_FAIL_PATTERN_MATCH');
+  });
+
+  it('passes safe payload with no banned fields or PII patterns', () => {
+    const result = sanitizer.sanitizePayload({
+      transactionAliasId: 'a1_abc123',
+      accountAliasId: 'a1_def456',
+      amountCents: 2500,
+      isCredit: false,
+      tags: ['groceries'],
+      categoryId: 'some-uuid',
+    });
+    expect(result.policyPassed).toBe(true);
+    expect(result.policyReason).toBe('POLICY_PASS');
+    expect(result.sanitizedPayload).toMatchObject({ amountCents: 2500 });
+  });
+});

--- a/apps/api/src/sync/__tests__/sanitizer-v2.service.spec.ts
+++ b/apps/api/src/sync/__tests__/sanitizer-v2.service.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { SanitizerV2Service } from '../sanitizer-v2.service';
+
+describe('SanitizerV2Service', () => {
+  const sanitizer = new SanitizerV2Service();
+
+  it('rejects payloads containing banned fields', () => {
+    const result = sanitizer.sanitizePayload({
+      event: 'transaction.projected.v1',
+      email: 'user@example.com',
+    });
+
+    expect(result.policyPassed).toBe(false);
+    expect(result.policyReason).toBe('POLICY_FAIL_BANNED_FIELD');
+    expect(result.bannedField).toBe('email');
+  });
+
+  it('rejects payloads containing pii-like patterns', () => {
+    const result = sanitizer.sanitizePayload({
+      event: 'transaction.projected.v1',
+      description: 'transfer to 123-45-6789',
+    });
+
+    expect(result.policyPassed).toBe(false);
+    expect(result.policyReason).toBe('POLICY_FAIL_PATTERN_MATCH');
+  });
+
+  it('passes and keeps safe payloads', () => {
+    const result = sanitizer.sanitizePayload({
+      event: 'transaction.projected.v1',
+      merchantToken: 'merchant_9bc1',
+      amountCents: 1250,
+    });
+
+    expect(result.policyPassed).toBe(true);
+    expect(result.policyReason).toBe('POLICY_PASS');
+    expect(result.sanitizedPayload).toEqual({
+      event: 'transaction.projected.v1',
+      merchantToken: 'merchant_9bc1',
+      amountCents: 1250,
+    });
+  });
+});

--- a/apps/api/src/sync/__tests__/signing.service.spec.ts
+++ b/apps/api/src/sync/__tests__/signing.service.spec.ts
@@ -1,15 +1,18 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { SigningService } from '../signing.service';
 
 describe('SigningService', () => {
   const signing = new SigningService();
 
   beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-19T19:15:00.000Z'));
     process.env.SYNC_SIGNING_SECRET = 'sync-secret-test';
     process.env.SYNC_SIGNING_KEY_ID = 'sync-key-v1';
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     delete process.env.SYNC_SIGNING_SECRET;
     delete process.env.SYNC_SIGNING_KEY_ID;
   });
@@ -24,5 +27,19 @@ describe('SigningService', () => {
     expect(signed.idempotencyKey).toBe('idem-123');
     expect(signed.signature).toHaveLength(64);
     expect(new Date(signed.timestamp).toString()).not.toBe('Invalid Date');
+  });
+
+  it('produces the same signature for equivalent payloads with different key order', () => {
+    const left = signing.signPayload(
+      { eventType: 'budget.projected.v1', nested: { b: 2, a: 1 } },
+      'idem-123',
+    );
+    const right = signing.signPayload(
+      { nested: { a: 1, b: 2 }, eventType: 'budget.projected.v1' },
+      'idem-123',
+    );
+
+    expect(left.timestamp).toBe('2026-04-19T19:15:00.000Z');
+    expect(right.signature).toBe(left.signature);
   });
 });

--- a/apps/api/src/sync/__tests__/signing.service.spec.ts
+++ b/apps/api/src/sync/__tests__/signing.service.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { SigningService } from '../signing.service';
+
+describe('SigningService', () => {
+  const signing = new SigningService();
+
+  beforeEach(() => {
+    process.env.SYNC_SIGNING_SECRET = 'sync-secret-test';
+    process.env.SYNC_SIGNING_KEY_ID = 'sync-key-v1';
+  });
+
+  afterEach(() => {
+    delete process.env.SYNC_SIGNING_SECRET;
+    delete process.env.SYNC_SIGNING_KEY_ID;
+  });
+
+  it('produces signature metadata for canonical payload', () => {
+    const signed = signing.signPayload(
+      { eventType: 'budget.projected.v1', amountCents: 5000 },
+      'idem-123',
+    );
+
+    expect(signed.keyId).toBe('sync-key-v1');
+    expect(signed.idempotencyKey).toBe('idem-123');
+    expect(signed.signature).toHaveLength(64);
+    expect(new Date(signed.timestamp).toString()).not.toBe('Invalid Date');
+  });
+});

--- a/apps/api/src/sync/__tests__/sync-delivery.service.spec.ts
+++ b/apps/api/src/sync/__tests__/sync-delivery.service.spec.ts
@@ -1,0 +1,350 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SyncDeliveryService } from '../sync-delivery.service';
+import { SanitizerV2Service } from '../sanitizer-v2.service';
+import { AliasMapperService } from '../alias-mapper.service';
+import { SigningService } from '../signing.service';
+import { SYNC_MAX_ATTEMPTS } from '../sync.constants';
+
+// ---------------------------------------------------------------------------
+// Helpers / fixtures
+// ---------------------------------------------------------------------------
+
+function makeRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'evt-001',
+    event_type: 'transaction.projected.v1',
+    user_id: 'user-abc',
+    payload_json: { amountCents: 500, isCredit: false, tags: [] },
+    attempts: 0,
+    idempotency_key: 'idem-xyz',
+    ...overrides,
+  };
+}
+
+function buildDb(overrides: Partial<ReturnType<typeof buildDb>> = {}) {
+  const where = vi.fn().mockResolvedValue(undefined);
+  const set = vi.fn().mockReturnValue({ where });
+  const update = vi.fn().mockReturnValue({ set });
+  const insertValues = vi.fn().mockResolvedValue(undefined);
+  const insert = vi.fn().mockReturnValue({ values: insertValues });
+  const execute = vi.fn().mockResolvedValue({ rows: [] });
+
+  return { execute, update, insert, set, where, insertValues, ...overrides };
+}
+
+function buildSanitizer(pass = true) {
+  const sanitizer = new SanitizerV2Service();
+  vi.spyOn(sanitizer, 'sanitizePayload').mockReturnValue(
+    pass
+      ? { policyPassed: true, policyReason: 'POLICY_PASS', sanitizedPayload: { amountCents: 500 } }
+      : { policyPassed: false, policyReason: 'POLICY_FAIL_BANNED_FIELD', sanitizedPayload: {}, bannedField: 'email' },
+  );
+  return sanitizer;
+}
+
+function buildAliasMapper(fail = false) {
+  const mapper = new AliasMapperService();
+  if (fail) {
+    vi.spyOn(mapper, 'toAliasId').mockImplementation(() => {
+      throw new Error('ALIAS_SECRET must be set for sync alias mapping');
+    });
+  } else {
+    vi.spyOn(mapper, 'toAliasId').mockReturnValue('a1_alias123');
+  }
+  return mapper;
+}
+
+function buildSigning(fail = false) {
+  const signing = new SigningService();
+  if (fail) {
+    vi.spyOn(signing, 'signPayload').mockImplementation(() => {
+      throw new Error('SYNC_SIGNING_SECRET must be set for sync payload signing');
+    });
+  } else {
+    vi.spyOn(signing, 'signPayload').mockReturnValue({
+      signature: 'sig-abc',
+      keyId: 'sync-key-v1',
+      timestamp: '2026-04-26T00:00:00.000Z',
+      idempotencyKey: 'idem-xyz',
+    });
+  }
+  return signing;
+}
+
+function buildService(
+  db: ReturnType<typeof buildDb>,
+  sanitizer: SanitizerV2Service,
+  aliasMapper: AliasMapperService,
+  signing: SigningService,
+) {
+  return new SyncDeliveryService(db as any, sanitizer, aliasMapper, signing);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SyncDeliveryService', () => {
+  const originalFetch = global.fetch;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.FIREBASE_SYNC_ENDPOINT = 'https://example.com/sync';
+    process.env.ALIAS_SECRET = 'alias-secret-test';
+    process.env.SYNC_SIGNING_SECRET = 'signing-secret-test';
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // deliverPending
+  // -------------------------------------------------------------------------
+
+  describe('deliverPending', () => {
+    it('returns the count of processed rows', async () => {
+      const db = buildDb();
+      db.execute.mockResolvedValue({
+        rows: [makeRow(), makeRow({ id: 'evt-002' })],
+      });
+      global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+
+      const service = buildService(db, buildSanitizer(), buildAliasMapper(), buildSigning());
+      const count = await service.deliverPending(10);
+
+      expect(count).toBe(2);
+    });
+
+    it('returns 0 when no rows are due', async () => {
+      const db = buildDb();
+      db.execute.mockResolvedValue({ rows: [] });
+
+      const service = buildService(db, buildSanitizer(), buildAliasMapper(), buildSigning());
+      const count = await service.deliverPending();
+
+      expect(count).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Policy-fail path
+  // -------------------------------------------------------------------------
+
+  describe('policy-fail path', () => {
+    it('marks the event as policy_failed and writes an audit row', async () => {
+      const db = buildDb();
+      const sanitizer = buildSanitizer(false);
+      const service = buildService(db, sanitizer, buildAliasMapper(), buildSigning());
+
+      db.execute.mockResolvedValue({ rows: [makeRow()] });
+      await service.deliverPending();
+
+      expect(db.update).toHaveBeenCalledTimes(1);
+      const setArg = db.set.mock.calls[0][0];
+      expect(setArg.status).toBe('policy_failed');
+      expect(setArg.policyPassed).toBe(false);
+
+      expect(db.insert).toHaveBeenCalledTimes(1);
+      const auditArg = db.insertValues.mock.calls[0][0];
+      expect(auditArg.policyPassed).toBe(false);
+      expect(auditArg.errorCode).toBe('POLICY');
+    });
+
+    it('does not call fetch when policy fails', async () => {
+      const db = buildDb();
+      db.execute.mockResolvedValue({ rows: [makeRow()] });
+      const fetchSpy = vi.fn();
+      global.fetch = fetchSpy;
+
+      const service = buildService(db, buildSanitizer(false), buildAliasMapper(), buildSigning());
+      await service.deliverPending();
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Signing/alias error path (now wrapped in try/catch)
+  // -------------------------------------------------------------------------
+
+  describe('signing/alias error path', () => {
+    it('marks the event as retry when alias mapping throws', async () => {
+      const db = buildDb();
+      db.execute.mockResolvedValue({ rows: [makeRow()] });
+
+      const service = buildService(db, buildSanitizer(), buildAliasMapper(true), buildSigning());
+      await service.deliverPending();
+
+      expect(db.update).toHaveBeenCalledTimes(1);
+      const setArg = db.set.mock.calls[0][0];
+      expect(setArg.status).toBe('retry');
+      expect(setArg.lastErrorCode).toBe('SIGNING_ERROR');
+    });
+
+    it('marks the event as retry when signing throws', async () => {
+      const db = buildDb();
+      db.execute.mockResolvedValue({ rows: [makeRow()] });
+
+      const service = buildService(db, buildSanitizer(), buildAliasMapper(), buildSigning(true));
+      await service.deliverPending();
+
+      expect(db.update).toHaveBeenCalledTimes(1);
+      const setArg = db.set.mock.calls[0][0];
+      expect(setArg.status).toBe('retry');
+      expect(setArg.lastErrorCode).toBe('SIGNING_ERROR');
+    });
+
+    it('does not call fetch when signing/alias fails', async () => {
+      const db = buildDb();
+      db.execute.mockResolvedValue({ rows: [makeRow()] });
+      const fetchSpy = vi.fn();
+      global.fetch = fetchSpy;
+
+      const service = buildService(db, buildSanitizer(), buildAliasMapper(true), buildSigning());
+      await service.deliverPending();
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Endpoint-missing retry path
+  // -------------------------------------------------------------------------
+
+  describe('endpoint-missing path', () => {
+    it('marks the event as retry with NO_ENDPOINT code when endpoint is empty', async () => {
+      delete process.env.FIREBASE_SYNC_ENDPOINT;
+
+      const db = buildDb();
+      db.execute.mockResolvedValue({ rows: [makeRow()] });
+
+      const service = buildService(db, buildSanitizer(), buildAliasMapper(), buildSigning());
+      await service.deliverPending();
+
+      expect(db.update).toHaveBeenCalledTimes(1);
+      const setArg = db.set.mock.calls[0][0];
+      expect(setArg.status).toBe('retry');
+      expect(setArg.lastErrorCode).toBe('NO_ENDPOINT');
+      expect(setArg.attempts).toBe(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Non-2xx retry path
+  // -------------------------------------------------------------------------
+
+  describe('non-2xx retry path', () => {
+    it('marks the event as retry and records the HTTP status code', async () => {
+      const db = buildDb();
+      db.execute.mockResolvedValue({ rows: [makeRow()] });
+      global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 503 });
+
+      const service = buildService(db, buildSanitizer(), buildAliasMapper(), buildSigning());
+      await service.deliverPending();
+
+      expect(db.update).toHaveBeenCalledTimes(1);
+      const setArg = db.set.mock.calls[0][0];
+      expect(setArg.status).toBe('retry');
+      expect(setArg.lastErrorCode).toBe('HTTP_503');
+      expect(setArg.attempts).toBe(1);
+
+      const auditArg = db.insertValues.mock.calls[0][0];
+      expect(auditArg.httpStatus).toBe(503);
+      expect(auditArg.policyPassed).toBe(false);
+    });
+
+    it('marks the event as retry on a network error', async () => {
+      const db = buildDb();
+      db.execute.mockResolvedValue({ rows: [makeRow()] });
+      global.fetch = vi.fn().mockRejectedValue(new Error('Connection refused'));
+
+      const service = buildService(db, buildSanitizer(), buildAliasMapper(), buildSigning());
+      await service.deliverPending();
+
+      const setArg = db.set.mock.calls[0][0];
+      expect(setArg.status).toBe('retry');
+      expect(setArg.lastErrorCode).toBe('NETWORK_ERROR');
+      expect(setArg.lastErrorMessage).toBe('Connection refused');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Max-attempt dead-letter path
+  // -------------------------------------------------------------------------
+
+  describe('dead-letter path', () => {
+    it('marks the event as dead_letter when attempts reach SYNC_MAX_ATTEMPTS', async () => {
+      const db = buildDb();
+      const row = makeRow({ attempts: SYNC_MAX_ATTEMPTS - 1 });
+      db.execute.mockResolvedValue({ rows: [row] });
+      global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+
+      const service = buildService(db, buildSanitizer(), buildAliasMapper(), buildSigning());
+      await service.deliverPending();
+
+      const setArg = db.set.mock.calls[0][0];
+      expect(setArg.status).toBe('dead_letter');
+      expect(setArg.deadLetteredAt).toBeInstanceOf(Date);
+      expect(setArg.attempts).toBe(SYNC_MAX_ATTEMPTS);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Successful delivery path
+  // -------------------------------------------------------------------------
+
+  describe('successful delivery path', () => {
+    it('marks the event as delivered and increments attempts', async () => {
+      const db = buildDb();
+      const row = makeRow({ attempts: 2 });
+      db.execute.mockResolvedValue({ rows: [row] });
+      global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+
+      const service = buildService(db, buildSanitizer(), buildAliasMapper(), buildSigning());
+      await service.deliverPending();
+
+      expect(db.update).toHaveBeenCalledTimes(1);
+      const setArg = db.set.mock.calls[0][0];
+      expect(setArg.status).toBe('delivered');
+      expect(setArg.attempts).toBe(3);
+      expect(setArg.deliveredAt).toBeInstanceOf(Date);
+      expect(setArg.lastErrorCode).toBeNull();
+      expect(setArg.lastErrorMessage).toBeNull();
+    });
+
+    it('writes an audit log row on successful delivery', async () => {
+      const db = buildDb();
+      db.execute.mockResolvedValue({ rows: [makeRow()] });
+      global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+
+      const service = buildService(db, buildSanitizer(), buildAliasMapper(), buildSigning());
+      await service.deliverPending();
+
+      expect(db.insert).toHaveBeenCalledTimes(1);
+      const auditArg = db.insertValues.mock.calls[0][0];
+      expect(auditArg.policyPassed).toBe(true);
+      expect(auditArg.policyReason).toBe('POLICY_PASS');
+      expect(auditArg.httpStatus).toBe(200);
+      expect(auditArg.errorCode).toBeNull();
+      expect(auditArg.attemptNo).toBe(1);
+    });
+
+    it('sends correct HTTP headers to the sync endpoint', async () => {
+      const db = buildDb();
+      db.execute.mockResolvedValue({ rows: [makeRow()] });
+      const fetchSpy = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+      global.fetch = fetchSpy;
+
+      const service = buildService(db, buildSanitizer(), buildAliasMapper(), buildSigning());
+      await service.deliverPending();
+
+      const [, init] = fetchSpy.mock.calls[0];
+      expect(init.headers['x-mp-signature']).toBe('sig-abc');
+      expect(init.headers['x-mp-key-id']).toBe('sync-key-v1');
+      expect(init.headers['x-mp-idempotency-key']).toBe('idem-xyz');
+    });
+  });
+});

--- a/apps/api/src/sync/__tests__/sync-payload.util.spec.ts
+++ b/apps/api/src/sync/__tests__/sync-payload.util.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canonicalizeSyncPayload,
+  hashSyncPayload,
+} from '../sync-payload.util';
+
+describe('sync-payload.util', () => {
+  it('canonicalizes object keys deterministically', () => {
+    const left = canonicalizeSyncPayload({
+      zebra: 1,
+      alpha: { y: 2, x: 1 },
+      list: [{ b: 2, a: 1 }],
+    });
+
+    const right = canonicalizeSyncPayload({
+      list: [{ a: 1, b: 2 }],
+      alpha: { x: 1, y: 2 },
+      zebra: 1,
+    });
+
+    expect(left).toBe(right);
+    expect(left).toBe('{"alpha":{"x":1,"y":2},"list":[{"a":1,"b":2}],"zebra":1}');
+  });
+
+  it('drops undefined values from canonical form and hashes consistently', () => {
+    const first = hashSyncPayload({ a: 1, b: undefined, c: 'ok' });
+    const second = hashSyncPayload({ c: 'ok', a: 1 });
+
+    expect(first).toBe(second);
+    expect(first).toHaveLength(64);
+  });
+});

--- a/apps/api/src/sync/alias-mapper.service.ts
+++ b/apps/api/src/sync/alias-mapper.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { createHmac } from 'crypto';
+
+@Injectable()
+export class AliasMapperService {
+  private getAliasSecret(): string {
+    return process.env.ALIAS_SECRET || '';
+  }
+
+  toAliasId(entityType: string, localId: string, version = 1): string {
+    const secret = this.getAliasSecret();
+    if (!secret) {
+      throw new Error('ALIAS_SECRET must be set for sync alias mapping');
+    }
+
+    const digest = createHmac('sha256', `${secret}:v${version}`)
+      .update(`${entityType}:${localId}`)
+      .digest('hex');
+
+    return `a${version}_${digest.slice(0, 40)}`;
+  }
+}

--- a/apps/api/src/sync/outbox.service.ts
+++ b/apps/api/src/sync/outbox.service.ts
@@ -27,26 +27,39 @@ export class OutboxService {
    */
   async enqueue(input: OutboxEnqueueInput): Promise<void> {
     try {
-      const idempotencyKey = `${input.eventType}:${input.aggregateId}:${randomUUID()}`;
-      const payloadHash = hashSyncPayload(input.payload);
-
-      await this.db.insert(schema.outboxEvents).values({
-        eventType: input.eventType,
-        aggregateType: input.aggregateType,
-        aggregateId: input.aggregateId,
-        userId: input.userId,
-        householdId: input.householdId ?? null,
-        payloadJson: input.payload,
-        payloadHash,
-        schemaVersion: input.schemaVersion ?? 1,
-        idempotencyKey,
-        status: 'pending',
-        nextAttemptAt: new Date(),
-      });
+      await this.insertRow(this.db, input);
     } catch (err) {
       this.logger.error(
         `Failed to enqueue outbox event ${input.eventType} for ${input.aggregateId}: ${(err as Error).message}`,
       );
     }
+  }
+
+  /**
+   * Enqueue a sync event within an existing Drizzle transaction context.
+   * Propagates errors so the outer transaction can roll back atomically.
+   * Use this when the domain write and outbox insert must succeed or fail together.
+   */
+  async enqueueInTx(tx: any, input: OutboxEnqueueInput): Promise<void> {
+    await this.insertRow(tx, input);
+  }
+
+  private async insertRow(executor: any, input: OutboxEnqueueInput): Promise<void> {
+    const idempotencyKey = `${input.eventType}:${input.aggregateId}:${randomUUID()}`;
+    const payloadHash = hashSyncPayload(input.payload);
+
+    await executor.insert(schema.outboxEvents).values({
+      eventType: input.eventType,
+      aggregateType: input.aggregateType,
+      aggregateId: input.aggregateId,
+      userId: input.userId,
+      householdId: input.householdId ?? null,
+      payloadJson: input.payload,
+      payloadHash,
+      schemaVersion: input.schemaVersion ?? 1,
+      idempotencyKey,
+      status: 'pending',
+      nextAttemptAt: new Date(),
+    });
   }
 }

--- a/apps/api/src/sync/outbox.service.ts
+++ b/apps/api/src/sync/outbox.service.ts
@@ -1,0 +1,52 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { DATABASE_CONNECTION } from '../db/db.module';
+import * as schema from '../db/schema';
+import { hashSyncPayload } from './sync-payload.util';
+
+export interface OutboxEnqueueInput {
+  eventType: string;
+  aggregateType: string;
+  aggregateId: string;
+  userId: string;
+  householdId?: string | null;
+  payload: Record<string, unknown>;
+  schemaVersion?: number;
+}
+
+@Injectable()
+export class OutboxService {
+  private readonly logger = new Logger(OutboxService.name);
+
+  constructor(@Inject(DATABASE_CONNECTION) private readonly db: any) {}
+
+  /**
+   * Enqueue a sync event for outbound delivery.
+   * Non-fatal: logs errors rather than throwing, so domain operations succeed
+   * even when the outbox insert fails (eventual consistency).
+   */
+  async enqueue(input: OutboxEnqueueInput): Promise<void> {
+    try {
+      const idempotencyKey = `${input.eventType}:${input.aggregateId}:${randomUUID()}`;
+      const payloadHash = hashSyncPayload(input.payload);
+
+      await this.db.insert(schema.outboxEvents).values({
+        eventType: input.eventType,
+        aggregateType: input.aggregateType,
+        aggregateId: input.aggregateId,
+        userId: input.userId,
+        householdId: input.householdId ?? null,
+        payloadJson: input.payload,
+        payloadHash,
+        schemaVersion: input.schemaVersion ?? 1,
+        idempotencyKey,
+        status: 'pending',
+        nextAttemptAt: new Date(),
+      });
+    } catch (err) {
+      this.logger.error(
+        `Failed to enqueue outbox event ${input.eventType} for ${input.aggregateId}: ${(err as Error).message}`,
+      );
+    }
+  }
+}

--- a/apps/api/src/sync/sanitizer-v2.service.ts
+++ b/apps/api/src/sync/sanitizer-v2.service.ts
@@ -1,0 +1,92 @@
+import { Injectable } from '@nestjs/common';
+import { SYNC_BANNED_FIELDS, SYNC_PII_PATTERNS } from './sync.constants';
+import type { SyncPolicyResult } from './sync.types';
+
+@Injectable()
+export class SanitizerV2Service {
+  sanitizePayload(payload: Record<string, unknown>): SyncPolicyResult {
+    const bannedField = this.findBannedField(payload);
+    if (bannedField) {
+      return {
+        policyPassed: false,
+        policyReason: 'POLICY_FAIL_BANNED_FIELD',
+        sanitizedPayload: {},
+        bannedField,
+      };
+    }
+
+    if (this.containsPiiLikeValue(payload)) {
+      return {
+        policyPassed: false,
+        policyReason: 'POLICY_FAIL_PATTERN_MATCH',
+        sanitizedPayload: {},
+      };
+    }
+
+    const sanitizedPayload = this.dropUndefined(payload);
+    return {
+      policyPassed: true,
+      policyReason: 'POLICY_PASS',
+      sanitizedPayload,
+    };
+  }
+
+  private findBannedField(node: unknown): string | null {
+    if (!node || typeof node !== 'object') {
+      return null;
+    }
+
+    if (Array.isArray(node)) {
+      for (const item of node) {
+        const found = this.findBannedField(item);
+        if (found) return found;
+      }
+      return null;
+    }
+
+    for (const [key, value] of Object.entries(node)) {
+      if (SYNC_BANNED_FIELDS.has(key)) {
+        return key;
+      }
+      const found = this.findBannedField(value);
+      if (found) return found;
+    }
+
+    return null;
+  }
+
+  private containsPiiLikeValue(node: unknown): boolean {
+    if (node == null) return false;
+
+    if (typeof node === 'string') {
+      return SYNC_PII_PATTERNS.some((pattern) => {
+        pattern.lastIndex = 0;
+        const matched = pattern.test(node);
+        pattern.lastIndex = 0;
+        return matched;
+      });
+    }
+
+    if (Array.isArray(node)) {
+      return node.some((item) => this.containsPiiLikeValue(item));
+    }
+
+    if (typeof node === 'object') {
+      return Object.values(node).some((value) => this.containsPiiLikeValue(value));
+    }
+
+    return false;
+  }
+
+  private dropUndefined(
+    payload: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(payload)) {
+      if (value !== undefined) {
+        out[key] = value;
+      }
+    }
+    return out;
+  }
+}

--- a/apps/api/src/sync/signing.service.ts
+++ b/apps/api/src/sync/signing.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { createHmac } from 'crypto';
 import type { SignedPayload } from './sync.types';
+import { canonicalizeSyncPayload } from './sync-payload.util';
 
 @Injectable()
 export class SigningService {
@@ -16,7 +17,7 @@ export class SigningService {
     }
 
     const timestamp = new Date().toISOString();
-    const canonical = JSON.stringify(body);
+    const canonical = canonicalizeSyncPayload(body);
     const toSign = `${timestamp}\n${idempotencyKey}\n${canonical}`;
 
     const signature = createHmac('sha256', keySecret).update(toSign).digest('hex');

--- a/apps/api/src/sync/signing.service.ts
+++ b/apps/api/src/sync/signing.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { createHmac } from 'crypto';
+import type { SignedPayload } from './sync.types';
+
+@Injectable()
+export class SigningService {
+  signPayload(
+    body: Record<string, unknown>,
+    idempotencyKey: string,
+  ): SignedPayload {
+    const keyId = process.env.SYNC_SIGNING_KEY_ID || 'sync-key-v1';
+    const keySecret = process.env.SYNC_SIGNING_SECRET;
+
+    if (!keySecret) {
+      throw new Error('SYNC_SIGNING_SECRET must be set for sync payload signing');
+    }
+
+    const timestamp = new Date().toISOString();
+    const canonical = JSON.stringify(body);
+    const toSign = `${timestamp}\n${idempotencyKey}\n${canonical}`;
+
+    const signature = createHmac('sha256', keySecret).update(toSign).digest('hex');
+
+    return {
+      signature,
+      keyId,
+      timestamp,
+      idempotencyKey,
+    };
+  }
+}

--- a/apps/api/src/sync/sync-delivery.service.ts
+++ b/apps/api/src/sync/sync-delivery.service.ts
@@ -1,0 +1,179 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { sql } from 'drizzle-orm';
+import { DATABASE_CONNECTION } from '../db/db.module';
+import * as schema from '../db/schema';
+import { SanitizerV2Service } from './sanitizer-v2.service';
+import { AliasMapperService } from './alias-mapper.service';
+import { SigningService } from './signing.service';
+import { SYNC_MAX_ATTEMPTS } from './sync.constants';
+
+interface OutboxRow {
+  id: string;
+  event_type: string;
+  user_id: string;
+  payload_json: Record<string, unknown>;
+  attempts: number;
+  idempotency_key: string;
+}
+
+@Injectable()
+export class SyncDeliveryService {
+  private readonly logger = new Logger(SyncDeliveryService.name);
+  private readonly endpoint = process.env.FIREBASE_SYNC_ENDPOINT || '';
+
+  constructor(
+    @Inject(DATABASE_CONNECTION) private readonly db: any,
+    private readonly sanitizer: SanitizerV2Service,
+    private readonly aliasMapper: AliasMapperService,
+    private readonly signing: SigningService,
+  ) {}
+
+  async deliverPending(limit = 25): Promise<number> {
+    const due = await this.db.execute(sql`
+      SELECT id, event_type, user_id, payload_json, attempts, idempotency_key
+      FROM ${schema.outboxEvents}
+      WHERE status IN ('pending', 'retry')
+        AND next_attempt_at <= NOW()
+      ORDER BY created_at ASC
+      LIMIT ${limit}
+    `);
+
+    const rows = (due.rows ?? due) as OutboxRow[];
+    for (const row of rows) {
+      await this.deliverOne(row);
+    }
+    return rows.length;
+  }
+
+  private async deliverOne(row: OutboxRow): Promise<void> {
+    const policy = this.sanitizer.sanitizePayload(row.payload_json);
+
+    if (!policy.policyPassed) {
+      await this.markPolicyFailed(row, policy.policyReason);
+      return;
+    }
+
+    const userAlias = this.aliasMapper.toAliasId('user', row.user_id);
+    const projected = {
+      ...policy.sanitizedPayload,
+      userAliasId: userAlias,
+    };
+
+    const signed = this.signing.signPayload(projected, row.idempotency_key);
+
+    if (!this.endpoint) {
+      this.logger.warn('FIREBASE_SYNC_ENDPOINT is not configured, scheduling retry');
+      await this.markRetry(row, 'NO_ENDPOINT', 'Missing FIREBASE_SYNC_ENDPOINT');
+      return;
+    }
+
+    const startedAt = Date.now();
+
+    try {
+      const res = await fetch(this.endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-mp-signature': signed.signature,
+          'x-mp-key-id': signed.keyId,
+          'x-mp-timestamp': signed.timestamp,
+          'x-mp-idempotency-key': signed.idempotencyKey,
+        },
+        body: JSON.stringify(projected),
+        signal: AbortSignal.timeout(15_000),
+      });
+
+      if (res.ok) {
+        await this.db
+          .update(schema.outboxEvents)
+          .set({
+            status: 'delivered',
+            deliveredAt: new Date(),
+            updatedAt: new Date(),
+          })
+          .where(sql`${schema.outboxEvents.id} = ${row.id}`);
+
+        await this.insertAudit(row, true, 'POLICY_PASS', row.attempts + 1, res.status, null, null, signed.keyId);
+        return;
+      }
+
+      await this.markRetry(row, `HTTP_${res.status}`, `Delivery failed with status ${res.status}`, signed.keyId, res.status);
+      this.logger.warn(`Sync delivery failed for ${row.id} with status ${res.status} in ${Date.now() - startedAt}ms`);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      await this.markRetry(row, 'NETWORK_ERROR', message, signed.keyId);
+    }
+  }
+
+  private computeBackoffMillis(attempt: number): number {
+    const caps = [0, 30_000, 120_000, 600_000, 1_800_000, 7_200_000, 28_800_000, 86_400_000];
+    const base = caps[Math.min(attempt, caps.length - 1)] || 86_400_000;
+    const jitter = Math.floor(Math.random() * 5_000);
+    return base + jitter;
+  }
+
+  private async markPolicyFailed(row: OutboxRow, reason: string): Promise<void> {
+    await this.db
+      .update(schema.outboxEvents)
+      .set({
+        status: 'policy_failed',
+        policyPassed: false,
+        policyReason: reason,
+        updatedAt: new Date(),
+      })
+      .where(sql`${schema.outboxEvents.id} = ${row.id}`);
+
+    await this.insertAudit(row, false, reason, row.attempts + 1, null, 'POLICY', 'Policy rejection');
+  }
+
+  private async markRetry(
+    row: OutboxRow,
+    code: string,
+    message: string,
+    signatureKeyId: string | null = null,
+    httpStatus: number | null = null,
+  ): Promise<void> {
+    const nextAttempts = row.attempts + 1;
+    const deadLetter = nextAttempts >= SYNC_MAX_ATTEMPTS;
+
+    await this.db
+      .update(schema.outboxEvents)
+      .set({
+        attempts: nextAttempts,
+        status: deadLetter ? 'dead_letter' : 'retry',
+        nextAttemptAt: new Date(Date.now() + this.computeBackoffMillis(nextAttempts)),
+        lastErrorCode: code,
+        lastErrorMessage: message,
+        deadLetteredAt: deadLetter ? new Date() : null,
+        updatedAt: new Date(),
+      })
+      .where(sql`${schema.outboxEvents.id} = ${row.id}`);
+
+    await this.insertAudit(row, false, 'POLICY_PASS', nextAttempts, httpStatus, code, message, signatureKeyId);
+  }
+
+  private async insertAudit(
+    row: OutboxRow,
+    policyPassed: boolean,
+    policyReason: string,
+    attemptNo: number,
+    httpStatus: number | null,
+    errorCode: string | null,
+    errorMessage: string | null,
+    signatureKeyId: string | null = null,
+  ): Promise<void> {
+    await this.db.insert(schema.syncAuditLogs).values({
+      outboxEventId: row.id,
+      userId: row.user_id,
+      action: 'delivery_attempt',
+      payloadHash: 'deferred',
+      policyPassed,
+      policyReason,
+      signatureKid: signatureKeyId,
+      attemptNo,
+      httpStatus,
+      errorCode,
+      errorMessage,
+    });
+  }
+}

--- a/apps/api/src/sync/sync-delivery.service.ts
+++ b/apps/api/src/sync/sync-delivery.service.ts
@@ -6,6 +6,7 @@ import { SanitizerV2Service } from './sanitizer-v2.service';
 import { AliasMapperService } from './alias-mapper.service';
 import { SigningService } from './signing.service';
 import { SYNC_MAX_ATTEMPTS } from './sync.constants';
+import { hashSyncPayload } from './sync-payload.util';
 
 interface OutboxRow {
   id: string;
@@ -49,7 +50,11 @@ export class SyncDeliveryService {
     const policy = this.sanitizer.sanitizePayload(row.payload_json);
 
     if (!policy.policyPassed) {
-      await this.markPolicyFailed(row, policy.policyReason);
+      await this.markPolicyFailed(
+        row,
+        policy.policyReason,
+        hashSyncPayload(row.payload_json),
+      );
       return;
     }
 
@@ -63,7 +68,14 @@ export class SyncDeliveryService {
 
     if (!this.endpoint) {
       this.logger.warn('FIREBASE_SYNC_ENDPOINT is not configured, scheduling retry');
-      await this.markRetry(row, 'NO_ENDPOINT', 'Missing FIREBASE_SYNC_ENDPOINT');
+      await this.markRetry(
+        row,
+        'NO_ENDPOINT',
+        'Missing FIREBASE_SYNC_ENDPOINT',
+        null,
+        null,
+        hashSyncPayload(projected),
+      );
       return;
     }
 
@@ -93,15 +105,39 @@ export class SyncDeliveryService {
           })
           .where(sql`${schema.outboxEvents.id} = ${row.id}`);
 
-        await this.insertAudit(row, true, 'POLICY_PASS', row.attempts + 1, res.status, null, null, signed.keyId);
+        await this.insertAudit(
+          row,
+          hashSyncPayload(projected),
+          true,
+          'POLICY_PASS',
+          row.attempts + 1,
+          res.status,
+          null,
+          null,
+          signed.keyId,
+        );
         return;
       }
 
-      await this.markRetry(row, `HTTP_${res.status}`, `Delivery failed with status ${res.status}`, signed.keyId, res.status);
+      await this.markRetry(
+        row,
+        `HTTP_${res.status}`,
+        `Delivery failed with status ${res.status}`,
+        signed.keyId,
+        res.status,
+        hashSyncPayload(projected),
+      );
       this.logger.warn(`Sync delivery failed for ${row.id} with status ${res.status} in ${Date.now() - startedAt}ms`);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Unknown error';
-      await this.markRetry(row, 'NETWORK_ERROR', message, signed.keyId);
+      await this.markRetry(
+        row,
+        'NETWORK_ERROR',
+        message,
+        signed.keyId,
+        null,
+        hashSyncPayload(projected),
+      );
     }
   }
 
@@ -112,7 +148,11 @@ export class SyncDeliveryService {
     return base + jitter;
   }
 
-  private async markPolicyFailed(row: OutboxRow, reason: string): Promise<void> {
+  private async markPolicyFailed(
+    row: OutboxRow,
+    reason: string,
+    payloadHash: string,
+  ): Promise<void> {
     await this.db
       .update(schema.outboxEvents)
       .set({
@@ -123,7 +163,16 @@ export class SyncDeliveryService {
       })
       .where(sql`${schema.outboxEvents.id} = ${row.id}`);
 
-    await this.insertAudit(row, false, reason, row.attempts + 1, null, 'POLICY', 'Policy rejection');
+    await this.insertAudit(
+      row,
+      payloadHash,
+      false,
+      reason,
+      row.attempts + 1,
+      null,
+      'POLICY',
+      'Policy rejection',
+    );
   }
 
   private async markRetry(
@@ -132,6 +181,7 @@ export class SyncDeliveryService {
     message: string,
     signatureKeyId: string | null = null,
     httpStatus: number | null = null,
+    payloadHash: string | null = null,
   ): Promise<void> {
     const nextAttempts = row.attempts + 1;
     const deadLetter = nextAttempts >= SYNC_MAX_ATTEMPTS;
@@ -149,11 +199,22 @@ export class SyncDeliveryService {
       })
       .where(sql`${schema.outboxEvents.id} = ${row.id}`);
 
-    await this.insertAudit(row, false, 'POLICY_PASS', nextAttempts, httpStatus, code, message, signatureKeyId);
+    await this.insertAudit(
+      row,
+      payloadHash ?? hashSyncPayload(row.payload_json),
+      false,
+      'POLICY_PASS',
+      nextAttempts,
+      httpStatus,
+      code,
+      message,
+      signatureKeyId,
+    );
   }
 
   private async insertAudit(
     row: OutboxRow,
+    payloadHash: string,
     policyPassed: boolean,
     policyReason: string,
     attemptNo: number,
@@ -166,7 +227,7 @@ export class SyncDeliveryService {
       outboxEventId: row.id,
       userId: row.user_id,
       action: 'delivery_attempt',
-      payloadHash: 'deferred',
+      payloadHash,
       policyPassed,
       policyReason,
       signatureKid: signatureKeyId,

--- a/apps/api/src/sync/sync-delivery.service.ts
+++ b/apps/api/src/sync/sync-delivery.service.ts
@@ -58,13 +58,32 @@ export class SyncDeliveryService {
       return;
     }
 
-    const userAlias = this.aliasMapper.toAliasId('user', row.user_id);
-    const projected = {
-      ...policy.sanitizedPayload,
-      userAliasId: userAlias,
-    };
+    // Alias mapping and signing may throw if secrets are missing or invalid.
+    // These are treated as transient failures so the event is retried/dead-lettered
+    // rather than left stuck without a status transition.
+    let projected: Record<string, unknown>;
+    let signed: import('./sync.types').SignedPayload;
 
-    const signed = this.signing.signPayload(projected, row.idempotency_key);
+    try {
+      const userAlias = this.aliasMapper.toAliasId('user', row.user_id);
+      projected = {
+        ...policy.sanitizedPayload,
+        userAliasId: userAlias,
+      };
+      signed = this.signing.signPayload(projected, row.idempotency_key);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      await this.markRetry(
+        row,
+        'SIGNING_ERROR',
+        message,
+        null,
+        null,
+        hashSyncPayload(row.payload_json),
+      );
+      this.logger.warn(`Sync signing/alias failed for ${row.id}: ${message}`);
+      return;
+    }
 
     if (!this.endpoint) {
       this.logger.warn('FIREBASE_SYNC_ENDPOINT is not configured, scheduling retry');
@@ -96,11 +115,15 @@ export class SyncDeliveryService {
       });
 
       if (res.ok) {
+        const nextAttempts = row.attempts + 1;
         await this.db
           .update(schema.outboxEvents)
           .set({
             status: 'delivered',
+            attempts: nextAttempts,
             deliveredAt: new Date(),
+            lastErrorCode: null,
+            lastErrorMessage: null,
             updatedAt: new Date(),
           })
           .where(sql`${schema.outboxEvents.id} = ${row.id}`);
@@ -110,7 +133,7 @@ export class SyncDeliveryService {
           hashSyncPayload(projected),
           true,
           'POLICY_PASS',
-          row.attempts + 1,
+          nextAttempts,
           res.status,
           null,
           null,

--- a/apps/api/src/sync/sync-payload.util.ts
+++ b/apps/api/src/sync/sync-payload.util.ts
@@ -1,0 +1,31 @@
+import { createHash } from 'crypto';
+
+function normalizeValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeValue(item));
+  }
+
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, entryValue]) => entryValue !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right));
+
+    return Object.fromEntries(
+      entries.map(([key, entryValue]) => [key, normalizeValue(entryValue)]),
+    );
+  }
+
+  return value;
+}
+
+export function canonicalizeSyncPayload(
+  payload: Record<string, unknown>,
+): string {
+  return JSON.stringify(normalizeValue(payload));
+}
+
+export function hashSyncPayload(payload: Record<string, unknown>): string {
+  return createHash('sha256')
+    .update(canonicalizeSyncPayload(payload))
+    .digest('hex');
+}

--- a/apps/api/src/sync/sync.constants.ts
+++ b/apps/api/src/sync/sync.constants.ts
@@ -1,0 +1,19 @@
+export const SYNC_BANNED_FIELDS = new Set([
+  'email',
+  'accountNumber',
+  'routingNumber',
+  'lastFour',
+  'originalDescriptionRaw',
+  'promptText',
+  'outputText',
+]);
+
+// Basic PII-oriented patterns for outbound policy checks.
+export const SYNC_PII_PATTERNS: RegExp[] = [
+  /\b\d{3}-\d{2}-\d{4}\b/g, // SSN
+  /\b(?:\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}|\d{10,18})\b/g, // card/account-like numbers
+  /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g, // email
+  /(?:\(\d{3}\)[\s.-]?\d{3}[\s.-]?\d{4}|\d{3}[\s.-]\d{3}[\s.-]\d{4})/g, // phone
+];
+
+export const SYNC_MAX_ATTEMPTS = 8;

--- a/apps/api/src/sync/sync.module.ts
+++ b/apps/api/src/sync/sync.module.ts
@@ -3,6 +3,7 @@ import { SanitizerV2Service } from './sanitizer-v2.service';
 import { AliasMapperService } from './alias-mapper.service';
 import { SigningService } from './signing.service';
 import { SyncDeliveryService } from './sync-delivery.service';
+import { OutboxService } from './outbox.service';
 
 @Module({
   providers: [
@@ -10,12 +11,14 @@ import { SyncDeliveryService } from './sync-delivery.service';
     AliasMapperService,
     SigningService,
     SyncDeliveryService,
+    OutboxService,
   ],
   exports: [
     SanitizerV2Service,
     AliasMapperService,
     SigningService,
     SyncDeliveryService,
+    OutboxService,
   ],
 })
 export class SyncModule {}

--- a/apps/api/src/sync/sync.module.ts
+++ b/apps/api/src/sync/sync.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { SanitizerV2Service } from './sanitizer-v2.service';
+import { AliasMapperService } from './alias-mapper.service';
+import { SigningService } from './signing.service';
+import { SyncDeliveryService } from './sync-delivery.service';
+
+@Module({
+  providers: [
+    SanitizerV2Service,
+    AliasMapperService,
+    SigningService,
+    SyncDeliveryService,
+  ],
+  exports: [
+    SanitizerV2Service,
+    AliasMapperService,
+    SigningService,
+    SyncDeliveryService,
+  ],
+})
+export class SyncModule {}

--- a/apps/api/src/sync/sync.types.ts
+++ b/apps/api/src/sync/sync.types.ts
@@ -1,0 +1,19 @@
+export type SyncPolicyReason =
+  | 'POLICY_PASS'
+  | 'POLICY_FAIL_BANNED_FIELD'
+  | 'POLICY_FAIL_PATTERN_MATCH'
+  | 'POLICY_FAIL_SCHEMA';
+
+export interface SyncPolicyResult {
+  policyPassed: boolean;
+  policyReason: SyncPolicyReason;
+  sanitizedPayload: Record<string, unknown>;
+  bannedField?: string;
+}
+
+export interface SignedPayload {
+  signature: string;
+  keyId: string;
+  timestamp: string;
+  idempotencyKey: string;
+}

--- a/apps/api/src/transactions/transactions.module.ts
+++ b/apps/api/src/transactions/transactions.module.ts
@@ -3,9 +3,10 @@ import { TransactionsService } from './transactions.service';
 import { TransactionsController } from './transactions.controller';
 import { ExportService } from './export.service';
 import { CategorizationModule } from '../categorization/categorization.module';
+import { SyncModule } from '../sync/sync.module';
 
 @Module({
-  imports: [CategorizationModule],
+  imports: [CategorizationModule, SyncModule],
   providers: [TransactionsService, ExportService],
   controllers: [TransactionsController],
   exports: [TransactionsService],

--- a/apps/api/src/transactions/transactions.service.ts
+++ b/apps/api/src/transactions/transactions.service.ts
@@ -1,10 +1,13 @@
 import {
   Injectable,
   Inject,
+  Logger,
   NotFoundException,
   BadRequestException,
 } from '@nestjs/common';
 import { DATABASE_CONNECTION } from '../db/db.module';
+import { OutboxService } from '../sync/outbox.service';
+import { AliasMapperService } from '../sync/alias-mapper.service';
 import * as schema from '../db/schema';
 import {
   eq,
@@ -29,7 +32,13 @@ import { encryptField, decryptField } from '../common/crypto';
 
 @Injectable()
 export class TransactionsService {
-  constructor(@Inject(DATABASE_CONNECTION) private readonly db: any) {}
+  private readonly logger = new Logger(TransactionsService.name);
+
+  constructor(
+    @Inject(DATABASE_CONNECTION) private readonly db: any,
+    private readonly outbox: OutboxService,
+    private readonly aliasMapper: AliasMapperService,
+  ) {}
 
   /**
    * Manual transaction entry (cash purchases, etc.)
@@ -76,7 +85,10 @@ export class TransactionsService {
         tags: input.tags ?? [],
       })
       .returning();
-    return this.decryptTxn(rows[0]);
+
+    const txn = this.decryptTxn(rows[0]);
+    await this.enqueueTransactionEvent('transaction.projected.v1', txn);
+    return txn;
   }
 
   /**
@@ -250,7 +262,9 @@ export class TransactionsService {
       .set({ ...input, updatedAt: new Date() })
       .where(eq(schema.transactions.id, id))
       .returning();
-    return this.decryptTxn(rows[0]);
+    const updated = this.decryptTxn(rows[0]);
+    await this.enqueueTransactionEvent('transaction.projected.v1', updated);
+    return updated;
   }
 
   /**
@@ -377,5 +391,39 @@ export class TransactionsService {
       ...txn,
       originalDescription: decryptField(txn.originalDescription),
     };
+  }
+
+  /**
+   * Enqueue a safe, PII-free projection event for the sync outbox.
+   * Aliasing errors are caught and logged so the domain operation succeeds.
+   */
+  private async enqueueTransactionEvent(
+    eventType: string,
+    txn: any,
+  ): Promise<void> {
+    try {
+      const payload: Record<string, unknown> = {
+        transactionAliasId: this.aliasMapper.toAliasId('transaction', txn.id),
+        accountAliasId: this.aliasMapper.toAliasId('account', txn.accountId),
+        amountCents: txn.amountCents,
+        date: txn.date instanceof Date ? txn.date.toISOString() : txn.date,
+        categoryId: txn.categoryId ?? null,
+        isCredit: txn.isCredit,
+        isManual: txn.isManual ?? false,
+        tags: txn.tags ?? [],
+      };
+
+      await this.outbox.enqueue({
+        eventType,
+        aggregateType: 'transaction',
+        aggregateId: txn.id,
+        userId: txn.userId,
+        payload,
+      });
+    } catch (err) {
+      this.logger.warn(
+        `Skipping outbox enqueue for transaction ${txn.id}: ${(err as Error).message}`,
+      );
+    }
   }
 }

--- a/apps/api/src/transactions/transactions.service.ts
+++ b/apps/api/src/transactions/transactions.service.ts
@@ -68,26 +68,32 @@ export class TransactionsService {
       )
       .digest('hex');
 
-    const rows = await this.db
-      .insert(schema.transactions)
-      .values({
-        accountId: input.accountId,
-        userId,
-        txnHash,
-        date: new Date(input.date),
-        description: input.description,
-        originalDescription: encryptField(input.description),
-        amountCents: input.amountCents,
-        categoryId: input.categoryId ?? null,
-        merchantName: input.merchantName ?? null,
-        isCredit: input.isCredit,
-        isManual: true,
-        tags: input.tags ?? [],
-      })
-      .returning();
+    // Domain write and outbox insert are wrapped in a single DB transaction so
+    // a committed transaction always has a corresponding outbox event (transactional outbox pattern).
+    const txn = await this.db.transaction(async (tx: any) => {
+      const rows = await tx
+        .insert(schema.transactions)
+        .values({
+          accountId: input.accountId,
+          userId,
+          txnHash,
+          date: new Date(input.date),
+          description: input.description,
+          originalDescription: encryptField(input.description),
+          amountCents: input.amountCents,
+          categoryId: input.categoryId ?? null,
+          merchantName: input.merchantName ?? null,
+          isCredit: input.isCredit,
+          isManual: true,
+          tags: input.tags ?? [],
+        })
+        .returning();
 
-    const txn = this.decryptTxn(rows[0]);
-    await this.enqueueTransactionEvent('transaction.projected.v1', txn);
+      const inserted = this.decryptTxn(rows[0]);
+      await this.enqueueTransactionEventInTx(tx, 'transaction.projected.v1', inserted);
+      return inserted;
+    });
+
     return txn;
   }
 
@@ -257,13 +263,18 @@ export class TransactionsService {
     if (!txn || txn.userId !== userId)
       throw new NotFoundException('Transaction not found');
 
-    const rows = await this.db
-      .update(schema.transactions)
-      .set({ ...input, updatedAt: new Date() })
-      .where(eq(schema.transactions.id, id))
-      .returning();
-    const updated = this.decryptTxn(rows[0]);
-    await this.enqueueTransactionEvent('transaction.projected.v1', updated);
+    // Wrap the domain update and outbox insert in a single DB transaction.
+    const updated = await this.db.transaction(async (tx: any) => {
+      const rows = await tx
+        .update(schema.transactions)
+        .set({ ...input, updatedAt: new Date() })
+        .where(eq(schema.transactions.id, id))
+        .returning();
+      const updatedRow = this.decryptTxn(rows[0]);
+      await this.enqueueTransactionEventInTx(tx, 'transaction.projected.v1', updatedRow);
+      return updatedRow;
+    });
+
     return updated;
   }
 
@@ -394,8 +405,40 @@ export class TransactionsService {
   }
 
   /**
-   * Enqueue a safe, PII-free projection event for the sync outbox.
-   * Aliasing errors are caught and logged so the domain operation succeeds.
+   * Enqueue a safe, PII-free projection event within an existing DB transaction.
+   * Alias mapping errors propagate so the outer transaction can roll back atomically.
+   * If ALIAS_SECRET is missing, the domain write is rolled back and the caller receives an error.
+   */
+  private async enqueueTransactionEventInTx(
+    tx: any,
+    eventType: string,
+    txn: any,
+  ): Promise<void> {
+    const payload: Record<string, unknown> = {
+      transactionAliasId: this.aliasMapper.toAliasId('transaction', txn.id),
+      accountAliasId: this.aliasMapper.toAliasId('account', txn.accountId),
+      amountCents: txn.amountCents,
+      date: txn.date instanceof Date ? txn.date.toISOString() : txn.date,
+      categoryId: txn.categoryId ?? null,
+      isCredit: txn.isCredit,
+      isManual: txn.isManual ?? false,
+      tags: txn.tags ?? [],
+    };
+
+    await this.outbox.enqueueInTx(tx, {
+      eventType,
+      aggregateType: 'transaction',
+      aggregateId: txn.id,
+      userId: txn.userId,
+      payload,
+    });
+  }
+
+  /**
+   * Enqueue a safe, PII-free projection event for the sync outbox (best-effort).
+   * Aliasing and outbox insert errors are caught and logged so the domain operation
+   * succeeds even when sync secrets are missing or the outbox insert fails.
+   * Prefer enqueueTransactionEventInTx when atomicity with the domain write is required.
    */
   private async enqueueTransactionEvent(
     eventType: string,

--- a/apps/api/test/sync-no-reverse-route.e2e-spec.ts
+++ b/apps/api/test/sync-no-reverse-route.e2e-spec.ts
@@ -1,0 +1,38 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import request from 'supertest';
+import cookieParser from 'cookie-parser';
+import { AppModule } from '../src/app.module';
+
+describe('Sync Boundary (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api');
+    app.use(cookieParser());
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('does not expose reverse sync mutation routes', async () => {
+    const candidates = [
+      '/api/sync/import',
+      '/api/sync/apply',
+      '/api/firebase/pull',
+    ];
+
+    for (const path of candidates) {
+      const response = await request(app.getHttpServer()).post(path).send({});
+      expect(response.status).toBe(404);
+    }
+  });
+});

--- a/db/migrations/0003_furry_talisman.sql
+++ b/db/migrations/0003_furry_talisman.sql
@@ -1,0 +1,73 @@
+CREATE TYPE "public"."ai_prompt_type" AS ENUM('categorization', 'pdf_parse');--> statement-breakpoint
+CREATE TABLE "ai_prompt_logs" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"user_id" uuid,
+	"prompt_type" "ai_prompt_type" NOT NULL,
+	"model" varchar(100) NOT NULL,
+	"input_text" text NOT NULL,
+	"output_text" text,
+	"token_count_in" integer,
+	"token_count_out" integer,
+	"latency_ms" integer,
+	"transactions_count" integer,
+	"categories_assigned" integer,
+	"avg_confidence" real,
+	"pii_detected" boolean DEFAULT false NOT NULL,
+	"pii_types_found" jsonb DEFAULT '[]'::jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "outbox_events" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"event_type" varchar(80) NOT NULL,
+	"aggregate_type" varchar(80) NOT NULL,
+	"aggregate_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"household_id" uuid,
+	"payload_json" jsonb NOT NULL,
+	"payload_hash" varchar(64) NOT NULL,
+	"schema_version" integer DEFAULT 1 NOT NULL,
+	"idempotency_key" varchar(128) NOT NULL,
+	"status" varchar(24) DEFAULT 'pending' NOT NULL,
+	"policy_passed" boolean,
+	"policy_reason" text,
+	"attempts" integer DEFAULT 0 NOT NULL,
+	"next_attempt_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"last_error_code" varchar(64),
+	"last_error_message" text,
+	"delivered_at" timestamp with time zone,
+	"dead_lettered_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "outbox_events_idempotency_key_unique" UNIQUE("idempotency_key")
+);
+--> statement-breakpoint
+CREATE TABLE "sync_audit_logs" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"outbox_event_id" uuid NOT NULL,
+	"user_id" uuid,
+	"action" varchar(40) NOT NULL,
+	"payload_hash" varchar(64) NOT NULL,
+	"policy_passed" boolean NOT NULL,
+	"policy_reason" text,
+	"signature_kid" varchar(64),
+	"attempt_no" integer NOT NULL,
+	"http_status" integer,
+	"error_code" varchar(64),
+	"error_message" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "ai_prompt_logs" ADD CONSTRAINT "ai_prompt_logs_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "outbox_events" ADD CONSTRAINT "outbox_events_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "outbox_events" ADD CONSTRAINT "outbox_events_household_id_households_id_fk" FOREIGN KEY ("household_id") REFERENCES "public"."households"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sync_audit_logs" ADD CONSTRAINT "sync_audit_logs_outbox_event_id_outbox_events_id_fk" FOREIGN KEY ("outbox_event_id") REFERENCES "public"."outbox_events"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sync_audit_logs" ADD CONSTRAINT "sync_audit_logs_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_ai_log_user" ON "ai_prompt_logs" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "idx_ai_log_type" ON "ai_prompt_logs" USING btree ("prompt_type");--> statement-breakpoint
+CREATE INDEX "idx_ai_log_created" ON "ai_prompt_logs" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "idx_outbox_status_next_attempt" ON "outbox_events" USING btree ("status","next_attempt_at");--> statement-breakpoint
+CREATE INDEX "idx_outbox_user_created" ON "outbox_events" USING btree ("user_id","created_at");--> statement-breakpoint
+CREATE INDEX "idx_outbox_aggregate" ON "outbox_events" USING btree ("aggregate_type","aggregate_id");--> statement-breakpoint
+CREATE INDEX "idx_sync_audit_outbox" ON "sync_audit_logs" USING btree ("outbox_event_id");--> statement-breakpoint
+CREATE INDEX "idx_sync_audit_created" ON "sync_audit_logs" USING btree ("created_at");

--- a/db/migrations/meta/0003_snapshot.json
+++ b/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,2194 @@
+{
+  "id": "c27e244c-21a6-4ebd-9a8f-9c23764efa2a",
+  "prevId": "7861dde1-343a-4680-83ef-90c218b61dfd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "institution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_four": {
+          "name": "last_four",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starting_balance_cents": {
+          "name": "starting_balance_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "credit_limit_cents": {
+          "name": "credit_limit_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "csv_format_config": {
+          "name": "csv_format_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_prompt_logs": {
+      "name": "ai_prompt_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_type": {
+          "name": "prompt_type",
+          "type": "ai_prompt_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_text": {
+          "name": "input_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_text": {
+          "name": "output_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_count_in": {
+          "name": "token_count_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_count_out": {
+          "name": "token_count_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transactions_count": {
+          "name": "transactions_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "categories_assigned": {
+          "name": "categories_assigned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_confidence": {
+          "name": "avg_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pii_detected": {
+          "name": "pii_detected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pii_types_found": {
+          "name": "pii_types_found",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ai_log_user": {
+          "name": "idx_ai_log_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_log_type": {
+          "name": "idx_ai_log_type",
+          "columns": [
+            {
+              "expression": "prompt_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_log_created": {
+          "name": "idx_ai_log_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_prompt_logs_user_id_users_id_fk": {
+          "name": "ai_prompt_logs_user_id_users_id_fk",
+          "tableFrom": "ai_prompt_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "old_value": {
+          "name": "old_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_value": {
+          "name": "new_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_user": {
+          "name": "idx_audit_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_action": {
+          "name": "idx_audit_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_created": {
+          "name": "idx_audit_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period": {
+          "name": "period",
+          "type": "budget_period",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "budgets_user_id_users_id_fk": {
+          "name": "budgets_user_id_users_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "budgets_household_id_households_id_fk": {
+          "name": "budgets_household_id_households_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "households",
+          "columnsFrom": [
+            "household_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "budgets_category_id_categories_id_fk": {
+          "name": "budgets_category_id_categories_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categories_parent_id_categories_id_fk": {
+          "name": "categories_parent_id_categories_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categorization_rules": {
+      "name": "categorization_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "rule_match_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field": {
+          "name": "field",
+          "type": "rule_field",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'description'"
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_ai_generated": {
+          "name": "is_ai_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "categorization_rules_user_id_users_id_fk": {
+          "name": "categorization_rules_user_id_users_id_fk",
+          "tableFrom": "categorization_rules",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "categorization_rules_category_id_categories_id_fk": {
+          "name": "categorization_rules_category_id_categories_id_fk",
+          "tableFrom": "categorization_rules",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_uploads": {
+      "name": "file_uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "file_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_hash": {
+          "name": "file_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "upload_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "rows_imported": {
+          "name": "rows_imported",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rows_skipped": {
+          "name": "rows_skipped",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rows_errored": {
+          "name": "rows_errored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_log": {
+          "name": "error_log",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "archived_path": {
+          "name": "archived_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "file_uploads_user_id_users_id_fk": {
+          "name": "file_uploads_user_id_users_id_fk",
+          "tableFrom": "file_uploads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "file_uploads_account_id_accounts_id_fk": {
+          "name": "file_uploads_account_id_accounts_id_fk",
+          "tableFrom": "file_uploads",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.households": {
+      "name": "households",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investment_accounts": {
+      "name": "investment_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "institution": {
+          "name": "institution",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "investment_accounts_user_id_users_id_fk": {
+          "name": "investment_accounts_user_id_users_id_fk",
+          "tableFrom": "investment_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.investment_snapshots": {
+      "name": "investment_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "investment_account_id": {
+          "name": "investment_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_cents": {
+          "name": "balance_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "investment_snapshots_investment_account_id_investment_accounts_id_fk": {
+          "name": "investment_snapshots_investment_account_id_investment_accounts_id_fk",
+          "tableFrom": "investment_snapshots",
+          "tableTo": "investment_accounts",
+          "columnsFrom": [
+            "investment_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "webhook_sent": {
+          "name": "webhook_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.outbox_events": {
+      "name": "outbox_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregate_type": {
+          "name": "aggregate_type",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregate_id": {
+          "name": "aggregate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "policy_passed": {
+          "name": "policy_passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy_reason": {
+          "name": "policy_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dead_lettered_at": {
+          "name": "dead_lettered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_outbox_status_next_attempt": {
+          "name": "idx_outbox_status_next_attempt",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_outbox_user_created": {
+          "name": "idx_outbox_user_created",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_outbox_aggregate": {
+          "name": "idx_outbox_aggregate",
+          "columns": [
+            {
+              "expression": "aggregate_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "aggregate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "outbox_events_user_id_users_id_fk": {
+          "name": "outbox_events_user_id_users_id_fk",
+          "tableFrom": "outbox_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "outbox_events_household_id_households_id_fk": {
+          "name": "outbox_events_household_id_households_id_fk",
+          "tableFrom": "outbox_events",
+          "tableTo": "households",
+          "columnsFrom": [
+            "household_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "outbox_events_idempotency_key_unique": {
+          "name": "outbox_events_idempotency_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.savings_goals": {
+      "name": "savings_goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_amount_cents": {
+          "name": "target_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_amount_cents": {
+          "name": "current_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "savings_goals_user_id_users_id_fk": {
+          "name": "savings_goals_user_id_users_id_fk",
+          "tableFrom": "savings_goals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_audit_logs": {
+      "name": "sync_audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "outbox_event_id": {
+          "name": "outbox_event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_passed": {
+          "name": "policy_passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_reason": {
+          "name": "policy_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature_kid": {
+          "name": "signature_kid",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_no": {
+          "name": "attempt_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sync_audit_outbox": {
+          "name": "idx_sync_audit_outbox",
+          "columns": [
+            {
+              "expression": "outbox_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sync_audit_created": {
+          "name": "idx_sync_audit_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sync_audit_logs_outbox_event_id_outbox_events_id_fk": {
+          "name": "sync_audit_logs_outbox_event_id_outbox_events_id_fk",
+          "tableFrom": "sync_audit_logs",
+          "tableTo": "outbox_events",
+          "columnsFrom": [
+            "outbox_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sync_audit_logs_user_id_users_id_fk": {
+          "name": "sync_audit_logs_user_id_users_id_fk",
+          "tableFrom": "sync_audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "txn_hash": {
+          "name": "txn_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_description": {
+          "name": "original_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant_name": {
+          "name": "merchant_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_credit": {
+          "name": "is_credit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_manual": {
+          "name": "is_manual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "source_file_id": {
+          "name": "source_file_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_transaction_id": {
+          "name": "parent_transaction_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_split_parent": {
+          "name": "is_split_parent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_txn_account_external_id": {
+          "name": "idx_txn_account_external_id",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_txn_account_hash": {
+          "name": "idx_txn_account_hash",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "txn_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_txn_user_date": {
+          "name": "idx_txn_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_txn_category": {
+          "name": "idx_txn_category",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_txn_parent": {
+          "name": "idx_txn_parent",
+          "columns": [
+            {
+              "expression": "parent_transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_account_id_accounts_id_fk": {
+          "name": "transactions_account_id_accounts_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_category_id_categories_id_fk": {
+          "name": "transactions_category_id_categories_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "transactions_source_file_id_file_uploads_id_fk": {
+          "name": "transactions_source_file_id_file_uploads_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "file_uploads",
+          "columnsFrom": [
+            "source_file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'America/New_York'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "theme",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "enable_cloud_ai": {
+          "name": "enable_cloud_ai",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ha_webhook_url": {
+          "name": "ha_webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weekly_digest_enabled": {
+          "name": "weekly_digest_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notification_email": {
+          "name": "notification_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_user_id_unique": {
+          "name": "user_settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_household_id_households_id_fk": {
+          "name": "users_household_id_households_id_fk",
+          "tableFrom": "users",
+          "tableTo": "households",
+          "columnsFrom": [
+            "household_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "checking",
+        "savings",
+        "credit_card"
+      ]
+    },
+    "public.ai_prompt_type": {
+      "name": "ai_prompt_type",
+      "schema": "public",
+      "values": [
+        "categorization",
+        "pdf_parse"
+      ]
+    },
+    "public.budget_period": {
+      "name": "budget_period",
+      "schema": "public",
+      "values": [
+        "monthly",
+        "weekly"
+      ]
+    },
+    "public.file_type": {
+      "name": "file_type",
+      "schema": "public",
+      "values": [
+        "csv",
+        "excel",
+        "pdf"
+      ]
+    },
+    "public.institution": {
+      "name": "institution",
+      "schema": "public",
+      "values": [
+        "boa",
+        "chase",
+        "amex",
+        "citi",
+        "other"
+      ]
+    },
+    "public.rule_field": {
+      "name": "rule_field",
+      "schema": "public",
+      "values": [
+        "description",
+        "merchant"
+      ]
+    },
+    "public.rule_match_type": {
+      "name": "rule_match_type",
+      "schema": "public",
+      "values": [
+        "contains",
+        "starts_with",
+        "regex",
+        "exact"
+      ]
+    },
+    "public.theme": {
+      "name": "theme",
+      "schema": "public",
+      "values": [
+        "light",
+        "dark",
+        "system"
+      ]
+    },
+    "public.upload_status": {
+      "name": "upload_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "member"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1776560535475,
       "tag": "0002_messy_trish_tilby",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1776639591043,
+      "tag": "0003_furry_talisman",
+      "breakpoints": true
     }
   ]
 }

--- a/docs/FIREBASE-SETUP-SECRETS-HANDOFF.md
+++ b/docs/FIREBASE-SETUP-SECRETS-HANDOFF.md
@@ -1,0 +1,144 @@
+# Firebase Setup and Secret Handoff (MoneyPulse Web)
+
+This document gives you a beginner-friendly, click-by-click setup to create Firebase resources and collect the exact values needed to continue implementation and CI/CD.
+
+## 1) Create/verify Google + Firebase access
+
+1. Sign in to Google with the account you want to own the project.
+2. Open Firebase Console: https://console.firebase.google.com/
+3. If this is your first time, accept terms and continue.
+
+## 2) Create the Firebase project (region target: us-east4)
+
+1. Click **Create a project**.
+2. Project name: `moneypulse-web` (or your preferred name).
+3. Keep Google Analytics optional for MVP; you can enable it later.
+4. Open project settings and copy **Project ID** (you will need this multiple times).
+
+Record now:
+- `FIREBASE_PROJECT_ID`
+
+## 3) Add a Web app and capture public config
+
+1. In Firebase Console, open **Project settings**.
+2. Under **Your apps**, click **Web** (`</>`).
+3. App nickname: `moneypulse-web-app`.
+4. Register app.
+5. Firebase shows a JS config object. Copy these fields:
+
+Required values:
+- `NEXT_PUBLIC_FIREBASE_API_KEY`
+- `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN`
+- `NEXT_PUBLIC_FIREBASE_PROJECT_ID`
+- `NEXT_PUBLIC_FIREBASE_APP_ID`
+- `NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID`
+
+Note: `NEXT_PUBLIC_*` values are intentionally public client config (not secrets).
+
+## 4) Enable Firebase Authentication (Email/Password)
+
+1. Go to **Build -> Authentication -> Get started**.
+2. Under **Sign-in method**, enable **Email/Password**.
+3. Save.
+4. (Optional later) Enable MFA if you want stricter login protection.
+
+## 5) Create Firestore database
+
+1. Go to **Build -> Firestore Database -> Create database**.
+2. Start in production mode.
+3. Select location closest to users (for now use `us-east4` related US region option available in UI).
+4. Create.
+
+## 6) Enable Cloud Messaging and generate Web Push key
+
+1. Go to **Project settings -> Cloud Messaging**.
+2. Under **Web configuration**, create or use a Web Push certificate key pair.
+3. Copy the **VAPID key**.
+
+Record now:
+- `NEXT_PUBLIC_FIREBASE_VAPID_KEY`
+
+## 7) Create deploy credentials for GitHub Actions
+
+Preferred (best practice): Workload Identity Federation (no long-lived JSON key).
+Fast path (acceptable for MVP): Service account JSON key stored in GitHub secrets.
+
+### Fast path steps
+
+1. Open Google Cloud Console IAM service accounts for the same project.
+2. Create service account: `github-actions-deploy`.
+3. Grant minimum roles needed for Firebase deploy (typically Firebase Admin / Hosting Admin / Cloud Functions deploy roles as required by your workflows).
+4. Create JSON key and download it once.
+
+Extract and record:
+- `FIREBASE_CLIENT_EMAIL` (from JSON `client_email`)
+- `FIREBASE_PRIVATE_KEY` (from JSON `private_key`)
+
+Important formatting for GitHub secret:
+- Preserve line breaks in private key. If needed, store with escaped `\n` and unescape at runtime.
+
+## 8) Create sync ingress signing secret (dedicated secret)
+
+For local -> cloud payload signing, use a dedicated secret that is not reused for JWT/auth.
+
+Generate example:
+
+```bash
+openssl rand -base64 48
+```
+
+Record now:
+- `SYNC_SIGNING_SECRET`
+- `SYNC_SIGNING_KEY_ID` (example: `sync-key-v1`)
+
+Recommendation:
+- Rotate by adding `sync-key-v2` later while still accepting `v1` during cutover.
+- Never reuse JWT secret for sync signing.
+
+## 9) Create local alias secret (for deterministic pseudonyms)
+
+Generate example:
+
+```bash
+openssl rand -base64 48
+```
+
+Record now:
+- `ALIAS_SECRET`
+
+## 10) Provide values back for continuation
+
+Please share these values (or confirm they are set in your env/secrets manager):
+
+Web app config:
+- `NEXT_PUBLIC_FIREBASE_API_KEY`
+- `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN`
+- `NEXT_PUBLIC_FIREBASE_PROJECT_ID`
+- `NEXT_PUBLIC_FIREBASE_APP_ID`
+- `NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID`
+- `NEXT_PUBLIC_FIREBASE_VAPID_KEY`
+
+Server/deploy:
+- `FIREBASE_PROJECT_ID`
+- `FIREBASE_CLIENT_EMAIL`
+- `FIREBASE_PRIVATE_KEY`
+- `SYNC_SIGNING_KEY_ID`
+- `SYNC_SIGNING_SECRET`
+
+Local sync security:
+- `ALIAS_SECRET`
+
+## 11) Where each value will be used
+
+- Client runtime (`moneypulse-web/.env`): `NEXT_PUBLIC_FIREBASE_*`
+- Functions/server runtime: `FIREBASE_PROJECT_ID`, `SYNC_SIGNING_*`
+- GitHub Actions secrets: `FIREBASE_PROJECT_ID`, `FIREBASE_CLIENT_EMAIL`, `FIREBASE_PRIVATE_KEY`
+- Local API sync sender (`MyMoney` API env): `ALIAS_SECRET`, `SYNC_SIGNING_SECRET`, optional `SYNC_SIGNING_KEY_ID`
+
+## 12) Security checklist before first deploy
+
+- Do not commit `.env` files.
+- Keep `SYNC_SIGNING_SECRET` and `ALIAS_SECRET` out of client-visible env vars.
+- Restrict service account permissions to least privilege.
+- Plan key rotation every 90 days.
+- Keep Firestore rules deny-by-default and allow only authenticated household members by alias scope.

--- a/docs/agentic/README.md
+++ b/docs/agentic/README.md
@@ -1,0 +1,43 @@
+# Agentic Development Guide
+
+This repository is configured for GitHub Copilot customization in both VS Code chat and Copilot CLI sessions.
+
+## Included Surfaces
+
+- `AGENTS.md` — repo-wide agent operating guidance
+- `.github/copilot-instructions.md` — always-on repo instructions
+- `.github/instructions` — path-specific instructions
+- `.github/agents` — custom agents
+- `.github/prompts` — reusable slash prompts
+- `.github/skills` — portable Agent Skills
+- `docs/agentic/rule-set.md` — mandatory review and decision-tree rules
+
+## Recommended Workflow
+
+1. Start with `mp-lead` to route the task.
+2. Use `mp-planner` or `mp-spec-generator` before major implementation.
+3. Use `mp-implementor` for coding work.
+4. Run `mp-tester` and `mp-reviewer` before completion.
+5. Use the `rubber-duck-review` skill or `/mp-rubber-duck` prompt before handoff.
+
+## VS Code Usage
+
+1. Open Chat Customizations.
+2. Select the repository agent such as `mp-lead`.
+3. Run prompt files from `/` such as `/mp-phase-orchestrate` or `/mp-expand-phase-spec`.
+4. Run skills from `/` such as `/grill-me` or `/rubber-duck-review`.
+
+## Copilot CLI Notes
+
+- In VS Code Copilot CLI sessions, workspace custom agents can be selected when creating the session.
+- Prompt files and skills are available as slash commands in Copilot CLI sessions.
+- Recommended entry points:
+  - `/mp-phase-orchestrate phase=PHASE6 task=Implement budget webhook retries constraints=preserve current alert engine`
+  - `/mp-expand-phase-spec phase=PHASE7 feature=MCP hardening current-state=phase spec exists but needs more implementation detail`
+  - `/mp-rubber-duck work=budget alert retry flow summary=need resilient retry and clear audit trail`
+
+## Memory Best Practice
+
+- Keep stable repo facts in `docs/agentic/memory.md` and repo memory.
+- Let the lead agent pass brief and decision context.
+- Let worker agents re-check nearby code before editing rather than trusting stale summaries blindly.

--- a/docs/agentic/inspiration.md
+++ b/docs/agentic/inspiration.md
@@ -1,0 +1,52 @@
+# Inspiration
+
+## Guiding Inputs
+
+### GitHub Awesome Copilot
+
+- Use native customization surfaces: repo instructions, path instructions, prompts, agents, and portable skills.
+- Keep always-on repo instructions short and broad, then move task-specific workflows into prompts, agents, and skills.
+
+Reference:
+
+- [github/awesome-copilot](https://github.com/github/awesome-copilot)
+
+### GitHub And VS Code Customization Docs
+
+- `.github/copilot-instructions.md` is for broad repo guidance.
+- `.github/instructions/*.instructions.md` is for path-specific guidance.
+- `.github/prompts/*.prompt.md` is for repeatable slash workflows.
+- `.github/agents/*.agent.md` is for persistent personas and handoffs.
+- `.github/skills/<name>/SKILL.md` is for portable capabilities.
+
+References:
+
+- [GitHub repository custom instructions](https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/add-custom-instructions/add-repository-instructions)
+- [VS Code custom agents](https://code.visualstudio.com/docs/copilot/customization/custom-agents)
+- [VS Code prompt files](https://code.visualstudio.com/docs/copilot/customization/prompt-files)
+- [VS Code agent skills](https://code.visualstudio.com/docs/copilot/customization/agent-skills)
+
+### Matt Pocock Skills
+
+- Strong skills are narrow, explicit, and easy to compose.
+- `grill-me` is a good model for forcing decision-tree clarity before implementation.
+
+Reference:
+
+- [mattpocock/skills](https://github.com/mattpocock/skills)
+
+### Andrej Karpathy
+
+- Prefer first-principles reasoning and specs that surface hidden assumptions.
+
+Reference:
+
+- [karpathy.ai](https://karpathy.ai/)
+
+### Burke Holland
+
+- Keep developer workflows practical and ergonomic; avoid over-complicating the system meant to help coding.
+
+Reference:
+
+- [Burke Holland](https://github.com/burkeholland)

--- a/docs/agentic/memory.md
+++ b/docs/agentic/memory.md
@@ -1,0 +1,17 @@
+# Memory
+
+Persist stable repo facts here so agents do not repeatedly rediscover them.
+
+## Stable Facts
+
+- MoneyPulse is the local system of record for household finance data.
+- Podman is the active container runtime in this environment.
+- Phase specs are detailed and should be treated as the authoritative delivery plan.
+- Shared package, DB schema, and API contracts must stay aligned.
+- PDF parser work is a separate Python surface and should not be documented as if it were a TypeScript package.
+
+## Usage Guidance
+
+- Lead agents should pass decisions and scope forward.
+- Worker agents should still verify nearby code before changing it.
+- Update this file when a repo fact is stable enough to save future exploration.

--- a/docs/agentic/rule-set.md
+++ b/docs/agentic/rule-set.md
@@ -1,0 +1,37 @@
+# MoneyPulse Rule Set
+
+## Always Rules
+
+1. Start from the master plan or the phase spec that owns the work.
+2. Preserve local-first privacy and clear data ownership.
+3. Prefer the smallest vertical slice that can be validated.
+4. Keep backend, frontend, shared package, DB, and parser contracts aligned.
+5. Document the real validation path, including manual steps if local services are required.
+
+## Decision Tree Checkpoints
+
+### Before planning
+
+- Which phase owns the change?
+- Does the change touch API, web, shared types, DB, Python parser, or sync?
+- What is the minimum slice that proves the design?
+
+### Before editing
+
+- Which files directly control the behavior?
+- Which tests, builds, or scripts can falsify the plan quickly?
+- Is any migration, seed, or shared-schema update required?
+
+### Before completing
+
+- Did you keep the local-first boundary intact?
+- Did you update specs and docs if a contract changed?
+- Did you record any environment prerequisite that an agent would otherwise rediscover the hard way?
+
+## Rubber-Duck Review
+
+1. State the exact user or system problem.
+2. State the smallest code or spec change that solves it.
+3. State the contract or invariant that must remain true.
+4. State the validation that would prove success.
+5. State the next likely regression if the change is wrong.

--- a/moneypulse-fullstack.code-workspace
+++ b/moneypulse-fullstack.code-workspace
@@ -1,0 +1,26 @@
+{
+  "folders": [
+    {
+      "name": "MoneyPulse Local",
+      "path": "."
+    },
+    {
+      "name": "MoneyPulse Web",
+      "path": "../moneypulse-web"
+    }
+  ],
+  "settings": {
+    "files.exclude": {
+      "**/.turbo": true,
+      "**/.next": true,
+      "**/node_modules": true,
+      "**/functions/lib": true
+    },
+    "search.exclude": {
+      "**/.turbo": true,
+      "**/.next": true,
+      "**/node_modules": true,
+      "**/functions/lib": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -19,9 +19,14 @@
     "db:seed": "pnpm --filter @moneypulse/api run db:seed",
     "docker:dev": "docker compose -f docker-compose.yml -f docker-compose.dev.yml up",
     "docker:prod": "docker compose up -d",
-    "docker:down": "docker compose down"
+    "docker:down": "docker compose down",
+    "prepare": "simple-git-hooks"
+  },
+  "simple-git-hooks": {
+    "pre-commit": "node scripts/validate-ai-customizations.mjs && npx markdownlint-cli2 --no-globs AGENTS.md '.github/**/*.md' 'docs/agentic/**/*.md'"
   },
   "devDependencies": {
+    "simple-git-hooks": "^2.13.1",
     "turbo": "^2.8.20",
     "vite": "8.0.8"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prepare": "simple-git-hooks"
   },
   "simple-git-hooks": {
-    "pre-commit": "node scripts/validate-ai-customizations.mjs && npx markdownlint-cli2 --no-globs AGENTS.md '.github/**/*.md' 'docs/agentic/**/*.md'"
+    "pre-commit": "node scripts/validate-ai-customizations.mjs && npx markdownlint-cli2 --no-globs AGENTS.md \".github/**/*.md\" \"docs/agentic/**/*.md\""
   },
   "devDependencies": {
     "simple-git-hooks": "^2.13.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
 
   .:
     devDependencies:
+      simple-git-hooks:
+        specifier: ^2.13.1
+        version: 2.13.1
       turbo:
         specifier: ^2.8.20
         version: 2.8.20
@@ -4503,6 +4506,10 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  simple-git-hooks@2.13.1:
+    resolution: {integrity: sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==}
+    hasBin: true
 
   sonner@2.0.7:
     resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
@@ -9349,6 +9356,8 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
+
+  simple-git-hooks@2.13.1: {}
 
   sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:

--- a/scripts/validate-ai-customizations.mjs
+++ b/scripts/validate-ai-customizations.mjs
@@ -1,0 +1,94 @@
+import { readdir, readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+
+const root = process.cwd();
+
+const requiredFiles = [
+  'AGENTS.md',
+  '.github/copilot-instructions.md',
+  'docs/agentic/README.md',
+  'docs/agentic/rule-set.md',
+  'docs/agentic/memory.md',
+];
+
+async function exists(filePath) {
+  try {
+    await stat(path.join(root, filePath));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function ensureRequiredFiles() {
+  const missing = [];
+  for (const file of requiredFiles) {
+    if (!(await exists(file))) {
+      missing.push(file);
+    }
+  }
+
+  if (missing.length) {
+    throw new Error(`Missing required customization files:\n${missing.map((file) => `- ${file}`).join('\n')}`);
+  }
+}
+
+async function ensureDirectoryHasMatches(dir, suffix) {
+  const fullDir = path.join(root, dir);
+  const entries = await readdir(fullDir, { withFileTypes: true });
+  const matches = entries.filter((entry) => entry.isFile() && entry.name.endsWith(suffix));
+
+  if (!matches.length) {
+    throw new Error(`Expected at least one ${suffix} file in ${dir}`);
+  }
+}
+
+async function ensureSkillsValid() {
+  const skillsDir = path.join(root, '.github/skills');
+  const entries = await readdir(skillsDir, { withFileTypes: true });
+  const skillDirs = entries.filter((entry) => entry.isDirectory());
+
+  if (!skillDirs.length) {
+    throw new Error('Expected at least one skill directory in .github/skills');
+  }
+
+  for (const skillDir of skillDirs) {
+    const skillPath = path.join(skillsDir, skillDir.name, 'SKILL.md');
+    if (!(await exists(path.relative(root, skillPath)))) {
+      throw new Error(`Missing SKILL.md for skill directory ${skillDir.name}`);
+    }
+
+    const content = await readFile(skillPath, 'utf8');
+    const match = content.match(/^---\s*[\r\n]+name:\s*([a-z0-9-]+)\s*[\r\n]+description:/m);
+    if (!match) {
+      throw new Error(`Skill ${skillDir.name} must include YAML frontmatter with name and description`);
+    }
+
+    if (match[1] !== skillDir.name) {
+      throw new Error(`Skill name '${match[1]}' must match directory '${skillDir.name}'`);
+    }
+  }
+}
+
+async function ensureRubberDuckReferenced() {
+  const filesToCheck = [
+    'AGENTS.md',
+    'docs/agentic/README.md',
+    'docs/agentic/rule-set.md',
+  ];
+
+  for (const file of filesToCheck) {
+    const content = await readFile(path.join(root, file), 'utf8');
+    if (!/rubber-duck/i.test(content)) {
+      throw new Error(`Expected rubber-duck guidance in ${file}`);
+    }
+  }
+}
+
+await ensureRequiredFiles();
+await ensureDirectoryHasMatches('.github/agents', '.agent.md');
+await ensureDirectoryHasMatches('.github/prompts', '.prompt.md');
+await ensureSkillsValid();
+await ensureRubberDuckReferenced();
+
+console.log('AI customization validation passed.');

--- a/scripts/validate-ai-customizations.mjs
+++ b/scripts/validate-ai-customizations.mjs
@@ -36,7 +36,9 @@ async function ensureRequiredFiles() {
 async function ensureDirectoryHasMatches(dir, suffix) {
   const fullDir = path.join(root, dir);
 
-  if (!(await exists(dir))) {
+  try {
+    await stat(fullDir);
+  } catch {
     throw new Error(`Required directory '${dir}' does not exist. Create it and add at least one ${suffix} file.`);
   }
 

--- a/scripts/validate-ai-customizations.mjs
+++ b/scripts/validate-ai-customizations.mjs
@@ -35,6 +35,11 @@ async function ensureRequiredFiles() {
 
 async function ensureDirectoryHasMatches(dir, suffix) {
   const fullDir = path.join(root, dir);
+
+  if (!(await exists(dir))) {
+    throw new Error(`Required directory '${dir}' does not exist. Create it and add at least one ${suffix} file.`);
+  }
+
   const entries = await readdir(fullDir, { withFileTypes: true });
   const matches = entries.filter((entry) => entry.isFile() && entry.name.endsWith(suffix));
 


### PR DESCRIPTION
## Summary
This PR bootstraps the local-to-cloud sync foundation and adds onboarding documentation for Firebase config/secret collection so Phase 6.7 can continue.

## What changed
- Added sync domain scaffolding under API:
  - sanitizer v2 policy checks
  - deterministic alias mapper
  - payload signing service
  - delivery service with retry and dead-letter transitions
- Added queue processor and module wiring for `sync-delivery`
- Extended schema with `outbox_events` and `sync_audit_logs`
- Added migration artifacts (`0003_furry_talisman.sql` + snapshot/journal update)
- Added sync tests:
  - sanitizer unit tests
  - signing unit tests
  - no-reverse-route e2e boundary test
- Added docs:
  - `PHASE9-SYNC-SPEC.md`
  - `docs/FIREBASE-SETUP-SECRETS-HANDOFF.md`
- Enforced dedicated secrets for sync:
  - `SYNC_SIGNING_SECRET` required (no JWT fallback)
  - `ALIAS_SECRET` required for alias mapping

## Validation
- Ran targeted API unit tests for sync services:
  - `sanitizer-v2.service.spec.ts`
  - `signing.service.spec.ts`

## Follow-ups
- Wire real Firebase endpoint and server-side signature verification
- Configure secrets and CI deploy identity
- Continue Phase 6.7 hardening (payload hash semantics, replay tooling)
