### PR TITLE
fix(web): register design tokens with Tailwind v4 @theme (#30)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,5 +1,35 @@
 @import 'tailwindcss';
 
+/*
+ * Register the design tokens defined below with Tailwind v4 so utilities like
+ * `bg-card`, `border-border`, and `text-muted-foreground` actually generate CSS.
+ * `inline` keeps the utilities referencing `var(--token)`, so `.dark` runtime
+ * theme switching still works. Chart colors are consumed as `hsl(var(--chart-N))`
+ * directly in JS and intentionally stay out of this map.
+ */
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-border: var(--border);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-success: var(--success);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-surface-container: var(--surface-container);
+  --color-surface-container-low: var(--surface-container-low);
+  --color-surface-container-high: var(--surface-container-high);
+  --color-surface-container-highest: var(--surface-container-highest);
+}
+
 :root {
   /* Light theme — clean slate */
   --background: #f7f9fb;


### PR DESCRIPTION
Closes #30

## Problem
Tailwind v4 only generates color utilities for tokens registered in a `@theme` block. `globals.css` defined the design tokens (`--card`, `--border`, `--primary`, `--muted-foreground`, …) as plain CSS variables with **no `@theme` block**, so `bg-card` / `border-border` / `text-muted-foreground` / `bg-primary` / `text-primary-foreground` generated **no CSS**. (Root cause behind #28.)

## Fix
Add an `@theme inline` block mapping each semantic token to `--color-<token>`. `inline` keeps utilities referencing `var()` so `.dark` runtime theme switching still works. Chart colors are consumed as `hsl(var(--chart-N))` in JS and are intentionally left out.

## Blast radius (small)
Most of the app already uses arbitrary `bg-[var(--…)]` values (login, ThemeToggle, notification dropdown). Only three surfaces still used the bare no-op utilities, all in the Budgets area:
- `app/(protected)/budgets/page.tsx`
- `components/BudgetCard.tsx`
- `components/SavingsGoalCard.tsx`

There, ghosted buttons / invisible cards / harsh `currentColor` borders now render as designed (see before/after below).

## Before / after (Budgets)
| Before | After |
|---|---|
| `+ Add budget` / `Save` are transparent text, harsh white borders, no card fill | lavender `bg-primary` buttons, subtle borders, elevated card surface, proper muted text |

## Test plan
- `pnpm --filter web build` — passes
- Tailwind CLI + built `.next` CSS now emit `.bg-card{background-color:var(--card)}`, `.border-border{border-color:var(--border)}`, etc. (previously 0 rules)
- 64 web Vitest tests pass
- Rendered the real Budgets markup against old vs new compiled CSS and screenshotted before/after (Playwright)