### PR TITLE
fix(web): make notification dropdown opaque and readable (#28)

### DIFF
--- a/apps/web/src/components/NotificationBell.tsx
+++ b/apps/web/src/components/NotificationBell.tsx
@@ -46,36 +46,36 @@ export function NotificationBell() {
       </button>
 
       {open && (
-        <div className="absolute right-0 mt-2 w-80 bg-card border border-border rounded-lg shadow-lg z-50 max-h-96 overflow-y-auto">
-          <div className="p-3 border-b border-border flex items-center justify-between">
+        <div className="absolute right-0 mt-2 w-80 bg-[var(--card)] text-[var(--card-foreground)] border border-[var(--border)] rounded-lg shadow-lg z-50 max-h-96 overflow-y-auto">
+          <div className="p-3 border-b border-[var(--border)] flex items-center justify-between">
             <h3 className="font-medium text-sm">Notifications</h3>
             {!!unread && unread > 0 && (
               <button
                 onClick={() => markAllRead.mutate()}
-                className="text-xs text-primary hover:underline"
+                className="text-xs text-[var(--primary)] hover:underline"
               >
                 Mark all read
               </button>
             )}
           </div>
-          <div className="divide-y divide-border">
+          <div className="divide-y divide-[var(--border)]">
             {notifications.slice(0, 20).map((n: any) => (
               <button
                 type="button"
                 key={n.id}
-                className={`w-full text-left p-3 cursor-pointer hover:bg-muted/50 ${!n.isRead ? 'bg-primary/5' : ''}`}
+                className={`w-full text-left p-3 cursor-pointer hover:bg-[var(--muted)]/50 ${!n.isRead ? 'bg-[var(--primary)]/5' : ''}`}
                 onClick={() => {
                   if (!n.isRead) markRead.mutate(n.id);
                 }}
               >
                 <p className="text-sm font-medium">{n.title}</p>
-                <p className="text-xs text-muted-foreground mt-0.5">
+                <p className="text-xs text-[var(--muted-foreground)] mt-0.5">
                   {n.message}
                 </p>
               </button>
             ))}
             {notifications.length === 0 && (
-              <p className="p-4 text-sm text-muted-foreground">
+              <p className="p-4 text-sm text-[var(--muted-foreground)]">
                 No notifications
               </p>
             )}


### PR DESCRIPTION
Closes #28

## Problem
The notification dropdown rendered with a transparent background, so the page content behind it bled through and overlapped the notification text, making both unreadable.

## Root cause
Tailwind v4 (`@tailwindcss/postcss`) only generates color utilities for tokens registered in a `@theme` block. `globals.css` defines the design tokens (`--card`, `--border`, `--muted-foreground`, …) as plain CSS variables with **no `@theme` mapping**, so `bg-card` / `border-border` / `text-muted-foreground` produce **no CSS**. Verified with a Tailwind CLI build: `bg-red-500` → 5 rules, `bg-card` → 0. The white border box in the screenshot only appears because `border` (width) works and defaults to `currentColor`.

## Fix
Switch the token utilities in `NotificationBell.tsx` to arbitrary-value equivalents that emit CSS regardless of the missing `@theme` mapping:
- `bg-card` → `bg-[var(--card)]` (+ `text-[var(--card-foreground)]`)
- `border-border` → `border-[var(--border)]`, `divide-[var(--border)]`
- `text-primary` → `text-[var(--primary)]`
- `text-muted-foreground` → `text-[var(--muted-foreground)]`
- `hover:bg-muted/50` / `bg-primary/5` → `hover:bg-[var(--muted)]/50` / `bg-[var(--primary)]/5`

The panel now has an opaque `#131313` card background (dark theme) and fully occludes the content behind it.

## Scope / follow-up
This is the same app-wide gap (budgets, SavingsGoalCard, BudgetCard also use `bg-card`); the proper systemic fix is adding a Tailwind v4 `@theme inline` block, which changes rendering across many pages and needs visual review. Left for a separate PR to keep this scoped to #28.

## Test plan
- `pnpm --filter @moneypulse/shared build && pnpm --filter web build` — passes.
- Confirmed compiled output now contains `background-color:var(--card)` and `var(--muted-foreground)` (previously absent).
- No unit/Playwright tests cover this component; change is CSS-class only.