### PR TITLE
feat(alerts): statistical spending-anomaly baselines (#32)

### DIFF
--- a/apps/api/src/analytics/__tests__/anomaly-detector.service.spec.ts
+++ b/apps/api/src/analytics/__tests__/anomaly-detector.service.spec.ts
@@ -24,13 +24,10 @@ function makeTxn(overrides: Record<string, any> = {}) {
 
 function buildMockDb(txn: any) {
   const mockDb: any = {
-    select: vi.fn().mockReturnThis(),
-    from: vi.fn().mockReturnThis(),
-    where: vi.fn().mockResolvedValue(txn ? [txn] : []),
-    limit: vi.fn().mockResolvedValue(txn ? [txn] : []),
+    select: vi.fn(),
     execute: vi.fn(),
   };
-  // Make the chain: select().from().where().limit() return the transaction
+  // Chain: select().from().where().limit() → the transaction row
   mockDb.select.mockReturnValue({
     from: vi.fn().mockReturnValue({
       where: vi.fn().mockReturnValue({
@@ -39,6 +36,30 @@ function buildMockDb(txn: any) {
     }),
   });
   return mockDb;
+}
+
+/**
+ * Convenience for the per-transaction execute() sequence:
+ *   1. merchant baseline stats
+ *   2. duplicate lookup
+ * Pass `stats: null` to simulate no merchant history (empty stats row).
+ */
+function mockExecuteSequence(
+  db: any,
+  {
+    stats,
+    duplicateRows = [],
+  }: {
+    stats: { avgCents: number; stddevCents: number; count: number } | null;
+    duplicateRows?: any[];
+  },
+) {
+  const statsRows = stats
+    ? [{ avg_cents: String(stats.avgCents), stddev_cents: String(stats.stddevCents), txn_count: stats.count }]
+    : [];
+  db.execute
+    .mockResolvedValueOnce({ rows: statsRows })
+    .mockResolvedValueOnce({ rows: duplicateRows });
 }
 
 function buildMockNotifications(existingDedupeKeys: string[] = []) {
@@ -51,8 +72,13 @@ function buildMockNotifications(existingDedupeKeys: string[] = []) {
 }
 
 function makeService(db: any, notifications: any) {
-  const svc = new AnomalyDetectorService(db, notifications as any);
-  return svc;
+  return new AnomalyDetectorService(db, notifications as any);
+}
+
+function callsForRule(notif: any, rule: string) {
+  return notif.createAndDispatch.mock.calls.filter(
+    (c: any[]) => c[0].metadata?.rule === rule,
+  );
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -60,53 +86,40 @@ function makeService(db: any, notifications: any) {
 describe('AnomalyDetectorService', () => {
   describe('detectAnomalies — skip conditions', () => {
     it('skips credit transactions (income/refunds)', async () => {
-      const txn = makeTxn({ isCredit: true });
-      const db = buildMockDb(txn);
       const notif = buildMockNotifications();
-      const svc = makeService(db, notif);
-
-      await svc.detectAnomalies('user-1', ['txn-1']);
-
+      await makeService(buildMockDb(makeTxn({ isCredit: true })), notif).detectAnomalies(
+        'user-1',
+        ['txn-1'],
+      );
       expect(notif.createAndDispatch).not.toHaveBeenCalled();
     });
 
     it('skips split-parent transactions', async () => {
-      const txn = makeTxn({ isSplitParent: true });
-      const db = buildMockDb(txn);
       const notif = buildMockNotifications();
-      const svc = makeService(db, notif);
-
-      await svc.detectAnomalies('user-1', ['txn-1']);
-
+      await makeService(buildMockDb(makeTxn({ isSplitParent: true })), notif).detectAnomalies(
+        'user-1',
+        ['txn-1'],
+      );
       expect(notif.createAndDispatch).not.toHaveBeenCalled();
     });
 
     it('skips split-child transactions (has parentTransactionId)', async () => {
-      const txn = makeTxn({ parentTransactionId: 'parent-txn-1' });
-      const db = buildMockDb(txn);
       const notif = buildMockNotifications();
-      const svc = makeService(db, notif);
-
-      await svc.detectAnomalies('user-1', ['txn-1']);
-
+      await makeService(
+        buildMockDb(makeTxn({ parentTransactionId: 'parent-txn-1' })),
+        notif,
+      ).detectAnomalies('user-1', ['txn-1']);
       expect(notif.createAndDispatch).not.toHaveBeenCalled();
     });
 
     it('skips when transaction is not found', async () => {
-      const db = buildMockDb(null);
       const notif = buildMockNotifications();
-      const svc = makeService(db, notif);
-
-      await svc.detectAnomalies('user-1', ['nonexistent-txn']);
-
+      await makeService(buildMockDb(null), notif).detectAnomalies('user-1', ['nope']);
       expect(notif.createAndDispatch).not.toHaveBeenCalled();
     });
 
     it('continues processing remaining transactions when one fails', async () => {
-      // First txn throws, second should still be checked
-      const db = buildMockDb(null); // returns no txn for both
-      const notif = buildMockNotifications();
-      // Simulate error on first txn by making the first select throw
+      const db = buildMockDb(null);
       let callCount = 0;
       db.select = vi.fn().mockImplementation(() => {
         callCount++;
@@ -119,184 +132,153 @@ describe('AnomalyDetectorService', () => {
           }),
         };
       });
-
-      const svc = makeService(db, notif);
-      // Should not throw even if one txn check fails
+      const notif = buildMockNotifications();
       await expect(
-        svc.detectAnomalies('user-1', ['txn-error', 'txn-2']),
+        makeService(db, notif).detectAnomalies('user-1', ['txn-error', 'txn-2']),
       ).resolves.not.toThrow();
     });
   });
 
-  describe('amount anomaly check', () => {
-    it('creates notification when transaction is > 3x the merchant average (with 3+ history)', async () => {
+  describe('amount anomaly (z-score)', () => {
+    it('flags a statistical outlier: amount many σ above the merchant mean', async () => {
+      // avg $30, σ≈0 → effective σ floored to 10% ($3); $120 is ~30σ above
       const txn = makeTxn({ amountCents: 12_000, normalizedMerchantName: 'Acme Corp' });
       const db = buildMockDb(txn);
-      db.execute = vi.fn().mockResolvedValueOnce({
-        rows: [{ avg_cents: '3000', txn_count: 5 }],
-      });
-      // subsequent execute calls (duplicate check) → no rows
-      db.execute.mockResolvedValue({ rows: [] });
+      mockExecuteSequence(db, { stats: { avgCents: 3000, stddevCents: 0, count: 6 } });
       const notif = buildMockNotifications();
-      const svc = makeService(db, notif);
 
-      await svc.detectAnomalies('user-1', ['txn-1']);
+      await makeService(db, notif).detectAnomalies('user-1', ['txn-1']);
 
-      const calls = notif.createAndDispatch.mock.calls;
-      const anomalyCalls = calls.filter((c: any[]) => c[0].metadata?.rule === 'amount_anomaly');
-      expect(anomalyCalls).toHaveLength(1);
-      expect(anomalyCalls[0][0].message).toContain('Acme Corp');
-      expect(anomalyCalls[0][0].message).toContain('$120.00');
+      const calls = callsForRule(notif, 'amount_anomaly');
+      expect(calls).toHaveLength(1);
+      expect(calls[0][0].title).toBe('Unusual spend detected');
+      expect(calls[0][0].message).toContain('Acme Corp');
+      expect(calls[0][0].message).toContain('$120.00');
+      expect(calls[0][0].metadata.zScore).toBeGreaterThanOrEqual(3);
     });
 
-    it('does NOT flag when transaction is only 1.5x the average', async () => {
-      const txn = makeTxn({ amountCents: 4_500, normalizedMerchantName: 'Acme Corp' });
+    it('does NOT flag when within the normal band (low z-score)', async () => {
+      // avg $300, σ $50 → $360 is only ~1.2σ above; not an outlier
+      const txn = makeTxn({ amountCents: 36_000, normalizedMerchantName: 'Acme Corp' });
       const db = buildMockDb(txn);
-      db.execute = vi.fn().mockResolvedValue({ rows: [{ avg_cents: '3000', txn_count: 5 }] });
+      mockExecuteSequence(db, { stats: { avgCents: 30_000, stddevCents: 5_000, count: 8 } });
       const notif = buildMockNotifications();
-      const svc = makeService(db, notif);
 
-      await svc.detectAnomalies('user-1', ['txn-1']);
+      await makeService(db, notif).detectAnomalies('user-1', ['txn-1']);
 
-      const anomalyCalls = notif.createAndDispatch.mock.calls.filter(
-        (c: any[]) => c[0].metadata?.rule === 'amount_anomaly',
-      );
-      expect(anomalyCalls).toHaveLength(0);
+      expect(callsForRule(notif, 'amount_anomaly')).toHaveLength(0);
     });
 
-    it('does NOT flag when history has fewer than 3 transactions', async () => {
-      const txn = makeTxn({ amountCents: 50_000, normalizedMerchantName: 'Acme Corp' });
+    it('does NOT flag a high-z but low-value merchant (absolute-delta floor)', async () => {
+      // avg $2, σ≈0 → $8 is a huge z-score but only $6 over → below $25 floor
+      const txn = makeTxn({ amountCents: 800, normalizedMerchantName: 'Coffee Cart' });
       const db = buildMockDb(txn);
-      db.execute = vi.fn().mockResolvedValue({ rows: [{ avg_cents: '5000', txn_count: 2 }] });
+      mockExecuteSequence(db, { stats: { avgCents: 200, stddevCents: 0, count: 10 } });
       const notif = buildMockNotifications();
-      const svc = makeService(db, notif);
 
-      await svc.detectAnomalies('user-1', ['txn-1']);
+      await makeService(db, notif).detectAnomalies('user-1', ['txn-1']);
 
-      const anomalyCalls = notif.createAndDispatch.mock.calls.filter(
-        (c: any[]) => c[0].metadata?.rule === 'amount_anomaly',
-      );
-      expect(anomalyCalls).toHaveLength(0);
+      expect(callsForRule(notif, 'amount_anomaly')).toHaveLength(0);
     });
 
-    it('skips amount anomaly check when merchant name is null', async () => {
-      const txn = makeTxn({ amountCents: 50_000, merchantName: null, normalizedMerchantName: null });
+    it('does NOT flag when history has fewer than MIN_HISTORY transactions', async () => {
+      const txn = makeTxn({ amountCents: 40_000, normalizedMerchantName: 'Acme Corp' });
       const db = buildMockDb(txn);
-      db.execute = vi.fn().mockResolvedValue({ rows: [] });
+      mockExecuteSequence(db, { stats: { avgCents: 5_000, stddevCents: 0, count: 3 } });
       const notif = buildMockNotifications();
-      const svc = makeService(db, notif);
 
-      await svc.detectAnomalies('user-1', ['txn-1']);
+      await makeService(db, notif).detectAnomalies('user-1', ['txn-1']);
 
-      const anomalyCalls = notif.createAndDispatch.mock.calls.filter(
-        (c: any[]) => c[0].metadata?.rule === 'amount_anomaly',
-      );
-      expect(anomalyCalls).toHaveLength(0);
+      expect(callsForRule(notif, 'amount_anomaly')).toHaveLength(0);
     });
 
-    it('does not create duplicate notification when dedupeKey already exists', async () => {
+    it('skips amount anomaly when merchant name is null', async () => {
+      const txn = makeTxn({ amountCents: 40_000, merchantName: null, normalizedMerchantName: null });
+      const db = buildMockDb(txn);
+      const notif = buildMockNotifications();
+
+      await makeService(db, notif).detectAnomalies('user-1', ['txn-1']);
+
+      expect(callsForRule(notif, 'amount_anomaly')).toHaveLength(0);
+      // No merchant → no stats/duplicate queries issued
+      expect(db.execute).not.toHaveBeenCalled();
+    });
+
+    it('does not re-notify when the amount dedupeKey already exists', async () => {
       const txn = makeTxn({ amountCents: 12_000 });
       const db = buildMockDb(txn);
-      db.execute = vi.fn().mockResolvedValue({ rows: [{ avg_cents: '3000', txn_count: 5 }] });
-      // Simulate dedupeKey already present for amount anomaly
+      mockExecuteSequence(db, { stats: { avgCents: 3000, stddevCents: 0, count: 6 } });
       const notif = buildMockNotifications([`anomaly_amount_${txn.id}`]);
-      const svc = makeService(db, notif);
 
-      await svc.detectAnomalies('user-1', ['txn-1']);
+      await makeService(db, notif).detectAnomalies('user-1', ['txn-1']);
 
-      const anomalyCalls = notif.createAndDispatch.mock.calls.filter(
-        (c: any[]) => c[0].metadata?.rule === 'amount_anomaly',
-      );
-      expect(anomalyCalls).toHaveLength(0);
+      expect(callsForRule(notif, 'amount_anomaly')).toHaveLength(0);
     });
   });
 
-  describe('duplicate detection check', () => {
-    it('creates notification when a similar transaction exists within 24 hours', async () => {
+  describe('duplicate detection', () => {
+    it('flags when a similar transaction exists within 24 hours', async () => {
       const txn = makeTxn({ amountCents: 5_000, normalizedMerchantName: 'Starbucks' });
       const db = buildMockDb(txn);
-      db.execute = vi
-        .fn()
-        // amount anomaly: no history (txn_count < 3)
-        .mockResolvedValueOnce({ rows: [{ avg_cents: '5000', txn_count: 1 }] })
-        // duplicate check: found a matching txn
-        .mockResolvedValueOnce({ rows: [{ id: 'other-txn' }] });
+      mockExecuteSequence(db, {
+        stats: { avgCents: 5_000, stddevCents: 0, count: 2 }, // too little history to flag amount
+        duplicateRows: [{ id: 'other-txn' }],
+      });
       const notif = buildMockNotifications();
-      const svc = makeService(db, notif);
 
-      await svc.detectAnomalies('user-1', ['txn-1']);
+      await makeService(db, notif).detectAnomalies('user-1', ['txn-1']);
 
-      const dupCalls = notif.createAndDispatch.mock.calls.filter(
-        (c: any[]) => c[0].metadata?.rule === 'duplicate',
-      );
-      expect(dupCalls).toHaveLength(1);
-      expect(dupCalls[0][0].title).toBe('Possible duplicate transaction');
+      const dup = callsForRule(notif, 'duplicate');
+      expect(dup).toHaveLength(1);
+      expect(dup[0][0].title).toBe('Possible duplicate transaction');
     });
 
     it('does NOT flag when no similar transaction exists', async () => {
       const txn = makeTxn({ amountCents: 5_000, normalizedMerchantName: 'Starbucks' });
       const db = buildMockDb(txn);
-      db.execute = vi
-        .fn()
-        .mockResolvedValueOnce({ rows: [{ avg_cents: '5000', txn_count: 1 }] }) // amount anomaly: skip
-        .mockResolvedValueOnce({ rows: [] }); // duplicate: none
+      mockExecuteSequence(db, { stats: { avgCents: 5_000, stddevCents: 0, count: 2 }, duplicateRows: [] });
       const notif = buildMockNotifications();
-      const svc = makeService(db, notif);
 
-      await svc.detectAnomalies('user-1', ['txn-1']);
+      await makeService(db, notif).detectAnomalies('user-1', ['txn-1']);
 
-      const dupCalls = notif.createAndDispatch.mock.calls.filter(
-        (c: any[]) => c[0].metadata?.rule === 'duplicate',
-      );
-      expect(dupCalls).toHaveLength(0);
+      expect(callsForRule(notif, 'duplicate')).toHaveLength(0);
     });
   });
 
-  describe('large debit check', () => {
-    it('creates notification when debit is at or above $500 threshold', async () => {
+  describe('large-debit fallback', () => {
+    it('flags a large debit when there is no merchant history to judge normality', async () => {
       const txn = makeTxn({ amountCents: 60_000, normalizedMerchantName: 'Best Buy' });
       const db = buildMockDb(txn);
-      db.execute = vi.fn().mockResolvedValue({ rows: [] }); // no history / no dup
+      mockExecuteSequence(db, { stats: null });
       const notif = buildMockNotifications();
-      const svc = makeService(db, notif);
 
-      await svc.detectAnomalies('user-1', ['txn-1']);
+      await makeService(db, notif).detectAnomalies('user-1', ['txn-1']);
 
-      const largeCalls = notif.createAndDispatch.mock.calls.filter(
-        (c: any[]) => c[0].metadata?.rule === 'large_debit',
-      );
-      expect(largeCalls).toHaveLength(1);
-      expect(largeCalls[0][0].message).toContain('$600.00');
+      const large = callsForRule(notif, 'large_debit');
+      expect(large).toHaveLength(1);
+      expect(large[0][0].message).toContain('$600.00');
     });
 
-    it('creates notification for exactly $500 (boundary)', async () => {
+    it('flags exactly $500 with no history (boundary)', async () => {
       const txn = makeTxn({ amountCents: 50_000, normalizedMerchantName: 'Best Buy' });
       const db = buildMockDb(txn);
-      db.execute = vi.fn().mockResolvedValue({ rows: [] });
+      mockExecuteSequence(db, { stats: null });
       const notif = buildMockNotifications();
-      const svc = makeService(db, notif);
 
-      await svc.detectAnomalies('user-1', ['txn-1']);
+      await makeService(db, notif).detectAnomalies('user-1', ['txn-1']);
 
-      const largeCalls = notif.createAndDispatch.mock.calls.filter(
-        (c: any[]) => c[0].metadata?.rule === 'large_debit',
-      );
-      expect(largeCalls).toHaveLength(1);
+      expect(callsForRule(notif, 'large_debit')).toHaveLength(1);
     });
 
-    it('does NOT flag when debit is $499.99 (below threshold)', async () => {
+    it('does NOT flag $499.99 (below threshold)', async () => {
       const txn = makeTxn({ amountCents: 49_999, normalizedMerchantName: 'Best Buy' });
       const db = buildMockDb(txn);
-      db.execute = vi.fn().mockResolvedValue({ rows: [{ avg_cents: '49999', txn_count: 1 }] });
+      mockExecuteSequence(db, { stats: null });
       const notif = buildMockNotifications();
-      const svc = makeService(db, notif);
 
-      await svc.detectAnomalies('user-1', ['txn-1']);
+      await makeService(db, notif).detectAnomalies('user-1', ['txn-1']);
 
-      const largeCalls = notif.createAndDispatch.mock.calls.filter(
-        (c: any[]) => c[0].metadata?.rule === 'large_debit',
-      );
-      expect(largeCalls).toHaveLength(0);
+      expect(callsForRule(notif, 'large_debit')).toHaveLength(0);
     });
 
     it('uses description as label when merchant name is null', async () => {
@@ -307,52 +289,53 @@ describe('AnomalyDetectorService', () => {
         description: 'Wire transfer',
       });
       const db = buildMockDb(txn);
-      db.execute = vi.fn().mockResolvedValue({ rows: [] });
       const notif = buildMockNotifications();
-      const svc = makeService(db, notif);
 
-      await svc.detectAnomalies('user-1', ['txn-1']);
+      await makeService(db, notif).detectAnomalies('user-1', ['txn-1']);
 
-      const largeCalls = notif.createAndDispatch.mock.calls.filter(
-        (c: any[]) => c[0].metadata?.rule === 'large_debit',
-      );
-      expect(largeCalls).toHaveLength(1);
-      expect(largeCalls[0][0].message).toContain('Wire transfer');
+      const large = callsForRule(notif, 'large_debit');
+      expect(large).toHaveLength(1);
+      expect(large[0][0].message).toContain('Wire transfer');
     });
 
-    it('does not create duplicate large-debit notification when dedupeKey already exists', async () => {
+    it('does not re-notify when the large dedupeKey already exists', async () => {
       const txn = makeTxn({ amountCents: 60_000 });
       const db = buildMockDb(txn);
-      db.execute = vi.fn().mockResolvedValue({ rows: [] });
+      mockExecuteSequence(db, { stats: null });
       const notif = buildMockNotifications([`anomaly_large_${txn.id}`]);
-      const svc = makeService(db, notif);
 
-      await svc.detectAnomalies('user-1', ['txn-1']);
+      await makeService(db, notif).detectAnomalies('user-1', ['txn-1']);
 
-      const largeCalls = notif.createAndDispatch.mock.calls.filter(
-        (c: any[]) => c[0].metadata?.rule === 'large_debit',
-      );
-      expect(largeCalls).toHaveLength(0);
+      expect(callsForRule(notif, 'large_debit')).toHaveLength(0);
     });
   });
 
-  describe('multiple rules on same transaction', () => {
-    it('can trigger both amount-anomaly and large-debit for a single transaction', async () => {
-      // $600 at a merchant where average is $100 (6x) with 5 history txns
+  describe('noise reduction (the point of the feature)', () => {
+    it('does NOT flag a large-but-normal recurring charge (e.g. rent/mortgage)', async () => {
+      // $3,000 mortgage where the merchant averages ~$3,000 with tiny variance
+      const txn = makeTxn({ amountCents: 300_000, normalizedMerchantName: 'Langley Federal' });
+      const db = buildMockDb(txn);
+      mockExecuteSequence(db, { stats: { avgCents: 300_000, stddevCents: 500, count: 12 } });
+      const notif = buildMockNotifications();
+
+      await makeService(db, notif).detectAnomalies('user-1', ['txn-1']);
+
+      expect(callsForRule(notif, 'amount_anomaly')).toHaveLength(0);
+      expect(callsForRule(notif, 'large_debit')).toHaveLength(0);
+      expect(notif.createAndDispatch).not.toHaveBeenCalled();
+    });
+
+    it('an unusual large charge fires amount_anomaly ONLY (large_debit is suppressed to avoid double-alert)', async () => {
+      // $600 at a merchant that usually charges ~$100, with plenty of history
       const txn = makeTxn({ amountCents: 60_000, normalizedMerchantName: 'Acme Corp' });
       const db = buildMockDb(txn);
-      db.execute = vi
-        .fn()
-        .mockResolvedValueOnce({ rows: [{ avg_cents: '10000', txn_count: 5 }] }) // amount anomaly: trigger
-        .mockResolvedValueOnce({ rows: [] }); // duplicate: none
+      mockExecuteSequence(db, { stats: { avgCents: 10_000, stddevCents: 1_000, count: 8 } });
       const notif = buildMockNotifications();
-      const svc = makeService(db, notif);
 
-      await svc.detectAnomalies('user-1', ['txn-1']);
+      await makeService(db, notif).detectAnomalies('user-1', ['txn-1']);
 
-      const rules = notif.createAndDispatch.mock.calls.map((c: any[]) => c[0].metadata?.rule);
-      expect(rules).toContain('amount_anomaly');
-      expect(rules).toContain('large_debit');
+      expect(callsForRule(notif, 'amount_anomaly')).toHaveLength(1);
+      expect(callsForRule(notif, 'large_debit')).toHaveLength(0);
     });
   });
 });

--- a/apps/api/src/analytics/anomaly-detector.service.ts
+++ b/apps/api/src/analytics/anomaly-detector.service.ts
@@ -4,15 +4,47 @@ import * as schema from '../db/schema';
 import { eq, and, isNull, sql } from 'drizzle-orm';
 import { NotificationsService } from '../notifications/notifications.service';
 
+/** Absolute floor for the flat large-debit fallback (used when we lack merchant history). */
 const LARGE_DEBIT_THRESHOLD_CENTS = 50_000; // $500.00
+
+/** Trailing window used to build a merchant's spending baseline. */
+const BASELINE_WINDOW_MONTHS = 6;
+
+/** Minimum number of prior transactions before a statistical baseline is trusted. */
+const MIN_HISTORY = 5;
+
+/** How many standard deviations above the mean counts as an outlier. */
+const Z_THRESHOLD = 3;
+
+/**
+ * Minimum absolute amount above the mean before we bother flagging, so low-value
+ * merchants (a $2 coffee that becomes $8) don't generate noise despite a high z-score.
+ */
+const MIN_ABS_DELTA_CENTS = 2_500; // $25.00
+
+interface MerchantStats {
+  avgCents: number;
+  stddevCents: number;
+  count: number;
+}
 
 function formatCents(cents: number): string {
   return `$${(cents / 100).toFixed(2)}`;
 }
 
-function currentMonthStr(): string {
-  const now = new Date();
-  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+/**
+ * Effective standard deviation used for the z-score. Floored to 10% of the mean
+ * (and at least 1 cent) so perfectly-recurring charges (σ ≈ 0) still require a
+ * meaningful jump — ~30% above normal at Z_THRESHOLD=3 — rather than flagging on
+ * a single cent of drift.
+ */
+function effectiveStddev(stats: MerchantStats): number {
+  return Math.max(stats.stddevCents, stats.avgCents * 0.1, 1);
+}
+
+/** z-score of an amount against a merchant baseline. */
+function zScore(amountCents: number, stats: MerchantStats): number {
+  return (amountCents - stats.avgCents) / effectiveStddev(stats);
 }
 
 @Injectable()
@@ -60,30 +92,29 @@ export class AnomalyDetectorService {
 
     const merchantKey = txn.normalizedMerchantName ?? txn.merchantName;
 
+    // Build the merchant baseline once and share it across the amount/large checks.
+    const stats = merchantKey ? await this.merchantStats(userId, txn, merchantKey) : null;
+
     // Run checks sequentially to avoid dedupe race conditions on shared keys
-    await this.checkAmountAnomaly(userId, txn, merchantKey);
+    await this.checkAmountAnomaly(userId, txn, merchantKey, stats);
     await this.checkDuplicate(userId, txn, merchantKey);
-    await this.checkLargeDebit(userId, txn, merchantKey);
+    await this.checkLargeDebit(userId, txn, merchantKey, stats);
   }
 
   /**
-   * Rule 1: Flag if this transaction's amount is > 3x the user's historical average
-   * at the same merchant (requires 3+ prior transactions).
+   * Trailing-window mean/stddev/count of prior debits at the same merchant.
+   * Excludes the transaction under test, credits, and split parents/children.
    */
-  private async checkAmountAnomaly(
+  private async merchantStats(
     userId: string,
     txn: any,
-    merchantKey: string | null,
-  ): Promise<void> {
-    if (!merchantKey) return;
-
-    const dedupeKey = `anomaly_amount_${txn.id}`;
-    if (await this.notificationsService.findByMetadata(userId, dedupeKey)) return;
-
+    merchantKey: string,
+  ): Promise<MerchantStats | null> {
     const rows = await this.db.execute(sql`
       SELECT
-        AVG(amount_cents)::float AS avg_cents,
-        COUNT(*)::int            AS txn_count
+        AVG(amount_cents)::float                       AS avg_cents,
+        COALESCE(STDDEV_POP(amount_cents), 0)::float   AS stddev_cents,
+        COUNT(*)::int                                  AS txn_count
       FROM ${schema.transactions}
       WHERE user_id              = ${userId}
         AND COALESCE(normalized_merchant_name, merchant_name) = ${merchantKey}
@@ -92,21 +123,57 @@ export class AnomalyDetectorService {
         AND parent_transaction_id IS NULL
         AND deleted_at           IS NULL
         AND id                  != ${txn.id}
+        AND date >= NOW() - (${BASELINE_WINDOW_MONTHS} || ' months')::interval
     `);
 
     const row = (rows.rows ?? rows)[0];
-    if (!row || row.txn_count < 3) return;
+    if (!row) return null;
 
-    const avgCents = parseFloat(row.avg_cents);
-    if (txn.amountCents <= avgCents * 3) return;
+    const count = Number(row.txn_count) || 0;
+    if (count === 0) return null;
+
+    return {
+      avgCents: parseFloat(row.avg_cents),
+      stddevCents: parseFloat(row.stddev_cents) || 0,
+      count,
+    };
+  }
+
+  /**
+   * Rule 1: Flag when this debit is a statistical outlier for the merchant —
+   * at least Z_THRESHOLD standard deviations above the trailing mean, with a
+   * minimum absolute delta so low-value merchants don't generate noise.
+   * Requires MIN_HISTORY prior transactions.
+   */
+  private async checkAmountAnomaly(
+    userId: string,
+    txn: any,
+    merchantKey: string | null,
+    stats: MerchantStats | null,
+  ): Promise<void> {
+    if (!merchantKey || !stats) return;
+    if (stats.count < MIN_HISTORY) return;
+
+    const delta = txn.amountCents - stats.avgCents;
+    if (delta <= MIN_ABS_DELTA_CENTS) return;
+    if (zScore(txn.amountCents, stats) < Z_THRESHOLD) return;
+
+    const dedupeKey = `anomaly_amount_${txn.id}`;
+    if (await this.notificationsService.findByMetadata(userId, dedupeKey)) return;
 
     await this.notificationsService.createAndDispatch({
       userId,
       type: 'spending_anomaly',
       title: 'Unusual spend detected',
-      message: `Unusual spend at ${merchantKey}: ${formatCents(txn.amountCents)} — your average is ${formatCents(Math.round(avgCents))}.`,
+      message: `Unusual spend at ${merchantKey}: ${formatCents(txn.amountCents)} — well above your usual ${formatCents(Math.round(stats.avgCents))}.`,
       dedupeKey,
-      metadata: { dedupeKey, transactionId: txn.id, rule: 'amount_anomaly' },
+      metadata: {
+        dedupeKey,
+        transactionId: txn.id,
+        rule: 'amount_anomaly',
+        avgCents: Math.round(stats.avgCents),
+        zScore: Number(zScore(txn.amountCents, stats).toFixed(2)),
+      },
     });
   }
 
@@ -154,14 +221,22 @@ export class AnomalyDetectorService {
   }
 
   /**
-   * Rule 3: Flag large debits above the threshold (default $500).
+   * Rule 3: Large-debit fallback. Only fires when we lack the history to judge
+   * whether a big charge is normal for the merchant — when we DO have history,
+   * the z-score rule above is the sole judge, so normal recurring large charges
+   * (rent, mortgage, utilities) no longer generate "large purchase" noise.
    */
   private async checkLargeDebit(
     userId: string,
     txn: any,
     merchantKey: string | null,
+    stats: MerchantStats | null,
   ): Promise<void> {
     if (txn.amountCents < LARGE_DEBIT_THRESHOLD_CENTS) return;
+
+    // Enough history to judge normality → defer to the z-score rule; don't
+    // double-alert on the flat threshold.
+    if (stats && stats.count >= MIN_HISTORY) return;
 
     const dedupeKey = `anomaly_large_${txn.id}`;
     if (await this.notificationsService.findByMetadata(userId, dedupeKey)) return;


### PR DESCRIPTION
Closes #32

## Problem
`anomaly-detector.service.ts` flagged large purchases with a flat $500 threshold, so it fired on large-but-normal recurring charges (mortgage/loan payments, utilities — see #28 screenshot), and the amount-anomaly rule used a variance-blind `3× mean` test.

## Change
Rework detection around a **per-merchant baseline** — mean + population stddev + count over a trailing 6-month window — fetched **once per transaction** and shared across rules:

- **Amount anomaly → z-score.** Fires when the amount is ≥ 3σ above the merchant mean, with a **stddev floor** (10% of mean, so perfectly-recurring charges still need a real jump) and a **$25 absolute-delta floor** (so low-value merchants don't generate noise). Requires 5+ priors. Message + metadata include the baseline and z-score.
- **Large-debit → fallback.** Only fires when there's *insufficient history* to judge normality. When history exists, the z-score rule is the sole judge — so normal recurring large charges no longer alert, and an unusual large charge produces a **single** "Unusual spend" alert instead of two.

Dedupe-by-metadata, non-throwing design, and `rule` metadata tags are preserved.

## Behaviour change
| Scenario | Before | After |
|---|---|---|
| $3,000 mortgage, avg $3,000 (12 priors) | "Large purchase" ❌ noise | no alert ✅ |
| $600 at a $100 merchant (8 priors) | amount_anomaly **+** large_debit (2 alerts) | one "Unusual spend" ✅ |
| $600 at a brand-new merchant (no history) | large_debit | large_debit (unchanged fallback) ✅ |
| $8 coffee vs $2 usual | 3× rule could flag | below $25 floor → no alert ✅ |

## Test plan
- Spec rewritten around the new logic incl. dedicated noise-reduction cases
- `pnpm --filter @moneypulse/api exec vitest run` — **410 pass**
- `pnpm --filter @moneypulse/api build` (nest build) — passes

Follow-up to the #28/#30 notification thread.