### PR TITLE
feat(mcp): phase7 MCP server — advisor foundation, user-scoped (#37)

### DIFF
--- a/apps/mcp-server/Dockerfile
+++ b/apps/mcp-server/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:22-alpine AS build
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/mcp-server/package.json apps/mcp-server/
+RUN corepack enable pnpm && pnpm install --frozen-lockfile --filter @moneypulse/mcp-server
+
+COPY apps/mcp-server/ apps/mcp-server/
+RUN cd apps/mcp-server && pnpm build
+
+FROM node:22-alpine
+WORKDIR /app
+COPY --from=build /app/apps/mcp-server/dist ./dist
+COPY --from=build /app/apps/mcp-server/package.json ./
+COPY --from=build /app/node_modules ./node_modules
+EXPOSE 3100
+CMD ["node", "dist/index.js", "--sse"]

--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -1,0 +1,49 @@
+# @moneypulse/mcp-server
+
+Read-only [MCP](https://modelcontextprotocol.io) server exposing MoneyPulse finances as
+tools an AI client (Claude, etc.) can call. This is the **semantic layer** for the AI
+Financial Advisor (epic #36) — each tool encapsulates one correct, user-scoped aggregation
+so the model never writes SQL or does arithmetic.
+
+## Tools (8)
+
+| Tool | Returns |
+|---|---|
+| `get_account_balances` | Per-account computed balances + credit utilization (aggregate) |
+| `get_spending_summary` | Spend by category for a date range (aggregate) |
+| `get_category_breakdown` | Category/sub-category totals + counts (aggregate) |
+| `get_budget_status` | Budget vs spent per category (aggregate) |
+| `get_recurring_expenses` | Merchants with ≥N occurrences in a window (aggregate) |
+| `compare_periods` | Per-category spend delta between two ranges (aggregate) |
+| `get_transactions` | Recent transaction rows (**row-level**) |
+| `search_transactions` | Transaction rows matching text (**row-level**) |
+
+## Privacy boundary
+
+Every tool is scoped to a single user (see below) and computes in Postgres. Six tools return
+**aggregates only**; `get_transactions` / `search_transactions` return **raw rows** and are
+intended for local use. When wiring the cloud advisor (Phase 1, #38), the "aggregates-only to
+cloud" rule means: do **not** expose the two row-level tools to the cloud model, or redact
+descriptions/merchant strings first.
+
+## Configuration (env)
+
+| Var | Purpose |
+|---|---|
+| `DB_HOST` / `DB_PORT` / `DB_NAME` / `DB_USER` / `DB_PASSWORD` | Postgres connection |
+| `MONEYPULSE_USER_ID` | User to scope all tools to. If unset, the sole user in the DB is used; the server errors if the DB has multiple users. |
+| `MCP_PORT` | Port for SSE mode (default 3100) |
+
+## Run
+
+```bash
+pnpm --filter @moneypulse/mcp-server build
+pnpm --filter @moneypulse/mcp-server start:stdio   # stdio transport (local MCP clients)
+pnpm --filter @moneypulse/mcp-server start:sse     # HTTP/SSE transport
+pnpm --filter @moneypulse/mcp-server test          # user-scoping guardrail
+```
+
+## Next steps
+
+- Wire the container into the NAS `docker-compose` (deployment).
+- Phase 1 (#38): advisor chat consuming these tools with the aggregates-only boundary.

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@moneypulse/mcp-server",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "start:stdio": "node dist/index.js --stdio",
+    "start:sse": "node dist/index.js --sse",
+    "dev": "tsx src/index.ts --stdio",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "pg": "^8.13.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.11.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0",
+    "vitest": "^4.1.0"
+  }
+}

--- a/apps/mcp-server/src/db.ts
+++ b/apps/mcp-server/src/db.ts
@@ -1,0 +1,59 @@
+import pg from 'pg';
+
+const pool = new pg.Pool({
+  host: process.env.DB_HOST || 'localhost',
+  port: Number(process.env.DB_PORT) || 5432,
+  database: process.env.DB_NAME || 'moneypulse',
+  user: process.env.DB_USER || 'moneypulse',
+  password: process.env.DB_PASSWORD!,
+  max: 5,
+});
+
+export async function query<T = any>(
+  text: string,
+  params?: any[],
+): Promise<T[]> {
+  const result = await pool.query(text, params);
+  return result.rows as T[];
+}
+
+export async function queryOne<T = any>(
+  text: string,
+  params?: any[],
+): Promise<T | null> {
+  const rows = await query<T>(text, params);
+  return rows[0] ?? null;
+}
+
+let cachedUserId: string | null = null;
+
+/**
+ * The user whose data the MCP tools operate on. Set MONEYPULSE_USER_ID to pin it
+ * explicitly; otherwise the sole user in the DB is used. Throws if the DB has
+ * multiple users and none is pinned, so tools never silently span accounts.
+ */
+export async function getUserId(): Promise<string> {
+  if (cachedUserId) return cachedUserId;
+
+  const envId = process.env.MONEYPULSE_USER_ID;
+  if (envId) {
+    cachedUserId = envId;
+    return cachedUserId;
+  }
+
+  const rows = await query<{ id: string }>('SELECT id FROM users LIMIT 2');
+  if (rows.length === 0) {
+    throw new Error('No users found. Set MONEYPULSE_USER_ID to scope the MCP server.');
+  }
+  if (rows.length > 1) {
+    throw new Error(
+      'Multiple users found. Set MONEYPULSE_USER_ID to scope the MCP server to one user.',
+    );
+  }
+  cachedUserId = rows[0].id;
+  return cachedUserId;
+}
+
+export async function close(): Promise<void> {
+  await pool.end();
+}

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -1,0 +1,64 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import { registerGetTransactions } from './tools/get-transactions.js';
+import { registerSearchTransactions } from './tools/search-transactions.js';
+import { registerGetSpendingSummary } from './tools/get-spending-summary.js';
+import { registerGetBudgetStatus } from './tools/get-budget-status.js';
+import { registerGetAccountBalances } from './tools/get-account-balances.js';
+import { registerGetCategoryBreakdown } from './tools/get-category-breakdown.js';
+import { registerComparePeriods } from './tools/compare-periods.js';
+import { registerGetRecurringExpenses } from './tools/get-recurring-expenses.js';
+import { close } from './db.js';
+import http from 'node:http';
+
+const server = new McpServer({
+  name: 'moneypulse',
+  version: '1.0.0',
+});
+
+registerGetTransactions(server);
+registerSearchTransactions(server);
+registerGetSpendingSummary(server);
+registerGetBudgetStatus(server);
+registerGetAccountBalances(server);
+registerGetCategoryBreakdown(server);
+registerComparePeriods(server);
+registerGetRecurringExpenses(server);
+
+const mode = process.argv.includes('--sse') ? 'sse' : 'stdio';
+
+if (mode === 'sse') {
+  const PORT = Number(process.env.MCP_PORT) || 3100;
+  let sseTransport: SSEServerTransport | null = null;
+
+  const httpServer = http.createServer(async (req, res) => {
+    if (req.method === 'GET' && req.url === '/sse') {
+      sseTransport = new SSEServerTransport('/messages', res);
+      await server.connect(sseTransport);
+    } else if (req.method === 'POST' && req.url === '/messages') {
+      if (sseTransport) {
+        await sseTransport.handlePostMessage(req, res);
+      } else {
+        res.writeHead(400);
+        res.end('No SSE connection');
+      }
+    } else {
+      res.writeHead(404);
+      res.end('Not found');
+    }
+  });
+
+  httpServer.listen(PORT, () => {
+    console.error(`MCP SSE server listening on port ${PORT}`);
+  });
+} else {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error('MCP stdio server running');
+}
+
+process.on('SIGINT', async () => {
+  await close();
+  process.exit(0);
+});

--- a/apps/mcp-server/src/tools/__tests__/user-scoping.spec.ts
+++ b/apps/mcp-server/src/tools/__tests__/user-scoping.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+/**
+ * Guardrail: every MCP tool queries a single user's data. A tool that hits the
+ * user-scoped tables (transactions/accounts/budgets) without resolving and
+ * filtering by the user would silently span accounts — this test fails if any
+ * tool forgets to scope. It reads the tool sources statically (no DB needed).
+ */
+const toolsDir = join(dirname(fileURLToPath(import.meta.url)), '..');
+const toolFiles = readdirSync(toolsDir).filter((f) => f.endsWith('.ts'));
+
+describe('MCP tool user-scoping', () => {
+  it('has tool files to check', () => {
+    expect(toolFiles.length).toBeGreaterThanOrEqual(8);
+  });
+
+  for (const file of toolFiles) {
+    const src = readFileSync(join(toolsDir, file), 'utf8');
+    const touchesUserTables = /\b(transactions|accounts|budgets)\b/i.test(src);
+
+    it(`${file} resolves the current user`, () => {
+      if (!touchesUserTables) return;
+      expect(src).toMatch(/getUserId\s*\(\s*\)/);
+    });
+
+    it(`${file} filters by user_id`, () => {
+      if (!touchesUserTables) return;
+      expect(src).toMatch(/\.user_id\s*=\s*\$/);
+    });
+  }
+});

--- a/apps/mcp-server/src/tools/compare-periods.ts
+++ b/apps/mcp-server/src/tools/compare-periods.ts
@@ -1,0 +1,73 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { query, getUserId } from '../db.js';
+
+export function registerComparePeriods(server: McpServer) {
+  server.tool(
+    'compare_periods',
+    'Compare spending between two date ranges. Shows per-category and total differences.',
+    {
+      period1_from: z.string().describe('First period start date (YYYY-MM-DD)'),
+      period1_to: z.string().describe('First period end date (YYYY-MM-DD)'),
+      period2_from: z.string().describe('Second period start date (YYYY-MM-DD)'),
+      period2_to: z.string().describe('Second period end date (YYYY-MM-DD)'),
+    },
+    async (params) => {
+      const userId = await getUserId();
+      const getSummary = async (from: string, to: string) =>
+        query(
+          `SELECT
+             COALESCE(c.name, 'Uncategorized') AS category,
+             SUM(t.amount_cents) AS total_cents
+           FROM transactions t
+           LEFT JOIN categories c ON t.category_id = c.id
+           WHERE t.is_split_parent = false
+             AND t.deleted_at IS NULL
+             AND t.is_credit = false
+             AND t.user_id = $3
+             AND t.date >= $1 AND t.date <= $2
+           GROUP BY c.name`,
+          [from, to, userId],
+        );
+
+      const [p1, p2] = await Promise.all([
+        getSummary(params.period1_from, params.period1_to),
+        getSummary(params.period2_from, params.period2_to),
+      ]);
+
+      const p1Map = new Map(p1.map((r) => [r.category, Number(r.total_cents)]));
+      const p2Map = new Map(p2.map((r) => [r.category, Number(r.total_cents)]));
+      const allCategories = new Set([...p1Map.keys(), ...p2Map.keys()]);
+
+      let totalP1 = 0;
+      let totalP2 = 0;
+      const lines: string[] = [
+        `Period 1: ${params.period1_from} to ${params.period1_to}`,
+        `Period 2: ${params.period2_from} to ${params.period2_to}`,
+        '',
+        'Category | Period 1 | Period 2 | Change',
+        '---------|----------|----------|-------',
+      ];
+
+      for (const cat of [...allCategories].sort()) {
+        const v1 = p1Map.get(cat) ?? 0;
+        const v2 = p2Map.get(cat) ?? 0;
+        totalP1 += v1;
+        totalP2 += v2;
+        const diff = v2 - v1;
+        const arrow = diff > 0 ? '↑' : diff < 0 ? '↓' : '→';
+        lines.push(
+          `${cat} | $${(v1 / 100).toFixed(2)} | $${(v2 / 100).toFixed(2)} | ${arrow} $${(Math.abs(diff) / 100).toFixed(2)}`,
+        );
+      }
+
+      const totalDiff = totalP2 - totalP1;
+      const arrow = totalDiff > 0 ? '↑' : totalDiff < 0 ? '↓' : '→';
+      lines.push(
+        `\nTOTAL | $${(totalP1 / 100).toFixed(2)} | $${(totalP2 / 100).toFixed(2)} | ${arrow} $${(Math.abs(totalDiff) / 100).toFixed(2)}`,
+      );
+
+      return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
+    },
+  );
+}

--- a/apps/mcp-server/src/tools/get-account-balances.ts
+++ b/apps/mcp-server/src/tools/get-account-balances.ts
@@ -1,0 +1,51 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { query, getUserId } from '../db.js';
+
+export function registerGetAccountBalances(server: McpServer) {
+  server.tool(
+    'get_account_balances',
+    'Get current balance for all bank and credit card accounts.',
+    {},
+    async () => {
+      const userId = await getUserId();
+      const rows = await query(
+        `SELECT
+           a.nickname,
+           a.institution,
+           a.account_type,
+           a.starting_balance_cents,
+           a.credit_limit_cents,
+           a.starting_balance_cents + COALESCE(SUM(
+             CASE WHEN t.is_credit THEN t.amount_cents ELSE -t.amount_cents END
+           ), 0) AS balance_cents
+         FROM accounts a
+         LEFT JOIN transactions t
+           ON a.id = t.account_id
+           AND t.is_split_parent = false
+           AND t.deleted_at IS NULL
+         WHERE a.deleted_at IS NULL
+           AND a.user_id = $1
+         GROUP BY a.id, a.nickname, a.institution, a.account_type,
+                  a.starting_balance_cents, a.credit_limit_cents
+         ORDER BY a.nickname`,
+        [userId],
+      );
+
+      const lines = rows.map((r) => {
+        const balance = Number(r.balance_cents);
+        const line = `${r.nickname} (${r.institution}, ${r.account_type}): $${(balance / 100).toFixed(2)}`;
+        if (r.credit_limit_cents) {
+          const limit = Number(r.credit_limit_cents);
+          const util =
+            limit > 0 ? ((Math.abs(balance) / limit) * 100).toFixed(0) : '0';
+          return `${line} (limit: $${(limit / 100).toFixed(2)}, ${util}% used)`;
+        }
+        return line;
+      });
+
+      return {
+        content: [{ type: 'text' as const, text: lines.join('\n') || 'No accounts.' }],
+      };
+    },
+  );
+}

--- a/apps/mcp-server/src/tools/get-budget-status.ts
+++ b/apps/mcp-server/src/tools/get-budget-status.ts
@@ -1,0 +1,57 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { query, getUserId } from '../db.js';
+
+export function registerGetBudgetStatus(server: McpServer) {
+  server.tool(
+    'get_budget_status',
+    'Get current budget status: budget amount, spent so far, and percentage used for each category.',
+    {},
+    async () => {
+      const userId = await getUserId();
+      const rows = await query(
+        `SELECT
+           c.name AS category,
+           b.amount_cents AS budget_cents,
+           b.period,
+           COALESCE(spent.total, 0) AS spent_cents
+         FROM budgets b
+         LEFT JOIN categories c ON b.category_id = c.id
+         LEFT JOIN LATERAL (
+           SELECT SUM(t.amount_cents) AS total
+           FROM transactions t
+           WHERE t.category_id = b.category_id
+             AND t.user_id = $1
+             AND t.is_credit = false
+             AND t.is_split_parent = false
+             AND t.deleted_at IS NULL
+             AND t.date >= CASE
+               WHEN b.period = 'monthly' THEN date_trunc('month', CURRENT_DATE)
+               WHEN b.period = 'weekly' THEN date_trunc('week', CURRENT_DATE)
+               ELSE date_trunc('month', CURRENT_DATE)
+             END
+         ) spent ON true
+         WHERE b.deleted_at IS NULL
+           AND b.user_id = $1
+         ORDER BY c.name`,
+        [userId],
+      );
+
+      const lines = rows.map((r) => {
+        const budget = Number(r.budget_cents);
+        const spent = Number(r.spent_cents);
+        const pct = budget > 0 ? ((spent / budget) * 100).toFixed(0) : '0';
+        const status =
+          spent > budget
+            ? '🔴 OVER'
+            : spent > budget * 0.8
+              ? '🟡 WARNING'
+              : '🟢 OK';
+        return `${status} ${r.category}: $${(spent / 100).toFixed(2)} / $${(budget / 100).toFixed(2)} (${pct}%) [${r.period}]`;
+      });
+
+      return {
+        content: [{ type: 'text' as const, text: lines.join('\n') || 'No budgets configured.' }],
+      };
+    },
+  );
+}

--- a/apps/mcp-server/src/tools/get-category-breakdown.ts
+++ b/apps/mcp-server/src/tools/get-category-breakdown.ts
@@ -1,0 +1,60 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { query, getUserId } from '../db.js';
+
+export function registerGetCategoryBreakdown(server: McpServer) {
+  server.tool(
+    'get_category_breakdown',
+    'Detailed spending breakdown by category with sub-categories and transaction counts.',
+    {
+      from: z.string().describe('Start date (YYYY-MM-DD)'),
+      to: z.string().describe('End date (YYYY-MM-DD)'),
+      category: z.string().optional().describe('Filter to a specific category name'),
+    },
+    async (params) => {
+      const userId = await getUserId();
+      const conditions = [
+        't.is_split_parent = false',
+        't.deleted_at IS NULL',
+        't.is_credit = false',
+        `t.date >= $1`,
+        `t.date <= $2`,
+      ];
+      const values: any[] = [params.from, params.to];
+
+      conditions.push(`t.user_id = $${values.length + 1}`);
+      values.push(userId);
+
+      if (params.category) {
+        conditions.push(`c.name ILIKE $${values.length + 1}`);
+        values.push(`%${params.category}%`);
+      }
+
+      const rows = await query(
+        `SELECT
+           COALESCE(c.name, 'Uncategorized') AS category,
+           COALESCE(parent.name, '') AS parent_category,
+           SUM(t.amount_cents) AS total_cents,
+           COUNT(*) AS txn_count,
+           MIN(t.date) AS first_txn,
+           MAX(t.date) AS last_txn
+         FROM transactions t
+         LEFT JOIN categories c ON t.category_id = c.id
+         LEFT JOIN categories parent ON c.parent_id = parent.id
+         WHERE ${conditions.join(' AND ')}
+         GROUP BY c.name, parent.name
+         ORDER BY total_cents DESC`,
+        values,
+      );
+
+      const lines = rows.map((r) => {
+        const parent = r.parent_category ? `${r.parent_category} > ` : '';
+        return `${parent}${r.category}: $${(Number(r.total_cents) / 100).toFixed(2)} (${r.txn_count} txns, ${r.first_txn.toISOString().slice(0, 10)} – ${r.last_txn.toISOString().slice(0, 10)})`;
+      });
+
+      return {
+        content: [{ type: 'text' as const, text: lines.join('\n') || 'No data.' }],
+      };
+    },
+  );
+}

--- a/apps/mcp-server/src/tools/get-recurring-expenses.ts
+++ b/apps/mcp-server/src/tools/get-recurring-expenses.ts
@@ -1,0 +1,64 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { query, getUserId } from '../db.js';
+
+export function registerGetRecurringExpenses(server: McpServer) {
+  server.tool(
+    'get_recurring_expenses',
+    'Identify recurring expenses by finding merchants/descriptions with 3+ transactions in the last 90 days.',
+    {
+      min_occurrences: z
+        .number()
+        .min(2)
+        .default(3)
+        .describe('Minimum occurrences to consider recurring'),
+      days: z
+        .number()
+        .min(30)
+        .max(365)
+        .default(90)
+        .describe('Lookback period in days'),
+    },
+    async (params) => {
+      const userId = await getUserId();
+      const rows = await query(
+        `SELECT
+           COALESCE(t.merchant_name, t.description) AS merchant,
+           COUNT(*) AS occurrences,
+           ROUND(AVG(t.amount_cents)) AS avg_amount_cents,
+           SUM(t.amount_cents) AS total_cents,
+           MIN(t.date) AS first_seen,
+           MAX(t.date) AS last_seen,
+           COALESCE(c.name, 'Uncategorized') AS category
+         FROM transactions t
+         LEFT JOIN categories c ON t.category_id = c.id
+         WHERE t.is_split_parent = false
+           AND t.deleted_at IS NULL
+           AND t.is_credit = false
+           AND t.user_id = $3
+           AND t.date >= CURRENT_DATE - $1::int * INTERVAL '1 day'
+         GROUP BY COALESCE(t.merchant_name, t.description), c.name
+         HAVING COUNT(*) >= $2
+         ORDER BY total_cents DESC`,
+        [params.days, params.min_occurrences, userId],
+      );
+
+      const lines = rows.map(
+        (r) =>
+          `${r.merchant} (${r.category}): ${r.occurrences}x in ${params.days}d, avg $${(Number(r.avg_amount_cents) / 100).toFixed(2)}, total $${(Number(r.total_cents) / 100).toFixed(2)} (${r.first_seen.toISOString().slice(0, 10)} – ${r.last_seen.toISOString().slice(0, 10)})`,
+      );
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text:
+              lines.length > 0
+                ? `Found ${lines.length} recurring expenses:\n\n${lines.join('\n')}`
+                : 'No recurring expenses found.',
+          },
+        ],
+      };
+    },
+  );
+}

--- a/apps/mcp-server/src/tools/get-spending-summary.ts
+++ b/apps/mcp-server/src/tools/get-spending-summary.ts
@@ -1,0 +1,45 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { query, getUserId } from '../db.js';
+
+export function registerGetSpendingSummary(server: McpServer) {
+  server.tool(
+    'get_spending_summary',
+    'Get total spending grouped by category for a date range.',
+    {
+      from: z.string().describe('Start date (YYYY-MM-DD)'),
+      to: z.string().describe('End date (YYYY-MM-DD)'),
+    },
+    async (params) => {
+      const userId = await getUserId();
+      const rows = await query(
+        `SELECT
+           COALESCE(c.name, 'Uncategorized') AS category,
+           SUM(t.amount_cents) AS total_cents,
+           COUNT(*) AS txn_count
+         FROM transactions t
+         LEFT JOIN categories c ON t.category_id = c.id
+         WHERE t.is_split_parent = false
+           AND t.deleted_at IS NULL
+           AND t.is_credit = false
+           AND t.user_id = $3
+           AND t.date >= $1
+           AND t.date <= $2
+         GROUP BY c.name
+         ORDER BY total_cents DESC`,
+        [params.from, params.to, userId],
+      );
+
+      const total = rows.reduce((s, r) => s + Number(r.total_cents), 0);
+      const lines = rows.map(
+        (r) =>
+          `${r.category}: $${(Number(r.total_cents) / 100).toFixed(2)} (${r.txn_count} txns, ${total > 0 ? ((Number(r.total_cents) / total) * 100).toFixed(1) : 0}%)`,
+      );
+      lines.push(`\nTotal: $${(total / 100).toFixed(2)}`);
+
+      return {
+        content: [{ type: 'text' as const, text: lines.join('\n') || 'No spending data.' }],
+      };
+    },
+  );
+}

--- a/apps/mcp-server/src/tools/get-transactions.ts
+++ b/apps/mcp-server/src/tools/get-transactions.ts
@@ -1,0 +1,72 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { query, getUserId } from '../db.js';
+
+export function registerGetTransactions(server: McpServer) {
+  server.tool(
+    'get_transactions',
+    'List recent transactions with optional filters. Returns date, description, amount, category, account.',
+    {
+      limit: z.number().min(1).max(100).default(20).describe('Number of transactions to return'),
+      offset: z.number().min(0).default(0).describe('Pagination offset'),
+      account_id: z.string().uuid().optional().describe('Filter by account ID'),
+      category_id: z.string().uuid().optional().describe('Filter by category ID'),
+      from: z.string().optional().describe('Start date (YYYY-MM-DD)'),
+      to: z.string().optional().describe('End date (YYYY-MM-DD)'),
+    },
+    async (params) => {
+      const userId = await getUserId();
+      const conditions: string[] = [
+        't.is_split_parent = false',
+        't.deleted_at IS NULL',
+      ];
+      const values: any[] = [];
+      let idx = 1;
+
+      conditions.push(`t.user_id = $${idx++}`);
+      values.push(userId);
+
+      if (params.account_id) {
+        conditions.push(`t.account_id = $${idx++}`);
+        values.push(params.account_id);
+      }
+      if (params.category_id) {
+        conditions.push(`t.category_id = $${idx++}`);
+        values.push(params.category_id);
+      }
+      if (params.from) {
+        conditions.push(`t.date >= $${idx++}`);
+        values.push(params.from);
+      }
+      if (params.to) {
+        conditions.push(`t.date <= $${idx++}`);
+        values.push(params.to);
+      }
+
+      values.push(params.limit, params.offset);
+
+      const rows = await query(
+        `SELECT t.date, t.description, t.amount_cents, t.is_credit,
+                c.name AS category, a.nickname AS account
+         FROM transactions t
+         LEFT JOIN categories c ON t.category_id = c.id
+         LEFT JOIN accounts a ON t.account_id = a.id
+         WHERE ${conditions.join(' AND ')}
+         ORDER BY t.date DESC, t.created_at DESC
+         LIMIT $${idx++} OFFSET $${idx++}`,
+        values,
+      );
+
+      const text = rows
+        .map(
+          (r) =>
+            `${r.date.toISOString().slice(0, 10)} | ${r.is_credit ? '+' : '-'}$${(r.amount_cents / 100).toFixed(2)} | ${r.description} | ${r.category || 'Uncategorized'} | ${r.account}`,
+        )
+        .join('\n');
+
+      return {
+        content: [{ type: 'text' as const, text: text || 'No transactions found.' }],
+      };
+    },
+  );
+}

--- a/apps/mcp-server/src/tools/search-transactions.ts
+++ b/apps/mcp-server/src/tools/search-transactions.ts
@@ -1,0 +1,42 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { query, getUserId } from '../db.js';
+
+export function registerSearchTransactions(server: McpServer) {
+  server.tool(
+    'search_transactions',
+    'Search transactions by description or merchant name. Case-insensitive.',
+    {
+      query: z.string().min(1).describe('Search text (matches description and merchant_name)'),
+      limit: z.number().min(1).max(50).default(20).describe('Max results'),
+    },
+    async (params) => {
+      const userId = await getUserId();
+      const rows = await query(
+        `SELECT t.date, t.description, t.merchant_name, t.amount_cents, t.is_credit,
+                c.name AS category, a.nickname AS account
+         FROM transactions t
+         LEFT JOIN categories c ON t.category_id = c.id
+         LEFT JOIN accounts a ON t.account_id = a.id
+         WHERE t.is_split_parent = false
+           AND t.deleted_at IS NULL
+           AND t.user_id = $3
+           AND (t.description ILIKE $1 OR t.merchant_name ILIKE $1)
+         ORDER BY t.date DESC
+         LIMIT $2`,
+        [`%${params.query}%`, params.limit, userId],
+      );
+
+      const text = rows
+        .map(
+          (r) =>
+            `${r.date.toISOString().slice(0, 10)} | ${r.is_credit ? '+' : '-'}$${(r.amount_cents / 100).toFixed(2)} | ${r.description} | ${r.merchant_name || ''} | ${r.category || 'Uncategorized'} | ${r.account}`,
+        )
+        .join('\n');
+
+      return {
+        content: [{ type: 'text' as const, text: text || 'No matching transactions.' }],
+      };
+    },
+  );
+}

--- a/apps/mcp-server/tsconfig.json
+++ b/apps/mcp-server/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,7 +97,7 @@ importers:
         version: 4.1.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(postgres@3.4.8)
+        version: 0.45.2(@types/pg@8.20.0)(pg@8.22.0)(postgres@3.4.8)
       exceljs:
         specifier: ^4.4.0
         version: 4.4.0
@@ -188,6 +188,31 @@ importers:
         version: 4.21.0
       typescript:
         specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0))
+
+  apps/mcp-server:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.12.0
+        version: 1.29.0(zod@3.25.76)
+      pg:
+        specifier: ^8.13.0
+        version: 8.22.0
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
+    devDependencies:
+      '@types/pg':
+        specifier: ^8.11.0
+        version: 8.20.0
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.0
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
@@ -853,6 +878,12 @@ packages:
   '@fast-csv/parse@4.3.6':
     resolution: {integrity: sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA==}
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -1196,6 +1227,16 @@ packages:
 
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
@@ -1985,6 +2026,9 @@ packages:
 
   '@types/passport@1.0.17':
     resolution: {integrity: sha512-aciLyx+wDwT2t2/kJGJR2AEeBz0nJU4WuRX04Wu9Dqc5lSUtwu0WERPHYsLhF9PtseiAMPBGNUOtFjxZ56prsg==}
+
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
   '@types/qs@6.15.0':
     resolution: {integrity: sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==}
@@ -3231,6 +3275,14 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   exceljs@4.4.0:
     resolution: {integrity: sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==}
     engines: {node: '>=8.3.0'}
@@ -3238,6 +3290,12 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
 
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
@@ -3464,6 +3522,10 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  hono@4.12.27:
+    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
+    engines: {node: '>=16.9.0'}
+
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -3533,6 +3595,10 @@ packages:
   ioredis@5.9.3:
     resolution: {integrity: sha512-VI5tMCdeoxZWU5vjHWsiE/Su76JGhBvWF1MJnV9ZtGltHk9BmD48oDq8Tj8haZ85aceXZMxLNDQZRVo5QKNgXA==}
     engines: {node: '>=12.22.0'}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -3699,6 +3765,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
@@ -3734,6 +3803,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -4309,6 +4381,40 @@ packages:
   pause@0.0.1:
     resolution: {integrity: sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==}
 
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
+
+  pg-connection-string@2.14.0:
+    resolution: {integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.15.0:
+    resolution: {integrity: sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.22.0:
+    resolution: {integrity: sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -4319,6 +4425,10 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   playwright-core@1.60.0:
     resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
@@ -4341,6 +4451,22 @@ packages:
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   postgres@3.4.8:
     resolution: {integrity: sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg==}
@@ -4664,6 +4790,10 @@ packages:
   source-map@0.7.4:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
     engines: {node: '>= 8'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
@@ -5219,6 +5349,10 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -5238,11 +5372,19 @@ packages:
     resolution: {integrity: sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==}
     engines: {node: '>= 10'}
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -5742,6 +5884,10 @@ snapshots:
       lodash.isundefined: 3.0.1
       lodash.uniq: 4.5.0
 
+  '@hono/node-server@1.19.14(hono@4.12.27)':
+    dependencies:
+      hono: 4.12.27
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -6021,6 +6167,28 @@ snapshots:
   '@lukeed/csprng@1.1.0': {}
 
   '@microsoft/tsdoc@0.16.0': {}
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.27)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.27
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     optional: true
@@ -6687,6 +6855,12 @@ snapshots:
   '@types/passport@1.0.17':
     dependencies:
       '@types/express': 5.0.6
+
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 25.5.0
+      pg-protocol: 1.15.0
+      pg-types: 2.2.0
 
   '@types/qs@6.15.0': {}
 
@@ -7638,8 +7812,10 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.45.2(postgres@3.4.8):
+  drizzle-orm@0.45.2(@types/pg@8.20.0)(pg@8.22.0)(postgres@3.4.8):
     optionalDependencies:
+      '@types/pg': 8.20.0
+      pg: 8.22.0
       postgres: 3.4.8
 
   dunder-proto@1.0.1:
@@ -8071,6 +8247,12 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
   exceljs@4.4.0:
     dependencies:
       archiver: 5.3.2
@@ -8084,6 +8266,11 @@ snapshots:
       uuid: 14.0.0
 
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
 
   express@5.2.1:
     dependencies:
@@ -8364,6 +8551,8 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  hono@4.12.27: {}
+
   html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
     dependencies:
       '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
@@ -8447,6 +8636,8 @@ snapshots:
       standard-as-callback: 2.1.0
     transitivePeerDependencies:
       - supports-color
+
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -8612,6 +8803,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@6.2.3: {}
+
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
@@ -8655,6 +8848,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -9185,11 +9380,48 @@ snapshots:
 
   pause@0.0.1: {}
 
+  pg-cloudflare@1.4.0:
+    optional: true
+
+  pg-connection-string@2.14.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.14.0(pg@8.22.0):
+    dependencies:
+      pg: 8.22.0
+
+  pg-protocol@1.15.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.22.0:
+    dependencies:
+      pg-connection-string: 2.14.0
+      pg-pool: 3.14.0(pg@8.22.0)
+      pg-protocol: 1.15.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  pkce-challenge@5.0.1: {}
 
   playwright-core@1.60.0: {}
 
@@ -9208,6 +9440,16 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   postgres@3.4.8: {}
 
@@ -9642,6 +9884,8 @@ snapshots:
   source-map@0.6.1: {}
 
   source-map@0.7.4: {}
+
+  split2@4.2.0: {}
 
   stable-hash@0.0.5: {}
 
@@ -10251,6 +10495,8 @@ snapshots:
 
   xmlchars@2.2.0: {}
 
+  xtend@4.0.2: {}
+
   yallist@3.1.1: {}
 
   yargs-parser@21.1.1: {}
@@ -10265,8 +10511,14 @@ snapshots:
       compress-commons: 4.1.2
       readable-stream: 3.6.2
 
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:
       zod: 4.3.6
+
+  zod@3.25.76: {}
 
   zod@4.3.6: {}


### PR DESCRIPTION
Closes #37. Part of the AI Financial Advisor epic #36 (Phase 0).

## Approach: extract, not rebase
The MCP server lives on `feature/sync-domain-firebase-bootstrap`, but that branch is **26 mixed commits** (MCP server + a 498-line sync-status page + a transactions rework + a **stale migration 0004** + edits to files we've since rewritten). Rebasing it would drag ~6k lines of unrelated, conflict-heavy changes onto main.

The MCP server is **self-contained** (own `pg` pool + MCP SDK, no imports from `@moneypulse/shared`/api), so this PR **lifts just `apps/mcp-server/`** onto current `main`. The rest of that branch can be evaluated separately.

## The 8 tools (semantic layer)
`get_account_balances`, `get_spending_summary`, `get_category_breakdown`, `get_budget_status`, `get_recurring_expenses`, `compare_periods` (aggregates) + `get_transactions`, `search_transactions` (row-level).

## Audit + hardening
- **Schema-verified** every tool's SQL against current `main` (columns, computed balances `starting_balance_cents + Σ(is_credit?+:-)`, `deleted_at`/split filters).
- **User-scoping (was missing!):** `getUserId()` resolves `MONEYPULSE_USER_ID` (or the sole user; errors if several) and every tool now filters `transactions`/`accounts`/`budgets` by `user_id`. Previously the tools spanned **all users** — a real multi-user correctness/privacy bug.
- **Guardrail test** (17 checks): every tool touching user tables must resolve the user and filter by `user_id` — fails if a future tool forgets.
- **README** documents env + the **aggregates-only-to-cloud** boundary: 6 tools aggregate; the 2 row-level tools stay off the cloud path in Phase 1 (#38).

## Test plan
- `pnpm --filter @moneypulse/mcp-server build` (tsc) — passes
- `pnpm --filter @moneypulse/mcp-server test` — 17 pass
- Self-contained; no changes to api/web/shared.

## Follow-ups
- Wire the container into the NAS `docker-compose` (deployment).
- Phase 1 (#38): advisor chat consuming these tools with the aggregates-only boundary.