### PR TITLE
Add merchant alias management page and API

### DIFF
--- a/apps/api/src/categorization/__tests__/merchant-alias.service.spec.ts
+++ b/apps/api/src/categorization/__tests__/merchant-alias.service.spec.ts
@@ -1,0 +1,90 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException, ForbiddenException } from '@nestjs/common';
+import { MerchantAliasService } from '../merchant-alias.service';
+import { DATABASE_CONNECTION } from '../../db/db.module';
+
+describe('MerchantAliasService', () => {
+  let service: MerchantAliasService;
+  let mockDb: any;
+
+  const globalAlias = { id: 'alias-g1', userId: null, pattern: 'amazon', matchType: 'contains', displayName: 'Amazon' };
+  const userAlias = { id: 'alias-u1', userId: 'user-1', pattern: 'spotify', matchType: 'exact', displayName: 'Spotify' };
+
+  beforeEach(async () => {
+    mockDb = {
+      select: vi.fn().mockReturnThis(),
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockResolvedValue([globalAlias, userAlias]),
+      limit: vi.fn().mockResolvedValue([userAlias]),
+      insert: vi.fn().mockReturnThis(),
+      values: vi.fn().mockReturnThis(),
+      returning: vi.fn().mockResolvedValue([userAlias]),
+      update: vi.fn().mockReturnThis(),
+      set: vi.fn().mockReturnThis(),
+      delete: vi.fn().mockReturnThis(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MerchantAliasService,
+        { provide: DATABASE_CONNECTION, useValue: mockDb },
+      ],
+    }).compile();
+
+    service = module.get<MerchantAliasService>(MerchantAliasService);
+  });
+
+  describe('findAllForUser', () => {
+    it('returns aliases for user and global aliases', async () => {
+      const result = await service.findAllForUser('user-1');
+      expect(mockDb.select).toHaveBeenCalled();
+      expect(result).toEqual([globalAlias, userAlias]);
+    });
+  });
+
+  describe('create', () => {
+    it('inserts and returns new alias', async () => {
+      const result = await service.create('user-1', { pattern: 'spotify', matchType: 'exact', displayName: 'Spotify' });
+      expect(mockDb.insert).toHaveBeenCalled();
+      expect(result).toEqual(userAlias);
+    });
+  });
+
+  describe('update', () => {
+    it('updates owned alias', async () => {
+      mockDb.limit.mockResolvedValue([userAlias]);
+      mockDb.returning.mockResolvedValue([{ ...userAlias, displayName: 'Spotify Premium' }]);
+      const result = await service.update('alias-u1', 'user-1', { displayName: 'Spotify Premium' });
+      expect(result.displayName).toBe('Spotify Premium');
+    });
+
+    it('throws NotFoundException when alias not found', async () => {
+      mockDb.limit.mockResolvedValue([]);
+      await expect(service.update('nonexistent', 'user-1', {})).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws ForbiddenException for global alias', async () => {
+      mockDb.limit.mockResolvedValue([globalAlias]);
+      await expect(service.update('alias-g1', 'user-1', {})).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('remove', () => {
+    it('deletes owned alias', async () => {
+      mockDb.limit.mockResolvedValue([userAlias]);
+      await service.remove('alias-u1', 'user-1');
+      expect(mockDb.delete).toHaveBeenCalled();
+    });
+
+    it('throws ForbiddenException for global alias', async () => {
+      mockDb.limit.mockResolvedValue([globalAlias]);
+      await expect(service.remove('alias-g1', 'user-1')).rejects.toThrow(ForbiddenException);
+    });
+
+    it('throws NotFoundException when alias not found', async () => {
+      mockDb.limit.mockResolvedValue([]);
+      await expect(service.remove('nonexistent', 'user-1')).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/apps/api/src/categorization/categorization.module.ts
+++ b/apps/api/src/categorization/categorization.module.ts
@@ -4,16 +4,20 @@ import { AiCategorizerService } from './ai-categorizer.service';
 import { LearningService } from './learning.service';
 import { CategorizationService } from './categorization.service';
 import { MerchantNormalizerService } from './merchant-normalizer.service';
+import { MerchantAliasController } from './merchant-alias.controller';
+import { MerchantAliasService } from './merchant-alias.service';
 import { AiLogsModule } from '../ai-logs/ai-logs.module';
 
 @Module({
   imports: [AiLogsModule],
+  controllers: [MerchantAliasController],
   providers: [
     RuleEngineService,
     AiCategorizerService,
     LearningService,
     CategorizationService,
     MerchantNormalizerService,
+    MerchantAliasService,
   ],
   exports: [CategorizationService, RuleEngineService, LearningService, MerchantNormalizerService],
 })

--- a/apps/api/src/categorization/merchant-alias.controller.ts
+++ b/apps/api/src/categorization/merchant-alias.controller.ts
@@ -1,0 +1,63 @@
+import { Controller, Get, Post, Patch, Delete, Body, Param, UseGuards, HttpCode } from '@nestjs/common';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { MerchantAliasService } from './merchant-alias.service';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
+import { z } from 'zod/v4';
+import type { AuthTokenPayload } from '@moneypulse/shared';
+
+const createAliasSchema = z.object({
+  pattern: z.string().min(1).max(200),
+  matchType: z.enum(['contains', 'startsWith', 'exact', 'regex']),
+  displayName: z.string().min(1).max(200),
+});
+
+const updateAliasSchema = createAliasSchema.partial();
+
+type CreateAliasInput = z.infer<typeof createAliasSchema>;
+type UpdateAliasInput = z.infer<typeof updateAliasSchema>;
+
+@ApiTags('Merchant Aliases')
+@Controller('merchant-aliases')
+@UseGuards(JwtAuthGuard)
+export class MerchantAliasController {
+  constructor(private readonly merchantAliasService: MerchantAliasService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List merchant aliases for current user and global aliases' })
+  async list(@CurrentUser() user: AuthTokenPayload) {
+    const aliases = await this.merchantAliasService.findAllForUser(user.sub);
+    return { data: aliases };
+  }
+
+  @Post()
+  @HttpCode(201)
+  @ApiOperation({ summary: 'Create a new merchant alias' })
+  async create(
+    @Body(new ZodValidationPipe(createAliasSchema)) body: CreateAliasInput,
+    @CurrentUser() user: AuthTokenPayload,
+  ) {
+    const alias = await this.merchantAliasService.create(user.sub, body);
+    return { data: alias };
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update a merchant alias (must own it)' })
+  async update(
+    @Param('id') id: string,
+    @Body(new ZodValidationPipe(updateAliasSchema)) body: UpdateAliasInput,
+    @CurrentUser() user: AuthTokenPayload,
+  ) {
+    const alias = await this.merchantAliasService.update(id, user.sub, body);
+    return { data: alias };
+  }
+
+  @Delete(':id')
+  @HttpCode(200)
+  @ApiOperation({ summary: 'Delete a user-created merchant alias' })
+  async remove(@Param('id') id: string, @CurrentUser() user: AuthTokenPayload) {
+    await this.merchantAliasService.remove(id, user.sub);
+    return { data: { deleted: true } };
+  }
+}

--- a/apps/api/src/categorization/merchant-alias.service.ts
+++ b/apps/api/src/categorization/merchant-alias.service.ts
@@ -1,0 +1,54 @@
+import { Injectable, Inject, NotFoundException, ForbiddenException } from '@nestjs/common';
+import { DATABASE_CONNECTION } from '../db/db.module';
+import * as schema from '../db/schema';
+import { eq, or, isNull } from 'drizzle-orm';
+
+@Injectable()
+export class MerchantAliasService {
+  constructor(@Inject(DATABASE_CONNECTION) private readonly db: any) {}
+
+  async findAllForUser(userId: string) {
+    return this.db
+      .select()
+      .from(schema.merchantAliases)
+      .where(or(eq(schema.merchantAliases.userId, userId), isNull(schema.merchantAliases.userId)))
+      .orderBy(schema.merchantAliases.createdAt);
+  }
+
+  async create(userId: string, data: { pattern: string; matchType: string; displayName: string }) {
+    const [created] = await this.db
+      .insert(schema.merchantAliases)
+      .values({ userId, ...data })
+      .returning();
+    return created;
+  }
+
+  async update(id: string, userId: string, data: Partial<{ pattern: string; matchType: string; displayName: string }>) {
+    const [existing] = await this.db
+      .select()
+      .from(schema.merchantAliases)
+      .where(eq(schema.merchantAliases.id, id))
+      .limit(1);
+    if (!existing) throw new NotFoundException('Alias not found');
+    if (existing.userId !== userId) throw new ForbiddenException('Cannot modify global or other-user aliases');
+    const [updated] = await this.db
+      .update(schema.merchantAliases)
+      .set(data)
+      .where(eq(schema.merchantAliases.id, id))
+      .returning();
+    return updated;
+  }
+
+  async remove(id: string, userId: string) {
+    const [existing] = await this.db
+      .select()
+      .from(schema.merchantAliases)
+      .where(eq(schema.merchantAliases.id, id))
+      .limit(1);
+    if (!existing) throw new NotFoundException('Alias not found');
+    if (!existing.userId || existing.userId !== userId) throw new ForbiddenException('Cannot delete global aliases');
+    await this.db
+      .delete(schema.merchantAliases)
+      .where(eq(schema.merchantAliases.id, id));
+  }
+}

--- a/apps/web/src/app/(protected)/merchants/page.tsx
+++ b/apps/web/src/app/(protected)/merchants/page.tsx
@@ -1,0 +1,332 @@
+'use client';
+
+import { useState } from 'react';
+import { Plus, Store, Trash2, Pencil, Lock, RefreshCw } from 'lucide-react';
+import {
+  useMerchantAliases,
+  useCreateMerchantAlias,
+  useUpdateMerchantAlias,
+  useDeleteMerchantAlias,
+  type MerchantAlias,
+} from '@/lib/hooks/useMerchantAliases';
+import { api } from '@/lib/api';
+import { cn } from '@/lib/utils';
+
+const MATCH_TYPE_LABELS: Record<string, string> = {
+  contains: 'Contains',
+  startsWith: 'Starts With',
+  exact: 'Exact',
+  regex: 'Regex',
+};
+
+const MATCH_TYPE_COLORS: Record<string, string> = {
+  contains: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+  startsWith: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
+  exact: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400',
+  regex: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400',
+};
+
+const emptyForm = { pattern: '', matchType: 'contains', displayName: '' };
+
+export default function MerchantsPage() {
+  const { data: aliasData, isLoading } = useMerchantAliases();
+  const createAlias = useCreateMerchantAlias();
+  const updateAlias = useUpdateMerchantAlias();
+  const deleteAlias = useDeleteMerchantAlias();
+
+  const [showForm, setShowForm] = useState(false);
+  const [form, setForm] = useState(emptyForm);
+  const [editTarget, setEditTarget] = useState<MerchantAlias | null>(null);
+  const [editForm, setEditForm] = useState(emptyForm);
+  const [showNormalizePrompt, setShowNormalizePrompt] = useState(false);
+  const [isNormalizing, setIsNormalizing] = useState(false);
+  const [normalizeMsg, setNormalizeMsg] = useState('');
+
+  const aliases = aliasData?.data ?? [];
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    await createAlias.mutateAsync(form);
+    setShowForm(false);
+    setForm(emptyForm);
+    setShowNormalizePrompt(true);
+  }
+
+  async function handleUpdate(e: React.FormEvent) {
+    e.preventDefault();
+    if (!editTarget) return;
+    await updateAlias.mutateAsync({ id: editTarget.id, ...editForm });
+    setEditTarget(null);
+    setShowNormalizePrompt(true);
+  }
+
+  async function handleNormalize() {
+    setIsNormalizing(true);
+    setNormalizeMsg('');
+    try {
+      const res = await api.post<{ data: { updated: number; total: number } }>(
+        '/transactions/normalize-merchants',
+        { force: true },
+      );
+      setNormalizeMsg(`Done — ${res.data.updated} of ${res.data.total} transactions updated.`);
+    } catch {
+      setNormalizeMsg('Normalization failed. Check API logs.');
+    } finally {
+      setIsNormalizing(false);
+      setShowNormalizePrompt(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between">
+        <div className="space-y-1">
+          <h1 className="text-4xl font-extrabold tracking-tight">Merchant Aliases</h1>
+          <p className="text-[var(--muted-foreground)]">
+            Map raw bank merchant strings to clean display names
+          </p>
+        </div>
+        <button
+          onClick={() => setShowForm(!showForm)}
+          className="flex items-center gap-2 rounded-full bg-[var(--primary)] px-5 py-2.5 text-sm font-bold text-[var(--primary-foreground)] shadow-lg shadow-[var(--primary)]/20 transition-all hover:opacity-90 active:scale-[0.98]"
+        >
+          <Plus className="h-4 w-4" />
+          Add Alias
+        </button>
+      </div>
+
+      {/* Re-normalize prompt */}
+      {showNormalizePrompt && (
+        <div className="flex items-center gap-4 rounded-2xl border border-[var(--border)] bg-[var(--card)] px-5 py-4 shadow-sm">
+          <RefreshCw className="h-5 w-5 shrink-0 text-[var(--primary)]" />
+          <p className="flex-1 text-sm font-medium">
+            Re-normalize all transactions with the updated alias?
+          </p>
+          <button
+            onClick={handleNormalize}
+            disabled={isNormalizing}
+            className="rounded-full bg-[var(--primary)] px-4 py-2 text-xs font-bold text-[var(--primary-foreground)] hover:opacity-90 disabled:opacity-50"
+          >
+            {isNormalizing ? 'Normalizing…' : 'Yes, normalize'}
+          </button>
+          <button
+            onClick={() => setShowNormalizePrompt(false)}
+            className="rounded-full border border-[var(--border)] px-4 py-2 text-xs font-semibold hover:bg-[var(--muted)]"
+          >
+            No thanks
+          </button>
+        </div>
+      )}
+
+      {normalizeMsg && (
+        <p className="text-sm text-green-600 dark:text-green-400">{normalizeMsg}</p>
+      )}
+
+      {/* Create form */}
+      {showForm && (
+        <form
+          onSubmit={handleCreate}
+          className="space-y-4 rounded-2xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-sm"
+        >
+          <h2 className="text-lg font-bold">New Alias</h2>
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div>
+              <label className="mb-1.5 block text-sm font-semibold">Pattern</label>
+              <input
+                type="text"
+                required
+                value={form.pattern}
+                onChange={(e) => setForm({ ...form, pattern: e.target.value })}
+                placeholder="e.g. costar"
+                className="w-full rounded-xl border border-[var(--border)] bg-[var(--surface-container-low)] px-3 py-2.5 text-sm focus:border-[var(--primary)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)]/30 transition-all"
+              />
+            </div>
+            <div>
+              <label className="mb-1.5 block text-sm font-semibold">Match Type</label>
+              <select
+                value={form.matchType}
+                onChange={(e) => setForm({ ...form, matchType: e.target.value })}
+                className="w-full rounded-xl border border-[var(--border)] bg-[var(--surface-container-low)] px-3 py-2.5 text-sm focus:border-[var(--primary)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)]/30 transition-all"
+              >
+                <option value="contains">Contains</option>
+                <option value="startsWith">Starts With</option>
+                <option value="exact">Exact</option>
+                <option value="regex">Regex</option>
+              </select>
+            </div>
+            <div>
+              <label className="mb-1.5 block text-sm font-semibold">Display Name</label>
+              <input
+                type="text"
+                required
+                value={form.displayName}
+                onChange={(e) => setForm({ ...form, displayName: e.target.value })}
+                placeholder="e.g. CoStar Group"
+                className="w-full rounded-xl border border-[var(--border)] bg-[var(--surface-container-low)] px-3 py-2.5 text-sm focus:border-[var(--primary)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)]/30 transition-all"
+              />
+            </div>
+          </div>
+          <div className="flex gap-3">
+            <button
+              type="submit"
+              disabled={createAlias.isPending}
+              className="rounded-full bg-[var(--primary)] px-5 py-2.5 text-sm font-bold text-[var(--primary-foreground)] shadow-lg shadow-[var(--primary)]/20 transition-all hover:opacity-90 active:scale-[0.98] disabled:opacity-50"
+            >
+              {createAlias.isPending ? 'Creating…' : 'Create Alias'}
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowForm(false)}
+              className="rounded-full border border-[var(--border)] px-5 py-2.5 text-sm font-semibold hover:bg-[var(--muted)] transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      )}
+
+      {/* Alias table */}
+      {isLoading ? (
+        <div className="flex items-center justify-center py-12">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-[var(--primary)] border-t-transparent" />
+        </div>
+      ) : aliases.length === 0 ? (
+        <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-[var(--border)] py-16">
+          <Store className="mb-3 h-10 w-10 text-[var(--muted-foreground)]" />
+          <p className="text-sm text-[var(--muted-foreground)]">
+            No merchant aliases yet. Add one to start cleaning up merchant names.
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-sm">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-[var(--border)] bg-[var(--surface-container-low)]">
+                <th className="px-5 py-3 text-left text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]">Pattern</th>
+                <th className="px-5 py-3 text-left text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]">Match Type</th>
+                <th className="px-5 py-3 text-left text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]">Display Name</th>
+                <th className="px-5 py-3 text-left text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]">Source</th>
+                <th className="px-5 py-3 text-right text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[var(--border)]">
+              {aliases.map((alias) => {
+                const isGlobal = alias.userId === null;
+                return (
+                  <tr key={alias.id} className="transition-colors hover:bg-[var(--muted)]/40">
+                    <td className="px-5 py-3 font-mono text-xs">{alias.pattern}</td>
+                    <td className="px-5 py-3">
+                      <span className={cn('inline-block rounded-full px-2.5 py-0.5 text-xs font-semibold', MATCH_TYPE_COLORS[alias.matchType] ?? 'bg-gray-100 text-gray-700')}>
+                        {MATCH_TYPE_LABELS[alias.matchType] ?? alias.matchType}
+                      </span>
+                    </td>
+                    <td className="px-5 py-3 font-medium">{alias.displayName}</td>
+                    <td className="px-5 py-3">
+                      {isGlobal ? (
+                        <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-semibold text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+                          <Lock className="h-3 w-3" />
+                          Global
+                        </span>
+                      ) : (
+                        <span className="inline-block rounded-full bg-[var(--accent)] px-2.5 py-0.5 text-xs font-semibold text-[var(--primary)]">
+                          Custom
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-5 py-3 text-right">
+                      {!isGlobal && (
+                        <div className="flex items-center justify-end gap-1">
+                          <button
+                            onClick={() => {
+                              setEditTarget(alias);
+                              setEditForm({ pattern: alias.pattern, matchType: alias.matchType, displayName: alias.displayName });
+                            }}
+                            className="rounded-full p-1.5 text-[var(--muted-foreground)] hover:bg-[var(--muted)] hover:text-[var(--primary)] transition-colors"
+                            aria-label="Edit alias"
+                          >
+                            <Pencil className="h-4 w-4" />
+                          </button>
+                          <button
+                            onClick={() => {
+                              if (confirm('Delete this alias?')) {
+                                deleteAlias.mutate(alias.id);
+                              }
+                            }}
+                            className="rounded-full p-1.5 text-[var(--muted-foreground)] hover:bg-[var(--muted)] hover:text-[var(--destructive)] transition-colors"
+                            aria-label="Delete alias"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </button>
+                        </div>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Edit modal */}
+      {editTarget && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="w-full max-w-md rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-xl">
+            <h2 className="mb-4 text-lg font-semibold">Edit Alias</h2>
+            <form onSubmit={handleUpdate} className="space-y-4">
+              <div>
+                <label className="mb-1.5 block text-sm font-semibold">Pattern</label>
+                <input
+                  type="text"
+                  required
+                  value={editForm.pattern}
+                  onChange={(e) => setEditForm({ ...editForm, pattern: e.target.value })}
+                  className="w-full rounded-xl border border-[var(--border)] bg-[var(--surface-container-low)] px-3 py-2.5 text-sm focus:border-[var(--primary)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)]/30 transition-all"
+                />
+              </div>
+              <div>
+                <label className="mb-1.5 block text-sm font-semibold">Match Type</label>
+                <select
+                  value={editForm.matchType}
+                  onChange={(e) => setEditForm({ ...editForm, matchType: e.target.value })}
+                  className="w-full rounded-xl border border-[var(--border)] bg-[var(--surface-container-low)] px-3 py-2.5 text-sm focus:border-[var(--primary)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)]/30 transition-all"
+                >
+                  <option value="contains">Contains</option>
+                  <option value="startsWith">Starts With</option>
+                  <option value="exact">Exact</option>
+                  <option value="regex">Regex</option>
+                </select>
+              </div>
+              <div>
+                <label className="mb-1.5 block text-sm font-semibold">Display Name</label>
+                <input
+                  type="text"
+                  required
+                  value={editForm.displayName}
+                  onChange={(e) => setEditForm({ ...editForm, displayName: e.target.value })}
+                  className="w-full rounded-xl border border-[var(--border)] bg-[var(--surface-container-low)] px-3 py-2.5 text-sm focus:border-[var(--primary)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)]/30 transition-all"
+                />
+              </div>
+              <div className="flex items-center justify-end gap-3 pt-2">
+                <button
+                  type="button"
+                  onClick={() => setEditTarget(null)}
+                  className="rounded-lg border border-[var(--border)] px-4 py-2 text-sm hover:bg-[var(--muted)]"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={updateAlias.isPending}
+                  className="rounded-lg bg-[var(--primary)] px-4 py-2 text-sm font-medium text-[var(--primary-foreground)] hover:opacity-90 disabled:opacity-50"
+                >
+                  {updateAlias.isPending ? 'Saving…' : 'Save Changes'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -19,6 +19,7 @@ import {
   LogOut,
   Brain,
   RefreshCw,
+  Store,
 } from 'lucide-react';
 import { useAuth } from '@/lib/auth';
 import { UserAvatar } from './UserAvatar';
@@ -38,6 +39,7 @@ const navItems: NavItem[] = [
   { href: '/accounts', label: 'Accounts', icon: Landmark },
   { href: '/budgets', label: 'Budgets', icon: Wallet },
   { href: '/categories', label: 'Categories', icon: Tags },
+  { href: '/merchants', label: 'Merchants', icon: Store },
   { href: '/ai-logs', label: 'AI Logs', icon: Brain },
   { href: '/sync', label: 'Sync', icon: RefreshCw },
   { href: '/settings', label: 'Settings', icon: Settings },

--- a/apps/web/src/lib/hooks/useMerchantAliases.ts
+++ b/apps/web/src/lib/hooks/useMerchantAliases.ts
@@ -1,0 +1,52 @@
+'use client';
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { api } from '../api';
+
+export interface MerchantAlias {
+  id: string;
+  userId: string | null;
+  pattern: string;
+  matchType: 'contains' | 'startsWith' | 'exact' | 'regex';
+  displayName: string;
+  createdAt: string;
+}
+
+export function useMerchantAliases() {
+  return useQuery({
+    queryKey: ['merchant-aliases'],
+    queryFn: () => api.get<{ data: MerchantAlias[] }>('/merchant-aliases'),
+  });
+}
+
+export function useCreateMerchantAlias() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: { pattern: string; matchType: string; displayName: string }) =>
+      api.post<{ data: MerchantAlias }>('/merchant-aliases', body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['merchant-aliases'] });
+    },
+  });
+}
+
+export function useUpdateMerchantAlias() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, ...body }: { id: string; pattern?: string; matchType?: string; displayName?: string }) =>
+      api.patch<{ data: MerchantAlias }>(`/merchant-aliases/${id}`, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['merchant-aliases'] });
+    },
+  });
+}
+
+export function useDeleteMerchantAlias() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.delete(`/merchant-aliases/${id}`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['merchant-aliases'] });
+    },
+  });
+}


### PR DESCRIPTION
Implement a new merchant alias management feature, including a dedicated page and API endpoints for CRUD operations. This feature allows users to manage their merchant aliases with ownership checks and validation. The implementation includes a new service, controller, and React Query hooks, along with unit tests to ensure functionality. A sidebar navigation item for merchants has also been added.