### PR TITLE
fix(forecast): bill deductions land a day early in timezones behind UTC (#47)

### DIFF
--- a/apps/api/src/analytics/__tests__/forecast.service.spec.ts
+++ b/apps/api/src/analytics/__tests__/forecast.service.spec.ts
@@ -84,8 +84,13 @@ describe('ForecastService', () => {
   it('deducts bill on exact projected date in net-worth series', async () => {
     // $5,000 balance, $0 daily net, $200 monthly bill 15 days from now
     const futureDate = new Date();
+    futureDate.setHours(0, 0, 0, 0);
     futureDate.setDate(futureDate.getDate() + 15);
-    const futureDateStr = futureDate.toISOString().slice(0, 10);
+    // Local calendar date (matches the service's local date frame; toISOString
+    // would use UTC and drift by a day in timezones behind UTC).
+    const futureDateStr = `${futureDate.getFullYear()}-${String(
+      futureDate.getMonth() + 1,
+    ).padStart(2, '0')}-${String(futureDate.getDate()).padStart(2, '0')}`;
 
     const svc = await buildService([
       { rows: [checkingAccount('acct-1', 500_000)] },

--- a/apps/api/src/analytics/forecast.service.ts
+++ b/apps/api/src/analytics/forecast.service.ts
@@ -89,6 +89,17 @@ function toDateStr(d: Date): string {
   return `${y}-${m}-${dd}`;
 }
 
+/**
+ * Parse a date-only `YYYY-MM-DD` string as a *local* calendar date.
+ * `new Date('2026-07-19')` parses as UTC midnight, which snaps to the previous
+ * local day in timezones behind UTC — misaligning bill dates with `today` /
+ * `toDateStr`, which are all local. Build the date in the local frame instead.
+ */
+function parseDateOnly(s: string): Date {
+  const [y, m, d] = s.slice(0, 10).split('-').map(Number);
+  return new Date(y, m - 1, d);
+}
+
 /** ISO week key (YYYY-Www) for deduplication of weekly alerts. */
 function isoWeekKey(d: Date): string {
   const tmp = new Date(d);
@@ -188,7 +199,7 @@ export class ForecastService {
       const amount = Number(bill.expected_amount_cents);
       const freq = bill.frequency as BillFrequency;
       // Fast-forward stale nextExpectedDate to first future occurrence
-      let next = new Date(bill.next_expected_date);
+      let next = parseDateOnly(bill.next_expected_date);
       next.setHours(0, 0, 0, 0);
       while (next < today) {
         next = addFrequency(next, freq);


### PR DESCRIPTION
Closes #47

## Problem
`ForecastService` parsed `recurring_bills.next_expected_date` (a date-only `YYYY-MM-DD`) with `new Date(str)`, which is **UTC midnight**. `.setHours(0,0,0,0)` then snapped it to local midnight — but in any timezone behind UTC, UTC-midnight of a date falls on the *previous* local calendar day, so the bill deduction was placed one day early in `netWorthSeries`. `today`, the day loop, and `toDateStr()` all use the local frame, so the two disagreed.

## Fix
- Add `parseDateOnly()` that builds a local `Date` from the `YYYY-MM-DD` parts, and use it for the bill date so it shares the local frame.
- Harden `forecast.service.spec.ts` to construct its expected date with the same local convention instead of `toISOString()` (which is UTC and drifts by a day).

## Test plan
- `forecast.service.spec.ts` — 7/7 pass (previously flaky/failing depending on wall-clock time; reproduced on main).
- Full API suite — 413/413 pass.
- `pnpm --filter @moneypulse/api build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)