### PR TITLE
feat(notifications): notification center v2 — triage UX (#34)

### DIFF
--- a/apps/api/src/notifications/notifications.controller.spec.ts
+++ b/apps/api/src/notifications/notifications.controller.spec.ts
@@ -14,9 +14,32 @@ describe('NotificationsController', () => {
       unreadCount: vi.fn().mockResolvedValue(0),
       markRead: vi.fn().mockResolvedValue(undefined),
       markAllRead: vi.fn().mockResolvedValue(undefined),
+      remove: vi.fn().mockResolvedValue(undefined),
     };
 
     controller = new NotificationsController(mockNotificationsService);
+  });
+
+  describe('DELETE /notifications/:id', () => {
+    it('dismisses the notification scoped to the authenticated user', async () => {
+      const result = await controller.remove(TEST_USER, 'notif-xyz');
+
+      expect(mockNotificationsService.remove).toHaveBeenCalledTimes(1);
+      expect(mockNotificationsService.remove).toHaveBeenCalledWith(
+        'notif-xyz',
+        TEST_USER.sub,
+      );
+      expect(result).toEqual({ data: { dismissed: true } });
+    });
+
+    it('derives the userId from @CurrentUser(), never a passed-in value', async () => {
+      await controller.remove({ sub: 'user-other' } as any, 'notif-1');
+
+      expect(mockNotificationsService.remove).toHaveBeenCalledWith(
+        'notif-1',
+        'user-other',
+      );
+    });
   });
 
   describe('POST /notifications/test', () => {

--- a/apps/api/src/notifications/notifications.controller.ts
+++ b/apps/api/src/notifications/notifications.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   Patch,
+  Delete,
   Param,
   UseGuards,
   Post,
@@ -41,6 +42,16 @@ export class NotificationsController {
   ) {
     await this.notificationsService.markRead(id, user.sub);
     return { data: { read: true } };
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Dismiss (delete) a notification' })
+  async remove(
+    @CurrentUser() user: AuthTokenPayload,
+    @Param('id') id: string,
+  ) {
+    await this.notificationsService.remove(id, user.sub);
+    return { data: { dismissed: true } };
   }
 
   @Post('mark-all-read')

--- a/apps/api/src/notifications/notifications.service.spec.ts
+++ b/apps/api/src/notifications/notifications.service.spec.ts
@@ -29,9 +29,13 @@ describe('NotificationsService', () => {
     const setMock = vi.fn().mockReturnValue(updateWhereChain);
     const updateMock = vi.fn().mockReturnValue({ set: setMock });
 
+    const deleteWhereMock = vi.fn().mockResolvedValue([]);
+    const deleteMock = vi.fn().mockReturnValue({ where: deleteWhereMock });
+
     mockDb = {
       insert: insertMock,
       update: updateMock,
+      delete: deleteMock,
     };
 
     mockWebhookService = {
@@ -52,6 +56,15 @@ describe('NotificationsService', () => {
       mockOutbox,
       mockAliasMapper,
     );
+  });
+
+  describe('remove', () => {
+    it('deletes the notification scoped to the owning user', async () => {
+      await service.remove('notif-1', 'user-1');
+
+      expect(mockDb.delete).toHaveBeenCalledTimes(1);
+      expect(mockDb.delete().where).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('createAndDispatch', () => {

--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -57,6 +57,18 @@ export class NotificationsService {
       );
   }
 
+  /** Permanently dismiss (delete) a single notification owned by the user. */
+  async remove(id: string, userId: string) {
+    await this.db
+      .delete(schema.notifications)
+      .where(
+        and(
+          eq(schema.notifications.id, id),
+          eq(schema.notifications.userId, userId),
+        ),
+      );
+  }
+
   async markAllRead(userId: string) {
     await this.db
       .update(schema.notifications)

--- a/apps/web/src/components/NotificationBell.tsx
+++ b/apps/web/src/components/NotificationBell.tsx
@@ -1,23 +1,105 @@
 'use client';
 
 import { useState, useRef, useEffect } from 'react';
-import { Bell } from 'lucide-react';
+import { Bell, X } from 'lucide-react';
+import { formatDistanceToNow } from 'date-fns';
 import {
   useNotifications,
   useUnreadCount,
   useMarkNotificationRead,
   useMarkAllRead,
+  useDismissNotification,
 } from '@/lib/hooks/useNotifications';
+
+/** Types whose alerts warrant a warning/destructive accent. */
+const DESTRUCTIVE_TYPES = new Set([
+  'large_debit',
+  'spending_anomaly',
+  'over_budget',
+  'cashflow_low',
+]);
+const SUCCESS_TYPES = new Set(['savings_milestone', 'savings']);
+
+/** CSS var for a notification's severity accent, derived from its type. */
+function accentVar(type: string): string {
+  if (DESTRUCTIVE_TYPES.has(type)) return 'var(--destructive)';
+  if (SUCCESS_TYPES.has(type)) return 'var(--success)';
+  return 'var(--primary)';
+}
+
+/** "2 hours ago" — tolerant of missing/invalid timestamps. */
+function relativeTime(createdAt?: string): string {
+  if (!createdAt) return '';
+  const d = new Date(createdAt);
+  if (Number.isNaN(d.getTime())) return '';
+  return formatDistanceToNow(d, { addSuffix: true });
+}
+
+function NotificationRow({
+  n,
+  onRead,
+  onDismiss,
+}: {
+  n: any;
+  onRead: (id: string) => void;
+  onDismiss: (id: string) => void;
+}) {
+  return (
+    <li
+      className={`group relative flex items-start gap-2 p-3 border-l-2 hover:bg-[var(--muted)]/50 ${
+        n.isRead ? '' : 'bg-[var(--primary)]/5'
+      }`}
+      style={{ borderLeftColor: n.isRead ? 'transparent' : accentVar(n.type) }}
+    >
+      <button
+        type="button"
+        onClick={() => !n.isRead && onRead(n.id)}
+        className="flex-1 text-left cursor-pointer min-w-0"
+      >
+        <div className="flex items-center gap-2">
+          {!n.isRead && (
+            <span
+              className="w-1.5 h-1.5 rounded-full shrink-0"
+              style={{ backgroundColor: accentVar(n.type) }}
+              aria-hidden
+            />
+          )}
+          <p className="text-sm font-medium truncate">{n.title}</p>
+        </div>
+        <p className="text-xs text-[var(--muted-foreground)] mt-0.5 line-clamp-2">
+          {n.message}
+        </p>
+        {relativeTime(n.createdAt) && (
+          <p className="text-[10px] text-[var(--muted-foreground)] mt-1">
+            {relativeTime(n.createdAt)}
+          </p>
+        )}
+      </button>
+      <button
+        type="button"
+        onClick={() => onDismiss(n.id)}
+        aria-label="Dismiss notification"
+        className="shrink-0 p-1 rounded text-[var(--muted-foreground)] opacity-0 group-hover:opacity-100 hover:bg-[var(--muted)] transition-opacity"
+      >
+        <X className="w-3.5 h-3.5" />
+      </button>
+    </li>
+  );
+}
 
 export function NotificationBell() {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
-  const { data: notificationsResponse } = useNotifications();
+  const { data: notificationsResponse, isLoading, isError } = useNotifications();
   const { count: unread } = useUnreadCount();
   const markRead = useMarkNotificationRead();
   const markAllRead = useMarkAllRead();
+  const dismiss = useDismissNotification();
 
   const notifications = notificationsResponse?.data ?? [];
+  const shown = notifications.slice(0, 20);
+  const unreadItems = shown.filter((n: any) => !n.isRead);
+  const readItems = shown.filter((n: any) => n.isRead);
 
   // Close on outside click
   useEffect(() => {
@@ -47,7 +129,7 @@ export function NotificationBell() {
 
       {open && (
         <div className="absolute right-0 mt-2 w-80 bg-[var(--card)] text-[var(--card-foreground)] border border-[var(--border)] rounded-lg shadow-lg z-50 max-h-96 overflow-y-auto">
-          <div className="p-3 border-b border-[var(--border)] flex items-center justify-between">
+          <div className="p-3 border-b border-[var(--border)] flex items-center justify-between sticky top-0 bg-[var(--card)]">
             <h3 className="font-medium text-sm">Notifications</h3>
             {!!unread && unread > 0 && (
               <button
@@ -58,28 +140,57 @@ export function NotificationBell() {
               </button>
             )}
           </div>
-          <div className="divide-y divide-[var(--border)]">
-            {notifications.slice(0, 20).map((n: any) => (
-              <button
-                type="button"
-                key={n.id}
-                className={`w-full text-left p-3 cursor-pointer hover:bg-[var(--muted)]/50 ${!n.isRead ? 'bg-[var(--primary)]/5' : ''}`}
-                onClick={() => {
-                  if (!n.isRead) markRead.mutate(n.id);
-                }}
-              >
-                <p className="text-sm font-medium">{n.title}</p>
-                <p className="text-xs text-[var(--muted-foreground)] mt-0.5">
-                  {n.message}
-                </p>
-              </button>
-            ))}
-            {notifications.length === 0 && (
-              <p className="p-4 text-sm text-[var(--muted-foreground)]">
-                No notifications
-              </p>
-            )}
-          </div>
+
+          {isLoading ? (
+            <div className="p-3 space-y-3">
+              {[0, 1, 2].map((i) => (
+                <div key={i} className="space-y-1.5 animate-pulse">
+                  <div className="h-3 w-1/2 rounded bg-[var(--muted)]" />
+                  <div className="h-2.5 w-3/4 rounded bg-[var(--muted)]" />
+                </div>
+              ))}
+            </div>
+          ) : isError ? (
+            <p className="p-4 text-sm text-[var(--destructive)]">
+              Couldn&apos;t load notifications. Try again shortly.
+            </p>
+          ) : shown.length === 0 ? (
+            <p className="p-4 text-sm text-[var(--muted-foreground)]">
+              You&apos;re all caught up — no notifications.
+            </p>
+          ) : (
+            <>
+              {unreadItems.length > 0 && (
+                <ul className="divide-y divide-[var(--border)]">
+                  {unreadItems.map((n: any) => (
+                    <NotificationRow
+                      key={n.id}
+                      n={n}
+                      onRead={(id) => markRead.mutate(id)}
+                      onDismiss={(id) => dismiss.mutate(id)}
+                    />
+                  ))}
+                </ul>
+              )}
+              {readItems.length > 0 && (
+                <>
+                  <p className="px-3 pt-3 pb-1 text-[10px] font-semibold uppercase tracking-wide text-[var(--muted-foreground)]">
+                    Earlier
+                  </p>
+                  <ul className="divide-y divide-[var(--border)]">
+                    {readItems.map((n: any) => (
+                      <NotificationRow
+                        key={n.id}
+                        n={n}
+                        onRead={(id) => markRead.mutate(id)}
+                        onDismiss={(id) => dismiss.mutate(id)}
+                      />
+                    ))}
+                  </ul>
+                </>
+              )}
+            </>
+          )}
         </div>
       )}
     </div>

--- a/apps/web/src/lib/hooks/useNotifications.ts
+++ b/apps/web/src/lib/hooks/useNotifications.ts
@@ -32,6 +32,17 @@ export function useMarkNotificationRead() {
   });
 }
 
+/** Dismiss (permanently delete) a single notification. */
+export function useDismissNotification() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.delete(`/notifications/${id}`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['notifications'] });
+    },
+  });
+}
+
 /** Mark all notifications as read. */
 export function useMarkAllRead() {
   const queryClient = useQueryClient();


### PR DESCRIPTION
Closes #34

Builds on #28/#30 (readable dropdown) to make the bell an actual notification center you can triage.

## Backend
- `DELETE /notifications/:id` → `NotificationsService.remove(id, userId)` — user-scoped hard delete mirroring `markRead`. No migration.

## Frontend (`NotificationBell.tsx` + `useNotifications.ts`)
- **Per-notification dismiss** (✕) via new `useDismissNotification` hook
- **Unread-first grouping** with an "Earlier" section for read items
- **Relative timestamps** from `createdAt` (`date-fns` `formatDistanceToNow`)
- **Severity accent** (left bar + dot) from `type`: destructive for `large_debit`/`spending_anomaly`/`over_budget`/`cashflow_low`, success for savings milestones, primary otherwise
- **Loading skeleton / error / friendly empty** states
- Nested-button invalid HTML avoided: rows are `<li>` with separate content + dismiss buttons

## Test plan
- `pnpm --filter @moneypulse/api exec vitest run src/notifications` — 28 pass (incl. new `remove` service + `DELETE` controller tests)
- `pnpm --filter @moneypulse/web exec vitest run` — 64 pass
- `nest build` + `next build` — pass
- Dropdown visual confirmed via a rendered replica against the compiled CSS (accents, grouping, timestamps, dismiss)

Follow-up to the #28/#30 notification thread.