### PR TITLE
feat(advisor): Phase 1 — ask-your-money chat over MCP (web + Telegram) (#38)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,6 +17,8 @@
     "db:seed": "tsx src/db/seed.ts"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.110.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@moneypulse/shared": "workspace:*",
     "@nestjs/bullmq": "^11.0.4",
     "@nestjs/common": "^11.1.17",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -44,6 +44,7 @@
     "ioredis": "^5.10.1",
     "multer": "^2.1.1",
     "nodemailer": "^8.0.5",
+    "openai": "^6.45.0",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "passport-local": "^1.0.0",

--- a/apps/api/src/advisor/__tests__/advisor-settings.service.spec.ts
+++ b/apps/api/src/advisor/__tests__/advisor-settings.service.spec.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { AdvisorSettingsService } from '../advisor-settings.service';
+import { encryptField } from '../../common/crypto';
+
+const HEX_KEY = 'a'.repeat(64); // valid 32-byte hex for ENCRYPTION_KEY
+
+beforeAll(() => {
+  process.env.ENCRYPTION_KEY = HEX_KEY;
+});
+
+function fakeDb(row: any) {
+  const captured: { values?: any } = {};
+  const db = {
+    select: () => ({
+      from: () => ({ where: () => ({ limit: async () => (row ? [row] : []) }) }),
+    }),
+    insert: () => ({
+      values: (v: any) => ({
+        onConflictDoUpdate: async () => {
+          captured.values = v;
+        },
+      }),
+    }),
+    captured,
+  };
+  return db;
+}
+
+function make(env: Record<string, string | undefined>, row: any = null) {
+  const config = { get: (k: string) => env[k] };
+  const db = fakeDb(row);
+  const svc = new AdvisorSettingsService(config as any, db as any);
+  return { svc, db };
+}
+
+describe('AdvisorSettingsService', () => {
+  it('resolve prefers the provider env key over the stored DB key', async () => {
+    const row = { provider: 'anthropic', model: 'claude-opus-4-8', apiKeyCiphertext: encryptField('db-key') };
+    const { svc } = make({ ENCRYPTION_KEY: HEX_KEY, ANTHROPIC_API_KEY: 'env-key' }, row);
+    const resolved = await svc.resolve();
+    expect(resolved).toMatchObject({ provider: 'anthropic', apiKey: 'env-key', keySource: 'env' });
+  });
+
+  it('resolve falls back to the decrypted DB key when no env key', async () => {
+    const row = { provider: 'openai', model: 'gpt-4o', apiKeyCiphertext: encryptField('sk-db-secret') };
+    const { svc } = make({ ENCRYPTION_KEY: HEX_KEY }, row);
+    const resolved = await svc.resolve();
+    expect(resolved).toMatchObject({ provider: 'openai', model: 'gpt-4o', apiKey: 'sk-db-secret', keySource: 'db' });
+  });
+
+  it('resolve returns null when no key is available anywhere', async () => {
+    const { svc } = make({ ENCRYPTION_KEY: HEX_KEY }, { provider: 'anthropic', model: null, apiKeyCiphertext: null });
+    expect(await svc.resolve()).toBeNull();
+  });
+
+  it('view masks the key and never returns it in full', async () => {
+    const row = { provider: 'anthropic', model: null, apiKeyCiphertext: encryptField('sk-abcdefgh1234') };
+    const { svc } = make({ ENCRYPTION_KEY: HEX_KEY }, row);
+    const view = await svc.view();
+    expect(view.enabled).toBe(true);
+    expect(view.keySource).toBe('db');
+    expect(view.keyMasked).toBe('sk-…1234');
+    expect(view.model).toBe('claude-opus-4-8'); // default filled in
+    expect(JSON.stringify(view)).not.toContain('abcdefgh');
+  });
+
+  it('update encrypts the API key and persists provider/model', async () => {
+    const { svc, db } = make({ ENCRYPTION_KEY: HEX_KEY });
+    await svc.update({ provider: 'openai', model: 'gpt-4o', apiKey: 'sk-plaintext' });
+    const stored = (db as any).captured.values;
+    expect(stored.provider).toBe('openai');
+    expect(stored.model).toBe('gpt-4o');
+    expect(stored.apiKeyCiphertext).not.toBe('sk-plaintext');
+    expect(stored.apiKeyCiphertext).toContain(':'); // iv:tag:ciphertext
+  });
+
+  it('update refuses to store a key when ENCRYPTION_KEY is absent', async () => {
+    const { svc } = make({}); // canStoreKey() false
+    await expect(svc.update({ provider: 'openai', apiKey: 'sk-x' })).rejects.toThrow(
+      /ENCRYPTION_KEY/,
+    );
+  });
+});

--- a/apps/api/src/advisor/__tests__/advisor.service.spec.ts
+++ b/apps/api/src/advisor/__tests__/advisor.service.spec.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AdvisorService } from '../advisor.service';
+
+// ── Fakes ──────────────────────────────────────────────────────────────────
+
+/** A fake Anthropic stream: async-iterable of events + finalMessage(). */
+function makeStream(deltas: string[], finalMsg: any) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const text of deltas) {
+        yield { type: 'content_block_delta', delta: { type: 'text_delta', text } };
+      }
+    },
+    finalMessage: async () => finalMsg,
+  };
+}
+
+const AGGREGATE_TOOLS = [
+  { name: 'get_spending_summary', description: '', input_schema: { type: 'object' } },
+  { name: 'get_account_balances', description: '', input_schema: { type: 'object' } },
+];
+
+function build(overrides: { key?: string | undefined } = {}) {
+  const config = {
+    get: (k: string) =>
+      k === 'ANTHROPIC_API_KEY' ? ('key' in overrides ? overrides.key : 'sk-test') : undefined,
+  };
+  const mcp = {
+    listAdvisorTools: vi.fn().mockResolvedValue(AGGREGATE_TOOLS),
+    callTool: vi.fn().mockResolvedValue('Dining: $420.00 (June)'),
+  };
+  const aiLogs = { create: vi.fn().mockResolvedValue(undefined) };
+  const service = new AdvisorService(config as any, mcp as any, aiLogs as any);
+  const streamCalls: any[] = [];
+  const fakeAnthropic = { messages: { stream: vi.fn((p: any) => { streamCalls.push(p); return fakeAnthropic.__next.shift(); }), }, __next: [] as any[] };
+  // Only inject the fake when the service actually constructed a client (key present),
+  // so the "disabled" case keeps its null client.
+  if (service.enabled) (service as any).anthropic = fakeAnthropic;
+  return { service, mcp, aiLogs, fakeAnthropic, streamCalls };
+}
+
+async function collect(gen: AsyncGenerator<string>): Promise<string> {
+  let out = '';
+  for await (const d of gen) out += d;
+  return out;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('AdvisorService', () => {
+  it('is disabled when ANTHROPIC_API_KEY is missing', async () => {
+    const { service } = build({ key: undefined });
+    expect(service.enabled).toBe(false);
+    await expect(collect(service.streamChat('u1', 'hi'))).rejects.toThrow(/not configured/);
+  });
+
+  describe('tool-use loop', () => {
+    let ctx: ReturnType<typeof build>;
+
+    beforeEach(() => {
+      ctx = build();
+    });
+
+    it('calls the aggregate tool, then streams the grounded answer', async () => {
+      ctx.fakeAnthropic.__next = [
+        // round 1: model asks for a tool
+        makeStream([], {
+          stop_reason: 'tool_use',
+          content: [
+            { type: 'tool_use', id: 't1', name: 'get_spending_summary', input: { from: '2026-06-01', to: '2026-06-30' } },
+          ],
+          usage: { input_tokens: 100, output_tokens: 20 },
+        }),
+        // round 2: model narrates the tool result
+        makeStream(['You spent ', '$420.00 on dining in June.'], {
+          stop_reason: 'end_turn',
+          content: [{ type: 'text', text: 'You spent $420.00 on dining in June.' }],
+          usage: { input_tokens: 150, output_tokens: 30 },
+        }),
+      ];
+
+      const answer = await collect(ctx.service.streamChat('u1', 'How much on dining in June?'));
+
+      expect(answer).toBe('You spent $420.00 on dining in June.');
+      expect(ctx.mcp.callTool).toHaveBeenCalledWith('u1', 'get_spending_summary', {
+        from: '2026-06-01',
+        to: '2026-06-30',
+      });
+      // number narrated matches the tool's number
+      expect(answer).toContain('$420.00');
+      // logged as an advisor turn with token usage
+      expect(ctx.aiLogs.create).toHaveBeenCalledTimes(1);
+      const log = ctx.aiLogs.create.mock.calls[0][0];
+      expect(log.promptType).toBe('advisor');
+      expect(log.tokenCountIn).toBe(250);
+      expect(log.tokenCountOut).toBe(50);
+    });
+
+    it('only offers the aggregate tools to Claude (row-level tools never sent)', async () => {
+      ctx.fakeAnthropic.__next = [
+        makeStream(['ok'], { stop_reason: 'end_turn', content: [{ type: 'text', text: 'ok' }], usage: { input_tokens: 1, output_tokens: 1 } }),
+      ];
+      await collect(ctx.service.streamChat('u1', 'hi'));
+
+      const toolsSent = ctx.streamCalls[0].tools.map((t: any) => t.name);
+      expect(toolsSent).toEqual(['get_spending_summary', 'get_account_balances']);
+      expect(toolsSent).not.toContain('get_transactions');
+      expect(toolsSent).not.toContain('search_transactions');
+      expect(ctx.streamCalls[0].model).toBe('claude-opus-4-8');
+    });
+
+    it('refuses without a tool call when nothing fits', async () => {
+      ctx.fakeAnthropic.__next = [
+        makeStream(["I don't have a way to answer that from your data."], {
+          stop_reason: 'end_turn',
+          content: [{ type: 'text', text: "I don't have a way to answer that from your data." }],
+          usage: { input_tokens: 10, output_tokens: 12 },
+        }),
+      ];
+      const answer = await collect(ctx.service.streamChat('u1', "what's the weather?"));
+      expect(answer).toMatch(/don't have a way/);
+      expect(ctx.mcp.callTool).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/advisor/__tests__/advisor.service.spec.ts
+++ b/apps/api/src/advisor/__tests__/advisor.service.spec.ts
@@ -1,17 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AdvisorService } from '../advisor.service';
+import type { LlmStreamChunk, LlmTurnResult } from '../llm/types';
 
 // ── Fakes ──────────────────────────────────────────────────────────────────
 
-/** A fake Anthropic stream: async-iterable of events + finalMessage(). */
-function makeStream(deltas: string[], finalMsg: any) {
+/** A fake provider turn: streams text deltas, then a single `final` chunk. */
+function makeTurn(deltas: string[], final: LlmTurnResult): AsyncIterable<LlmStreamChunk> {
   return {
     async *[Symbol.asyncIterator]() {
-      for (const text of deltas) {
-        yield { type: 'content_block_delta', delta: { type: 'text_delta', text } };
-      }
+      for (const text of deltas) yield { type: 'text', text };
+      yield { type: 'final', result: final };
     },
-    finalMessage: async () => finalMsg,
   };
 }
 
@@ -20,23 +19,40 @@ const AGGREGATE_TOOLS = [
   { name: 'get_account_balances', description: '', input_schema: { type: 'object' } },
 ];
 
-function build(overrides: { key?: string | undefined } = {}) {
-  const config = {
-    get: (k: string) =>
-      k === 'ANTHROPIC_API_KEY' ? ('key' in overrides ? overrides.key : 'sk-test') : undefined,
-  };
+function build(overrides: { resolved?: any } = {}) {
+  const resolved =
+    'resolved' in overrides
+      ? overrides.resolved
+      : { provider: 'anthropic', model: 'claude-opus-4-8', apiKey: 'sk-test', keySource: 'env' };
+
   const mcp = {
     listAdvisorTools: vi.fn().mockResolvedValue(AGGREGATE_TOOLS),
     callTool: vi.fn().mockResolvedValue('Dining: $420.00 (June)'),
   };
   const aiLogs = { create: vi.fn().mockResolvedValue(undefined) };
-  const service = new AdvisorService(config as any, mcp as any, aiLogs as any);
-  const streamCalls: any[] = [];
-  const fakeAnthropic = { messages: { stream: vi.fn((p: any) => { streamCalls.push(p); return fakeAnthropic.__next.shift(); }), }, __next: [] as any[] };
-  // Only inject the fake when the service actually constructed a client (key present),
-  // so the "disabled" case keeps its null client.
-  if (service.enabled) (service as any).anthropic = fakeAnthropic;
-  return { service, mcp, aiLogs, fakeAnthropic, streamCalls };
+  const settings = {
+    resolve: vi.fn().mockResolvedValue(resolved),
+  };
+
+  const turns: AsyncIterable<LlmStreamChunk>[] = [];
+  const turnParams: any[] = [];
+  const fakeProvider = {
+    id: resolved?.provider ?? 'anthropic',
+    streamTurn: vi.fn((p: any) => {
+      turnParams.push(p);
+      return turns.shift()!;
+    }),
+    testConnection: vi.fn(),
+  };
+  const factory = { create: vi.fn().mockReturnValue(fakeProvider) };
+
+  const service = new AdvisorService(
+    mcp as any,
+    aiLogs as any,
+    settings as any,
+    factory as any,
+  );
+  return { service, mcp, aiLogs, settings, factory, fakeProvider, turns, turnParams };
 }
 
 async function collect(gen: AsyncGenerator<string>): Promise<string> {
@@ -48,9 +64,9 @@ async function collect(gen: AsyncGenerator<string>): Promise<string> {
 // ── Tests ──────────────────────────────────────────────────────────────────
 
 describe('AdvisorService', () => {
-  it('is disabled when ANTHROPIC_API_KEY is missing', async () => {
-    const { service } = build({ key: undefined });
-    expect(service.enabled).toBe(false);
+  it('throws when no provider/key is configured', async () => {
+    const { service } = build({ resolved: null });
+    expect(await service.isEnabled()).toBe(false);
     await expect(collect(service.streamChat('u1', 'hi'))).rejects.toThrow(/not configured/);
   });
 
@@ -62,22 +78,28 @@ describe('AdvisorService', () => {
     });
 
     it('calls the aggregate tool, then streams the grounded answer', async () => {
-      ctx.fakeAnthropic.__next = [
+      ctx.turns.push(
         // round 1: model asks for a tool
-        makeStream([], {
-          stop_reason: 'tool_use',
+        makeTurn([], {
+          text: '',
           content: [
             { type: 'tool_use', id: 't1', name: 'get_spending_summary', input: { from: '2026-06-01', to: '2026-06-30' } },
           ],
-          usage: { input_tokens: 100, output_tokens: 20 },
+          toolCalls: [
+            { id: 't1', name: 'get_spending_summary', input: { from: '2026-06-01', to: '2026-06-30' } },
+          ],
+          stopReason: 'tool_use',
+          usage: { inputTokens: 100, outputTokens: 20 },
         }),
         // round 2: model narrates the tool result
-        makeStream(['You spent ', '$420.00 on dining in June.'], {
-          stop_reason: 'end_turn',
+        makeTurn(['You spent ', '$420.00 on dining in June.'], {
+          text: 'You spent $420.00 on dining in June.',
           content: [{ type: 'text', text: 'You spent $420.00 on dining in June.' }],
-          usage: { input_tokens: 150, output_tokens: 30 },
+          toolCalls: [],
+          stopReason: 'end_turn',
+          usage: { inputTokens: 150, outputTokens: 30 },
         }),
-      ];
+      );
 
       const answer = await collect(ctx.service.streamChat('u1', 'How much on dining in June?'));
 
@@ -86,37 +108,65 @@ describe('AdvisorService', () => {
         from: '2026-06-01',
         to: '2026-06-30',
       });
-      // number narrated matches the tool's number
       expect(answer).toContain('$420.00');
-      // logged as an advisor turn with token usage
+      // logged as an advisor turn with summed token usage
       expect(ctx.aiLogs.create).toHaveBeenCalledTimes(1);
       const log = ctx.aiLogs.create.mock.calls[0][0];
       expect(log.promptType).toBe('advisor');
+      expect(log.model).toBe('claude-opus-4-8');
       expect(log.tokenCountIn).toBe(250);
       expect(log.tokenCountOut).toBe(50);
     });
 
-    it('only offers the aggregate tools to Claude (row-level tools never sent)', async () => {
-      ctx.fakeAnthropic.__next = [
-        makeStream(['ok'], { stop_reason: 'end_turn', content: [{ type: 'text', text: 'ok' }], usage: { input_tokens: 1, output_tokens: 1 } }),
-      ];
+    it('only offers the aggregate tools to the model (row-level tools never sent)', async () => {
+      ctx.turns.push(
+        makeTurn(['ok'], {
+          text: 'ok',
+          content: [{ type: 'text', text: 'ok' }],
+          toolCalls: [],
+          stopReason: 'end_turn',
+          usage: { inputTokens: 1, outputTokens: 1 },
+        }),
+      );
       await collect(ctx.service.streamChat('u1', 'hi'));
 
-      const toolsSent = ctx.streamCalls[0].tools.map((t: any) => t.name);
+      const toolsSent = ctx.turnParams[0].tools.map((t: any) => t.name);
       expect(toolsSent).toEqual(['get_spending_summary', 'get_account_balances']);
       expect(toolsSent).not.toContain('get_transactions');
       expect(toolsSent).not.toContain('search_transactions');
-      expect(ctx.streamCalls[0].model).toBe('claude-opus-4-8');
+      expect(ctx.turnParams[0].model).toBe('claude-opus-4-8');
+      expect(ctx.factory.create).toHaveBeenCalledWith('anthropic', 'sk-test');
+    });
+
+    it('routes through whichever provider settings resolve to (OpenAI)', async () => {
+      const c = build({
+        resolved: { provider: 'openai', model: 'gpt-4o', apiKey: 'oa-key', keySource: 'db' },
+      });
+      c.turns.push(
+        makeTurn(['hello'], {
+          text: 'hello',
+          content: [{ type: 'text', text: 'hello' }],
+          toolCalls: [],
+          stopReason: 'end_turn',
+          usage: { inputTokens: 2, outputTokens: 2 },
+        }),
+      );
+      const answer = await collect(c.service.streamChat('u1', 'hi'));
+      expect(answer).toBe('hello');
+      expect(c.factory.create).toHaveBeenCalledWith('openai', 'oa-key');
+      expect(c.turnParams[0].model).toBe('gpt-4o');
     });
 
     it('refuses without a tool call when nothing fits', async () => {
-      ctx.fakeAnthropic.__next = [
-        makeStream(["I don't have a way to answer that from your data."], {
-          stop_reason: 'end_turn',
+      ctx.turns.push(
+        makeTurn(["I don't have a way to answer that from your data."], {
+          text: "I don't have a way to answer that from your data.",
           content: [{ type: 'text', text: "I don't have a way to answer that from your data." }],
-          usage: { input_tokens: 10, output_tokens: 12 },
+          toolCalls: [],
+          stopReason: 'end_turn',
+          usage: { inputTokens: 10, outputTokens: 12 },
         }),
-      ];
+      );
       const answer = await collect(ctx.service.streamChat('u1', "what's the weather?"));
       expect(answer).toMatch(/don't have a way/);
       expect(ctx.mcp.callTool).not.toHaveBeenCalled();

--- a/apps/api/src/advisor/__tests__/mcp-client.service.spec.ts
+++ b/apps/api/src/advisor/__tests__/mcp-client.service.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import {
+  toAdvisorTools,
+  AGGREGATE_TOOL_ALLOWLIST,
+  McpClientService,
+} from '../mcp-client.service';
+
+const ALL_EIGHT = [
+  { name: 'get_account_balances', description: 'a', inputSchema: { type: 'object' } },
+  { name: 'get_spending_summary', description: 'b', inputSchema: { type: 'object' } },
+  { name: 'get_category_breakdown', description: 'c', inputSchema: { type: 'object' } },
+  { name: 'get_budget_status', description: 'd', inputSchema: { type: 'object' } },
+  { name: 'get_recurring_expenses', description: 'e', inputSchema: { type: 'object' } },
+  { name: 'compare_periods', description: 'f', inputSchema: { type: 'object' } },
+  { name: 'get_transactions', description: 'ROW-LEVEL', inputSchema: { type: 'object' } },
+  { name: 'search_transactions', description: 'ROW-LEVEL', inputSchema: { type: 'object' } },
+];
+
+describe('MCP advisor tool boundary (aggregates-only)', () => {
+  it('exposes exactly the 6 aggregate tools and excludes the 2 row-level tools', () => {
+    const out = toAdvisorTools(ALL_EIGHT);
+    const names = out.map((t) => t.name).sort();
+    expect(names).toEqual([...AGGREGATE_TOOL_ALLOWLIST].sort());
+    expect(names).not.toContain('get_transactions');
+    expect(names).not.toContain('search_transactions');
+  });
+
+  it('maps inputSchema → input_schema for Anthropic', () => {
+    const out = toAdvisorTools([ALL_EIGHT[0]]);
+    expect(out[0]).toMatchObject({
+      name: 'get_account_balances',
+      description: 'a',
+      input_schema: { type: 'object' },
+    });
+  });
+
+  it('callTool rejects a non-allowlisted (row-level) tool before connecting', async () => {
+    const svc = new McpClientService({ get: () => undefined } as any);
+    await expect(
+      svc.callTool('user-1', 'get_transactions', {}),
+    ).rejects.toThrow(/not an allowed advisor tool/);
+    await expect(
+      svc.callTool('user-1', 'search_transactions', {}),
+    ).rejects.toThrow(/not an allowed advisor tool/);
+  });
+});

--- a/apps/api/src/advisor/__tests__/telegram.service.spec.ts
+++ b/apps/api/src/advisor/__tests__/telegram.service.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { TelegramService } from '../telegram.service';
+
+function make(env: Record<string, string | undefined>) {
+  return new TelegramService({ get: (k: string) => env[k] } as any);
+}
+
+describe('TelegramService', () => {
+  describe('verifySecret', () => {
+    it('accepts the correct secret and rejects wrong/short ones', () => {
+      const svc = make({ TELEGRAM_WEBHOOK_SECRET: 'super-secret-value' });
+      expect(svc.verifySecret('super-secret-value')).toBe(true);
+      expect(svc.verifySecret('wrong-secret-value!')).toBe(false);
+      expect(svc.verifySecret('short')).toBe(false);
+    });
+
+    it('rejects everything when no secret is configured', () => {
+      const svc = make({});
+      expect(svc.verifySecret('anything')).toBe(false);
+    });
+  });
+
+  describe('resolveUser', () => {
+    it('maps chat ids via the allowlist', () => {
+      const svc = make({ TELEGRAM_CHAT_MAP: '111:user-a, 222:user-b' });
+      expect(svc.resolveUser(111)).toBe('user-a');
+      expect(svc.resolveUser('222')).toBe('user-b');
+      expect(svc.resolveUser(999)).toBeNull(); // not in allowlist
+    });
+
+    it('falls back to the single default user when no allowlist is set', () => {
+      const svc = make({ TELEGRAM_DEFAULT_USER_ID: 'sole-user' });
+      expect(svc.resolveUser(12345)).toBe('sole-user');
+    });
+
+    it('returns null when neither allowlist nor default is configured', () => {
+      const svc = make({});
+      expect(svc.resolveUser(12345)).toBeNull();
+    });
+  });
+
+  it('reports disabled without a bot token', () => {
+    expect(make({}).enabled).toBe(false);
+    expect(make({ TELEGRAM_BOT_TOKEN: 't' }).enabled).toBe(true);
+  });
+});

--- a/apps/api/src/advisor/advisor-settings.service.ts
+++ b/apps/api/src/advisor/advisor-settings.service.ts
@@ -1,0 +1,187 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { eq } from 'drizzle-orm';
+import { DATABASE_CONNECTION } from '../db/db.module';
+import { advisorSettings } from '../db/schema';
+import { encryptField, decryptField } from '../common/crypto';
+import { DEFAULT_MODELS, type LlmProviderId } from './llm/types';
+
+const PROVIDERS: LlmProviderId[] = ['anthropic', 'openai'];
+
+/** Env var that carries the API key for each provider (takes precedence over DB). */
+const ENV_KEY: Record<LlmProviderId, string> = {
+  anthropic: 'ANTHROPIC_API_KEY',
+  openai: 'OPENAI_API_KEY',
+};
+
+/** What the advisor loop needs to run: which provider, which model, and the key. */
+export interface ResolvedAdvisorConfig {
+  provider: LlmProviderId;
+  model: string;
+  apiKey: string;
+  /** Where the key came from — surfaced (not the key) so the UI can explain state. */
+  keySource: 'env' | 'db';
+}
+
+/** Public, key-free view of the current settings for the web UI. */
+export interface AdvisorSettingsView {
+  provider: LlmProviderId;
+  model: string;
+  enabled: boolean;
+  /** True when a key is available from either env or the DB. */
+  hasKey: boolean;
+  keySource: 'env' | 'db' | null;
+  /** Masked hint like `sk-…a1b2`, or null. Never the full key. */
+  keyMasked: string | null;
+  /** True when at-rest key storage is possible (ENCRYPTION_KEY present). */
+  canStoreKey: boolean;
+  providers: LlmProviderId[];
+  defaultModels: Record<LlmProviderId, string>;
+}
+
+/**
+ * Reads/writes the global advisor settings singleton and resolves the effective
+ * provider/model/key. Precedence for the key: provider env var first, then the
+ * (decrypted) DB value — so ops can always pin a key via the NAS .env while the
+ * web UI stays a convenience layer. The key is never returned to callers.
+ */
+@Injectable()
+export class AdvisorSettingsService {
+  private readonly logger = new Logger(AdvisorSettingsService.name);
+
+  constructor(
+    private readonly config: ConfigService,
+    @Inject(DATABASE_CONNECTION) private readonly db: any,
+  ) {}
+
+  private isProvider(v: string): v is LlmProviderId {
+    return (PROVIDERS as string[]).includes(v);
+  }
+
+  private canStoreKey(): boolean {
+    const hex = this.config.get<string>('ENCRYPTION_KEY');
+    return !!hex && hex.length === 64;
+  }
+
+  /** Load the singleton row (id=1), or null if never saved. */
+  private async loadRow(): Promise<{
+    provider: string;
+    model: string | null;
+    apiKeyCiphertext: string | null;
+  } | null> {
+    const rows = await this.db
+      .select()
+      .from(advisorSettings)
+      .where(eq(advisorSettings.id, 1))
+      .limit(1);
+    return rows[0] ?? null;
+  }
+
+  private envKey(provider: LlmProviderId): string | undefined {
+    return this.config.get<string>(ENV_KEY[provider]);
+  }
+
+  /** Resolve the effective config, or null if no key is available anywhere. */
+  async resolve(): Promise<ResolvedAdvisorConfig | null> {
+    const row = await this.loadRow();
+    const provider: LlmProviderId =
+      row && this.isProvider(row.provider) ? row.provider : 'anthropic';
+    const model = row?.model || DEFAULT_MODELS[provider];
+
+    const envKey = this.envKey(provider);
+    if (envKey) {
+      return { provider, model, apiKey: envKey, keySource: 'env' };
+    }
+    if (row?.apiKeyCiphertext && this.canStoreKey()) {
+      try {
+        const apiKey = decryptField(row.apiKeyCiphertext);
+        if (apiKey) return { provider, model, apiKey, keySource: 'db' };
+      } catch (err: any) {
+        this.logger.error(`Failed to decrypt advisor API key: ${err.message}`);
+      }
+    }
+    return null;
+  }
+
+  /** Key-free settings view for the web UI. */
+  async view(): Promise<AdvisorSettingsView> {
+    const row = await this.loadRow();
+    const provider: LlmProviderId =
+      row && this.isProvider(row.provider) ? row.provider : 'anthropic';
+    const model = row?.model || DEFAULT_MODELS[provider];
+
+    const envKey = this.envKey(provider);
+    const hasDbKey = !!row?.apiKeyCiphertext && this.canStoreKey();
+    const keySource: 'env' | 'db' | null = envKey ? 'env' : hasDbKey ? 'db' : null;
+
+    let keyMasked: string | null = null;
+    if (envKey) {
+      keyMasked = this.mask(envKey);
+    } else if (hasDbKey) {
+      try {
+        keyMasked = this.mask(decryptField(row!.apiKeyCiphertext!));
+      } catch {
+        keyMasked = null;
+      }
+    }
+
+    return {
+      provider,
+      model,
+      enabled: keySource !== null,
+      hasKey: keySource !== null,
+      keySource,
+      keyMasked,
+      canStoreKey: this.canStoreKey(),
+      providers: PROVIDERS,
+      defaultModels: DEFAULT_MODELS,
+    };
+  }
+
+  /**
+   * Update provider/model, and optionally the API key. Passing an apiKey stores
+   * it encrypted; omitting it leaves the stored key untouched (write-only field).
+   */
+  async update(input: {
+    provider?: string;
+    model?: string;
+    apiKey?: string;
+  }): Promise<AdvisorSettingsView> {
+    const row = await this.loadRow();
+    const provider =
+      input.provider && this.isProvider(input.provider)
+        ? input.provider
+        : row && this.isProvider(row.provider)
+          ? row.provider
+          : 'anthropic';
+
+    // Empty string ⇒ leave model default (null); non-empty ⇒ set it.
+    const model =
+      input.model !== undefined ? input.model.trim() || null : (row?.model ?? null);
+
+    let apiKeyCiphertext = row?.apiKeyCiphertext ?? null;
+    if (input.apiKey !== undefined && input.apiKey.trim()) {
+      if (!this.canStoreKey()) {
+        throw new Error(
+          'Cannot store an API key: ENCRYPTION_KEY is not configured on the server.',
+        );
+      }
+      apiKeyCiphertext = encryptField(input.apiKey.trim());
+    }
+
+    await this.db
+      .insert(advisorSettings)
+      .values({ id: 1, provider, model, apiKeyCiphertext, updatedAt: new Date() })
+      .onConflictDoUpdate({
+        target: advisorSettings.id,
+        set: { provider, model, apiKeyCiphertext, updatedAt: new Date() },
+      });
+
+    return this.view();
+  }
+
+  private mask(key: string): string {
+    if (key.length <= 8) return '…';
+    return `${key.slice(0, 3)}…${key.slice(-4)}`;
+  }
+}

--- a/apps/api/src/advisor/advisor.controller.ts
+++ b/apps/api/src/advisor/advisor.controller.ts
@@ -1,6 +1,7 @@
 import {
   Controller,
   Post,
+  Put,
   Get,
   Body,
   Res,
@@ -12,22 +13,87 @@ import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
 import type { AuthTokenPayload } from '@moneypulse/shared';
 import { AdvisorService, ChatTurn, ADVISOR_DISCLAIMER } from './advisor.service';
+import { AdvisorSettingsService } from './advisor-settings.service';
+import { LlmProviderFactory } from './llm/provider-factory';
+import { DEFAULT_MODELS, type LlmProviderId } from './llm/types';
 
 interface ChatBody {
   message: string;
   history?: ChatTurn[];
 }
 
+interface SettingsBody {
+  provider?: string;
+  model?: string;
+  apiKey?: string;
+}
+
 @ApiTags('Advisor')
 @Controller('advisor')
 @UseGuards(JwtAuthGuard)
 export class AdvisorController {
-  constructor(private readonly advisor: AdvisorService) {}
+  constructor(
+    private readonly advisor: AdvisorService,
+    private readonly settings: AdvisorSettingsService,
+    private readonly factory: LlmProviderFactory,
+  ) {}
 
   @Get('status')
   @ApiOperation({ summary: 'Whether the advisor is configured, plus the disclaimer' })
-  status() {
-    return { data: { enabled: this.advisor.enabled, disclaimer: ADVISOR_DISCLAIMER } };
+  async status() {
+    const view = await this.settings.view();
+    return {
+      data: {
+        enabled: view.enabled,
+        provider: view.provider,
+        model: view.model,
+        disclaimer: ADVISOR_DISCLAIMER,
+      },
+    };
+  }
+
+  @Get('settings')
+  @ApiOperation({ summary: 'Current advisor provider/model settings (no API key)' })
+  async getSettings() {
+    return { data: await this.settings.view() };
+  }
+
+  @Put('settings')
+  @ApiOperation({ summary: 'Update advisor provider/model and optionally the API key' })
+  async updateSettings(@Body() body: SettingsBody) {
+    const view = await this.settings.update({
+      provider: body.provider,
+      model: body.model,
+      apiKey: body.apiKey,
+    });
+    return { data: view };
+  }
+
+  @Post('settings/test')
+  @ApiOperation({ summary: 'Validate the provider credentials (provided or stored)' })
+  async testSettings(@Body() body: SettingsBody) {
+    try {
+      let provider: LlmProviderId;
+      let model: string;
+      let apiKey: string;
+
+      if (body.apiKey && body.apiKey.trim()) {
+        provider = (body.provider as LlmProviderId) ?? 'anthropic';
+        model = body.model?.trim() || DEFAULT_MODELS[provider];
+        apiKey = body.apiKey.trim();
+      } else {
+        const resolved = await this.settings.resolve();
+        if (!resolved) {
+          return { data: { ok: false, error: 'No API key configured.' } };
+        }
+        ({ provider, model, apiKey } = resolved);
+      }
+
+      await this.factory.create(provider, apiKey).testConnection(model);
+      return { data: { ok: true } };
+    } catch (err: any) {
+      return { data: { ok: false, error: err.message ?? 'Connection failed.' } };
+    }
   }
 
   @Post('chat')

--- a/apps/api/src/advisor/advisor.controller.ts
+++ b/apps/api/src/advisor/advisor.controller.ts
@@ -1,0 +1,70 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Body,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import type { Response } from 'express';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import type { AuthTokenPayload } from '@moneypulse/shared';
+import { AdvisorService, ChatTurn, ADVISOR_DISCLAIMER } from './advisor.service';
+
+interface ChatBody {
+  message: string;
+  history?: ChatTurn[];
+}
+
+@ApiTags('Advisor')
+@Controller('advisor')
+@UseGuards(JwtAuthGuard)
+export class AdvisorController {
+  constructor(private readonly advisor: AdvisorService) {}
+
+  @Get('status')
+  @ApiOperation({ summary: 'Whether the advisor is configured, plus the disclaimer' })
+  status() {
+    return { data: { enabled: this.advisor.enabled, disclaimer: ADVISOR_DISCLAIMER } };
+  }
+
+  @Post('chat')
+  @ApiOperation({ summary: 'Ask the advisor a question (Server-Sent Events stream)' })
+  async chat(
+    @CurrentUser() user: AuthTokenPayload,
+    @Body() body: ChatBody,
+    @Res() res: Response,
+  ): Promise<void> {
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache, no-transform');
+    res.setHeader('Connection', 'keep-alive');
+    res.flushHeaders?.();
+
+    const send = (payload: Record<string, unknown>) =>
+      res.write(`data: ${JSON.stringify(payload)}\n\n`);
+
+    const message = (body?.message ?? '').trim();
+    if (!message) {
+      send({ type: 'error', text: 'Empty message.' });
+      res.end();
+      return;
+    }
+
+    try {
+      for await (const delta of this.advisor.streamChat(
+        user.sub,
+        message,
+        body.history ?? [],
+      )) {
+        send({ type: 'delta', text: delta });
+      }
+      send({ type: 'done' });
+    } catch (err: any) {
+      send({ type: 'error', text: err.message ?? 'Advisor error.' });
+    } finally {
+      res.end();
+    }
+  }
+}

--- a/apps/api/src/advisor/advisor.module.ts
+++ b/apps/api/src/advisor/advisor.module.ts
@@ -3,12 +3,20 @@ import { AiLogsModule } from '../ai-logs/ai-logs.module';
 import { McpClientService } from './mcp-client.service';
 import { AdvisorService } from './advisor.service';
 import { AdvisorController } from './advisor.controller';
+import { AdvisorSettingsService } from './advisor-settings.service';
+import { LlmProviderFactory } from './llm/provider-factory';
 import { TelegramService } from './telegram.service';
 import { TelegramController } from './telegram.controller';
 
 @Module({
   imports: [AiLogsModule],
-  providers: [McpClientService, AdvisorService, TelegramService],
+  providers: [
+    McpClientService,
+    AdvisorService,
+    AdvisorSettingsService,
+    LlmProviderFactory,
+    TelegramService,
+  ],
   controllers: [AdvisorController, TelegramController],
   exports: [AdvisorService],
 })

--- a/apps/api/src/advisor/advisor.module.ts
+++ b/apps/api/src/advisor/advisor.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { AiLogsModule } from '../ai-logs/ai-logs.module';
+import { McpClientService } from './mcp-client.service';
+import { AdvisorService } from './advisor.service';
+import { AdvisorController } from './advisor.controller';
+import { TelegramService } from './telegram.service';
+import { TelegramController } from './telegram.controller';
+
+@Module({
+  imports: [AiLogsModule],
+  providers: [McpClientService, AdvisorService, TelegramService],
+  controllers: [AdvisorController, TelegramController],
+  exports: [AdvisorService],
+})
+export class AdvisorModule {}

--- a/apps/api/src/advisor/advisor.service.ts
+++ b/apps/api/src/advisor/advisor.service.ts
@@ -1,11 +1,16 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
-import Anthropic from '@anthropic-ai/sdk';
 import { McpClientService } from './mcp-client.service';
 import { AiLogsService } from '../ai-logs/ai-logs.service';
 import { detectPiiTypes } from '../categorization/pii-sanitizer';
+import { AdvisorSettingsService } from './advisor-settings.service';
+import { LlmProviderFactory } from './llm/provider-factory';
+import type {
+  LlmContentBlock,
+  LlmMessage,
+  LlmTool,
+  LlmTurnResult,
+} from './llm/types';
 
-const DEFAULT_MODEL = 'claude-opus-4-8';
 const MAX_TOKENS = 8192;
 /** Hard cap on tool-use round trips so a loop can't run away. */
 const MAX_TOOL_ROUNDS = 8;
@@ -33,44 +38,46 @@ export interface ChatTurn {
 @Injectable()
 export class AdvisorService {
   private readonly logger = new Logger(AdvisorService.name);
-  private readonly anthropic: Anthropic | null;
-  private readonly model: string;
 
   constructor(
-    private readonly config: ConfigService,
     private readonly mcp: McpClientService,
     private readonly aiLogs: AiLogsService,
-  ) {
-    const apiKey = this.config.get<string>('ANTHROPIC_API_KEY');
-    this.anthropic = apiKey ? new Anthropic({ apiKey }) : null;
-    this.model = this.config.get<string>('ADVISOR_MODEL') || DEFAULT_MODEL;
-    if (!this.anthropic) {
-      this.logger.warn('ANTHROPIC_API_KEY not set — advisor chat is disabled.');
-    }
-  }
+    private readonly settings: AdvisorSettingsService,
+    private readonly factory: LlmProviderFactory,
+  ) {}
 
-  get enabled(): boolean {
-    return this.anthropic !== null;
+  /** Whether a provider + key are configured (env or DB). */
+  async isEnabled(): Promise<boolean> {
+    return (await this.settings.resolve()) !== null;
   }
 
   /**
    * Stream a grounded answer to the user's message. Yields text deltas as they arrive.
-   * Runs the Claude tool-use loop against the aggregate MCP tools; the model narrates
-   * verified tool results and never computes numbers itself.
+   * Runs the tool-use loop against the aggregate MCP tools through whichever provider
+   * (Anthropic/OpenAI) is configured; the model narrates verified tool results and
+   * never computes numbers itself.
    */
   async *streamChat(
     userId: string,
     message: string,
     history: ChatTurn[] = [],
   ): AsyncGenerator<string> {
-    if (!this.anthropic) {
+    const resolved = await this.settings.resolve();
+    if (!resolved) {
       throw new Error(
-        'Advisor is not configured (ANTHROPIC_API_KEY missing). Set it in the NAS .env.',
+        'Advisor is not configured. Set a provider API key in Settings or the NAS .env.',
       );
     }
+    const provider = this.factory.create(resolved.provider, resolved.apiKey);
 
-    const tools = await this.mcp.listAdvisorTools(userId);
-    const messages: Anthropic.MessageParam[] = [
+    const toolDefs = await this.mcp.listAdvisorTools(userId);
+    const tools: LlmTool[] = toolDefs.map((t) => ({
+      name: t.name,
+      description: t.description,
+      inputSchema: t.input_schema,
+    }));
+
+    const messages: LlmMessage[] = [
       ...history.map((t) => ({ role: t.role, content: t.content })),
       { role: 'user', content: message },
     ];
@@ -82,61 +89,54 @@ export class AdvisorService {
 
     try {
       for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
-        const stream = this.anthropic.messages.stream({
-          model: this.model,
-          max_tokens: MAX_TOKENS,
-          thinking: { type: 'adaptive' },
+        let final: LlmTurnResult | undefined;
+        for await (const chunk of provider.streamTurn({
+          model: resolved.model,
+          maxTokens: MAX_TOKENS,
           system: SYSTEM_PROMPT,
-          tools: tools as Anthropic.Tool[],
+          tools,
           messages,
-        });
-
-        for await (const event of stream) {
-          if (
-            event.type === 'content_block_delta' &&
-            event.delta.type === 'text_delta'
-          ) {
-            answer += event.delta.text;
-            yield event.delta.text;
+        })) {
+          if (chunk.type === 'text') {
+            answer += chunk.text;
+            yield chunk.text;
+          } else {
+            final = chunk.result;
           }
         }
+        if (!final) break;
 
-        const msg = await stream.finalMessage();
-        tokensIn += msg.usage.input_tokens;
-        tokensOut += msg.usage.output_tokens;
-        messages.push({ role: 'assistant', content: msg.content });
+        tokensIn += final.usage.inputTokens;
+        tokensOut += final.usage.outputTokens;
+        messages.push({ role: 'assistant', content: final.content });
 
-        if (msg.stop_reason !== 'tool_use') break;
+        if (final.stopReason !== 'tool_use') break;
 
-        const toolResults: Anthropic.ToolResultBlockParam[] = [];
-        for (const block of msg.content) {
-          if (block.type !== 'tool_use') continue;
+        const toolResults: LlmContentBlock[] = [];
+        for (const call of final.toolCalls) {
           let content: string;
           try {
-            content = await this.mcp.callTool(
-              userId,
-              block.name,
-              block.input as Record<string, any>,
-            );
+            content = await this.mcp.callTool(userId, call.name, call.input);
           } catch (err: any) {
             content = `Tool error: ${err.message}`;
           }
           toolResults.push({
             type: 'tool_result',
-            tool_use_id: block.id,
+            toolUseId: call.id,
             content,
           });
         }
         messages.push({ role: 'user', content: toolResults });
       }
     } finally {
-      this.logTurn(userId, message, answer, startMs, tokensIn, tokensOut);
+      this.logTurn(userId, resolved.model, message, answer, startMs, tokensIn, tokensOut);
     }
   }
 
   /** Fire-and-forget audit log of the advisor turn. */
   private logTurn(
     userId: string,
+    model: string,
     message: string,
     answer: string,
     startMs: number,
@@ -148,7 +148,7 @@ export class AdvisorService {
       .create({
         userId,
         promptType: 'advisor',
-        model: this.model,
+        model,
         inputText: message,
         outputText: answer || undefined,
         tokenCountIn: tokensIn || undefined,

--- a/apps/api/src/advisor/advisor.service.ts
+++ b/apps/api/src/advisor/advisor.service.ts
@@ -1,0 +1,171 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import Anthropic from '@anthropic-ai/sdk';
+import { McpClientService } from './mcp-client.service';
+import { AiLogsService } from '../ai-logs/ai-logs.service';
+import { detectPiiTypes } from '../categorization/pii-sanitizer';
+
+const DEFAULT_MODEL = 'claude-opus-4-8';
+const MAX_TOKENS = 8192;
+/** Hard cap on tool-use round trips so a loop can't run away. */
+const MAX_TOOL_ROUNDS = 8;
+
+/** Shown in the UI footer; the model is also instructed to frame output this way. */
+export const ADVISOR_DISCLAIMER =
+  'Informational insights based on your own data — not personalized financial, ' +
+  'investment, or tax advice. Verify before acting.';
+
+const SYSTEM_PROMPT = `You are MoneyPulse's financial insights assistant. You answer the user's questions about their own finances using ONLY the data returned by your tools.
+
+Rules:
+- Every number in your answer MUST come from a tool result. Never invent, estimate, or calculate figures yourself — if you need a number, call a tool. Quote the tool's figure as given.
+- Attach provenance: say which data a number came from (e.g. "based on your spending summary for June").
+- If no tool can answer the question, say so plainly ("I don't have a way to answer that from your data") rather than guessing. Do not fall back to general knowledge for figures about the user's finances.
+- You receive aggregated data only (category totals, balances, budgets, recurring merchants). You cannot see individual raw transactions or account numbers — don't claim to.
+- Keep answers concise and specific to the user's numbers. Lead with the answer.
+- For any suggestion about products, rates, or big decisions, present options with trade-offs and note this is informational, not personalized financial advice. Do not give reckless or absolute directives.`;
+
+export interface ChatTurn {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+@Injectable()
+export class AdvisorService {
+  private readonly logger = new Logger(AdvisorService.name);
+  private readonly anthropic: Anthropic | null;
+  private readonly model: string;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly mcp: McpClientService,
+    private readonly aiLogs: AiLogsService,
+  ) {
+    const apiKey = this.config.get<string>('ANTHROPIC_API_KEY');
+    this.anthropic = apiKey ? new Anthropic({ apiKey }) : null;
+    this.model = this.config.get<string>('ADVISOR_MODEL') || DEFAULT_MODEL;
+    if (!this.anthropic) {
+      this.logger.warn('ANTHROPIC_API_KEY not set — advisor chat is disabled.');
+    }
+  }
+
+  get enabled(): boolean {
+    return this.anthropic !== null;
+  }
+
+  /**
+   * Stream a grounded answer to the user's message. Yields text deltas as they arrive.
+   * Runs the Claude tool-use loop against the aggregate MCP tools; the model narrates
+   * verified tool results and never computes numbers itself.
+   */
+  async *streamChat(
+    userId: string,
+    message: string,
+    history: ChatTurn[] = [],
+  ): AsyncGenerator<string> {
+    if (!this.anthropic) {
+      throw new Error(
+        'Advisor is not configured (ANTHROPIC_API_KEY missing). Set it in the NAS .env.',
+      );
+    }
+
+    const tools = await this.mcp.listAdvisorTools(userId);
+    const messages: Anthropic.MessageParam[] = [
+      ...history.map((t) => ({ role: t.role, content: t.content })),
+      { role: 'user', content: message },
+    ];
+
+    const startMs = Date.now();
+    let answer = '';
+    let tokensIn = 0;
+    let tokensOut = 0;
+
+    try {
+      for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
+        const stream = this.anthropic.messages.stream({
+          model: this.model,
+          max_tokens: MAX_TOKENS,
+          thinking: { type: 'adaptive' },
+          system: SYSTEM_PROMPT,
+          tools: tools as Anthropic.Tool[],
+          messages,
+        });
+
+        for await (const event of stream) {
+          if (
+            event.type === 'content_block_delta' &&
+            event.delta.type === 'text_delta'
+          ) {
+            answer += event.delta.text;
+            yield event.delta.text;
+          }
+        }
+
+        const msg = await stream.finalMessage();
+        tokensIn += msg.usage.input_tokens;
+        tokensOut += msg.usage.output_tokens;
+        messages.push({ role: 'assistant', content: msg.content });
+
+        if (msg.stop_reason !== 'tool_use') break;
+
+        const toolResults: Anthropic.ToolResultBlockParam[] = [];
+        for (const block of msg.content) {
+          if (block.type !== 'tool_use') continue;
+          let content: string;
+          try {
+            content = await this.mcp.callTool(
+              userId,
+              block.name,
+              block.input as Record<string, any>,
+            );
+          } catch (err: any) {
+            content = `Tool error: ${err.message}`;
+          }
+          toolResults.push({
+            type: 'tool_result',
+            tool_use_id: block.id,
+            content,
+          });
+        }
+        messages.push({ role: 'user', content: toolResults });
+      }
+    } finally {
+      this.logTurn(userId, message, answer, startMs, tokensIn, tokensOut);
+    }
+  }
+
+  /** Fire-and-forget audit log of the advisor turn. */
+  private logTurn(
+    userId: string,
+    message: string,
+    answer: string,
+    startMs: number,
+    tokensIn: number,
+    tokensOut: number,
+  ): void {
+    const piiTypes = detectPiiTypes(message);
+    this.aiLogs
+      .create({
+        userId,
+        promptType: 'advisor',
+        model: this.model,
+        inputText: message,
+        outputText: answer || undefined,
+        tokenCountIn: tokensIn || undefined,
+        tokenCountOut: tokensOut || undefined,
+        latencyMs: Date.now() - startMs,
+        piiDetected: piiTypes.length > 0,
+        piiTypesFound: piiTypes,
+      })
+      .catch((err) => this.logger.warn(`Advisor log failed: ${err.message}`));
+  }
+
+  /** Non-streaming convenience: collect the full answer (used by the Telegram surface). */
+  async chat(userId: string, message: string, history: ChatTurn[] = []): Promise<string> {
+    let full = '';
+    for await (const delta of this.streamChat(userId, message, history)) {
+      full += delta;
+    }
+    return full;
+  }
+}

--- a/apps/api/src/advisor/llm/__tests__/openai.provider.spec.ts
+++ b/apps/api/src/advisor/llm/__tests__/openai.provider.spec.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi } from 'vitest';
+import { OpenAIProvider } from '../openai.provider';
+import type { LlmStreamChunk, LlmTurnParams } from '../types';
+
+/** Build an async-iterable of OpenAI streaming chunks. */
+function fakeStream(chunks: any[]) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const c of chunks) yield c;
+    },
+  };
+}
+
+function withClient(chunks: any[]) {
+  const provider = new OpenAIProvider('sk-test');
+  const create = vi.fn(async () => fakeStream(chunks));
+  (provider as any).client = { chat: { completions: { create } } };
+  return { provider, create };
+}
+
+async function run(provider: OpenAIProvider, params: LlmTurnParams) {
+  const out: LlmStreamChunk[] = [];
+  for await (const chunk of provider.streamTurn(params)) out.push(chunk);
+  return out;
+}
+
+const baseParams: LlmTurnParams = {
+  model: 'gpt-4o',
+  maxTokens: 100,
+  system: 'be helpful',
+  tools: [{ name: 'get_spending_summary', description: 'sum', inputSchema: { type: 'object' } }],
+  messages: [{ role: 'user', content: 'hi' }],
+};
+
+describe('OpenAIProvider', () => {
+  it('streams text and reassembles fragmented tool-call arguments', async () => {
+    const { provider } = withClient([
+      { choices: [{ delta: { content: 'Let me check.' }, finish_reason: null }] },
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                { index: 0, id: 'c1', function: { name: 'get_spending_summary', arguments: '{"from":' } },
+              ],
+            },
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        choices: [
+          { delta: { tool_calls: [{ index: 0, function: { arguments: '"2026-06-01"}' } }] }, finish_reason: 'tool_calls' },
+        ],
+        usage: { prompt_tokens: 42, completion_tokens: 7 },
+      },
+    ]);
+
+    const chunks = await run(provider, baseParams);
+    const text = chunks.filter((c) => c.type === 'text').map((c: any) => c.text).join('');
+    const final = chunks.find((c) => c.type === 'final') as any;
+
+    expect(text).toBe('Let me check.');
+    expect(final.result.stopReason).toBe('tool_use');
+    expect(final.result.toolCalls).toEqual([
+      { id: 'c1', name: 'get_spending_summary', input: { from: '2026-06-01' } },
+    ]);
+    expect(final.result.usage).toEqual({ inputTokens: 42, outputTokens: 7 });
+  });
+
+  it('ends the turn (end_turn) for a plain text answer', async () => {
+    const { provider } = withClient([
+      { choices: [{ delta: { content: 'You spent $10.' }, finish_reason: 'stop' }], usage: { prompt_tokens: 5, completion_tokens: 4 } },
+    ]);
+    const chunks = await run(provider, baseParams);
+    const final = chunks.find((c) => c.type === 'final') as any;
+    expect(final.result.stopReason).toBe('end_turn');
+    expect(final.result.text).toBe('You spent $10.');
+    expect(final.result.toolCalls).toEqual([]);
+  });
+
+  it('translates tool_use → assistant tool_calls and tool_result → tool messages', async () => {
+    const { provider, create } = withClient([
+      { choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }] },
+    ]);
+    await run(provider, {
+      ...baseParams,
+      messages: [
+        { role: 'user', content: 'how much dining?' },
+        {
+          role: 'assistant',
+          content: [{ type: 'tool_use', id: 'c1', name: 'get_spending_summary', input: { from: 'x' } }],
+        },
+        { role: 'user', content: [{ type: 'tool_result', toolUseId: 'c1', content: '$420' }] },
+      ],
+    });
+
+    const sent = create.mock.calls[0][0].messages;
+    expect(sent[0]).toEqual({ role: 'system', content: 'be helpful' });
+    // assistant tool_use → tool_calls with JSON-stringified args
+    const assistant = sent.find((m: any) => m.role === 'assistant');
+    expect(assistant.tool_calls[0]).toEqual({
+      id: 'c1',
+      type: 'function',
+      function: { name: 'get_spending_summary', arguments: JSON.stringify({ from: 'x' }) },
+    });
+    // tool_result → separate `tool` message keyed by tool_call_id
+    const toolMsg = sent.find((m: any) => m.role === 'tool');
+    expect(toolMsg).toEqual({ role: 'tool', tool_call_id: 'c1', content: '$420' });
+    // tools mapped to OpenAI function shape
+    expect(create.mock.calls[0][0].tools[0]).toEqual({
+      type: 'function',
+      function: { name: 'get_spending_summary', description: 'sum', parameters: { type: 'object' } },
+    });
+  });
+});

--- a/apps/api/src/advisor/llm/anthropic.provider.ts
+++ b/apps/api/src/advisor/llm/anthropic.provider.ts
@@ -1,0 +1,103 @@
+import Anthropic from '@anthropic-ai/sdk';
+import type {
+  LlmContentBlock,
+  LlmMessage,
+  LlmProvider,
+  LlmStreamChunk,
+  LlmToolCall,
+  LlmTurnParams,
+} from './types';
+
+/** Adapter for the Anthropic Messages API (adaptive thinking, streaming tool use). */
+export class AnthropicProvider implements LlmProvider {
+  readonly id = 'anthropic' as const;
+  private readonly client: Anthropic;
+
+  constructor(apiKey: string) {
+    this.client = new Anthropic({ apiKey });
+  }
+
+  private toAnthropicMessages(messages: LlmMessage[]): Anthropic.MessageParam[] {
+    return messages.map((m) => {
+      if (typeof m.content === 'string') {
+        return { role: m.role, content: m.content };
+      }
+      const blocks = m.content.map((b): Anthropic.ContentBlockParam => {
+        switch (b.type) {
+          case 'text':
+            return { type: 'text', text: b.text };
+          case 'tool_use':
+            return { type: 'tool_use', id: b.id, name: b.name, input: b.input };
+          case 'tool_result':
+            return {
+              type: 'tool_result',
+              tool_use_id: b.toolUseId,
+              content: b.content,
+            };
+        }
+      });
+      return { role: m.role, content: blocks };
+    });
+  }
+
+  async *streamTurn(params: LlmTurnParams): AsyncIterable<LlmStreamChunk> {
+    const stream = this.client.messages.stream({
+      model: params.model,
+      max_tokens: params.maxTokens,
+      thinking: { type: 'adaptive' },
+      system: params.system,
+      tools: params.tools.map((t) => ({
+        name: t.name,
+        description: t.description,
+        input_schema: t.inputSchema as Anthropic.Tool.InputSchema,
+      })),
+      messages: this.toAnthropicMessages(params.messages),
+    });
+
+    for await (const event of stream) {
+      if (
+        event.type === 'content_block_delta' &&
+        event.delta.type === 'text_delta'
+      ) {
+        yield { type: 'text', text: event.delta.text };
+      }
+    }
+
+    const msg = await stream.finalMessage();
+    let text = '';
+    const content: LlmContentBlock[] = [];
+    const toolCalls: LlmToolCall[] = [];
+    for (const block of msg.content) {
+      if (block.type === 'text') {
+        text += block.text;
+        content.push({ type: 'text', text: block.text });
+      } else if (block.type === 'tool_use') {
+        const input = (block.input ?? {}) as Record<string, unknown>;
+        content.push({ type: 'tool_use', id: block.id, name: block.name, input });
+        toolCalls.push({ id: block.id, name: block.name, input });
+      }
+    }
+
+    yield {
+      type: 'final',
+      result: {
+        text,
+        content,
+        toolCalls,
+        stopReason: msg.stop_reason === 'tool_use' ? 'tool_use' : 'end_turn',
+        usage: {
+          inputTokens: msg.usage.input_tokens,
+          outputTokens: msg.usage.output_tokens,
+        },
+      },
+    };
+  }
+
+  async testConnection(model: string): Promise<void> {
+    await this.client.messages.create({
+      model,
+      max_tokens: 1,
+      messages: [{ role: 'user', content: 'ping' }],
+    });
+  }
+}

--- a/apps/api/src/advisor/llm/openai.provider.ts
+++ b/apps/api/src/advisor/llm/openai.provider.ts
@@ -1,0 +1,146 @@
+import OpenAI from 'openai';
+import type {
+  LlmContentBlock,
+  LlmMessage,
+  LlmProvider,
+  LlmStreamChunk,
+  LlmToolCall,
+  LlmTurnParams,
+} from './types';
+
+type ChatMessage = OpenAI.Chat.Completions.ChatCompletionMessageParam;
+
+/**
+ * Adapter for the OpenAI Chat Completions API. Translates the normalized message
+ * shape to OpenAI's (tool_use → assistant `tool_calls`, tool_result → separate
+ * `tool` messages) and reassembles the streamed tool-call argument fragments.
+ */
+export class OpenAIProvider implements LlmProvider {
+  readonly id = 'openai' as const;
+  private readonly client: OpenAI;
+
+  constructor(apiKey: string) {
+    this.client = new OpenAI({ apiKey });
+  }
+
+  private toOpenAIMessages(system: string, messages: LlmMessage[]): ChatMessage[] {
+    const out: ChatMessage[] = [{ role: 'system', content: system }];
+    for (const m of messages) {
+      if (typeof m.content === 'string') {
+        out.push({ role: m.role, content: m.content } as ChatMessage);
+        continue;
+      }
+      if (m.role === 'assistant') {
+        // Split into assistant text + tool_calls.
+        const text = m.content
+          .filter((b): b is Extract<LlmContentBlock, { type: 'text' }> => b.type === 'text')
+          .map((b) => b.text)
+          .join('');
+        const toolCalls = m.content
+          .filter(
+            (b): b is Extract<LlmContentBlock, { type: 'tool_use' }> =>
+              b.type === 'tool_use',
+          )
+          .map((b) => ({
+            id: b.id,
+            type: 'function' as const,
+            function: { name: b.name, arguments: JSON.stringify(b.input) },
+          }));
+        out.push({
+          role: 'assistant',
+          content: text || null,
+          ...(toolCalls.length ? { tool_calls: toolCalls } : {}),
+        });
+      } else {
+        // A user turn carrying tool results → one `tool` message per result.
+        for (const b of m.content) {
+          if (b.type === 'tool_result') {
+            out.push({ role: 'tool', tool_call_id: b.toolUseId, content: b.content });
+          } else if (b.type === 'text') {
+            out.push({ role: 'user', content: b.text });
+          }
+        }
+      }
+    }
+    return out;
+  }
+
+  async *streamTurn(params: LlmTurnParams): AsyncIterable<LlmStreamChunk> {
+    const stream = await this.client.chat.completions.create({
+      model: params.model,
+      max_tokens: params.maxTokens,
+      stream: true,
+      stream_options: { include_usage: true },
+      messages: this.toOpenAIMessages(params.system, params.messages),
+      tools: params.tools.map((t) => ({
+        type: 'function' as const,
+        function: {
+          name: t.name,
+          description: t.description,
+          parameters: t.inputSchema,
+        },
+      })),
+    });
+
+    let text = '';
+    let finishReason: string | null = null;
+    let usageIn = 0;
+    let usageOut = 0;
+    // Reassemble streamed tool-call fragments, keyed by their position index.
+    const acc = new Map<number, { id: string; name: string; args: string }>();
+
+    for await (const chunk of stream) {
+      const choice = chunk.choices[0];
+      if (choice?.delta?.content) {
+        text += choice.delta.content;
+        yield { type: 'text', text: choice.delta.content };
+      }
+      for (const tc of choice?.delta?.tool_calls ?? []) {
+        const cur = acc.get(tc.index) ?? { id: '', name: '', args: '' };
+        if (tc.id) cur.id = tc.id;
+        if (tc.function?.name) cur.name = tc.function.name;
+        if (tc.function?.arguments) cur.args += tc.function.arguments;
+        acc.set(tc.index, cur);
+      }
+      if (choice?.finish_reason) finishReason = choice.finish_reason;
+      if (chunk.usage) {
+        usageIn = chunk.usage.prompt_tokens ?? 0;
+        usageOut = chunk.usage.completion_tokens ?? 0;
+      }
+    }
+
+    const content: LlmContentBlock[] = [];
+    if (text) content.push({ type: 'text', text });
+    const toolCalls: LlmToolCall[] = [];
+    for (const { id, name, args } of acc.values()) {
+      if (!name) continue;
+      let input: Record<string, unknown> = {};
+      try {
+        input = args ? (JSON.parse(args) as Record<string, unknown>) : {};
+      } catch {
+        input = {};
+      }
+      content.push({ type: 'tool_use', id, name, input });
+      toolCalls.push({ id, name, input });
+    }
+
+    yield {
+      type: 'final',
+      result: {
+        text,
+        content,
+        toolCalls,
+        stopReason: finishReason === 'tool_calls' ? 'tool_use' : 'end_turn',
+        usage: { inputTokens: usageIn, outputTokens: usageOut },
+      },
+    };
+  }
+
+  async testConnection(model: string): Promise<void> {
+    await this.client.chat.completions.create({
+      model,
+      max_tokens: 1,
+      messages: [{ role: 'user', content: 'ping' }],
+    });
+  }
+}

--- a/apps/api/src/advisor/llm/provider-factory.ts
+++ b/apps/api/src/advisor/llm/provider-factory.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import type { LlmProvider, LlmProviderId } from './types';
+import { AnthropicProvider } from './anthropic.provider';
+import { OpenAIProvider } from './openai.provider';
+
+/** Constructs the right provider adapter for a resolved (provider, apiKey) pair. */
+@Injectable()
+export class LlmProviderFactory {
+  create(provider: LlmProviderId, apiKey: string): LlmProvider {
+    switch (provider) {
+      case 'anthropic':
+        return new AnthropicProvider(apiKey);
+      case 'openai':
+        return new OpenAIProvider(apiKey);
+      default:
+        throw new Error(`Unknown LLM provider: ${provider as string}`);
+    }
+  }
+}

--- a/apps/api/src/advisor/llm/types.ts
+++ b/apps/api/src/advisor/llm/types.ts
@@ -1,0 +1,75 @@
+/**
+ * Provider-agnostic LLM types. Every supported provider (Anthropic, OpenAI) is
+ * driven through this one shape so the advisor tool-use loop never has to know
+ * which vendor is behind it. Adapters translate these to/from the vendor wire
+ * format and emit the same stream chunks (`text` then a single `final`).
+ */
+
+/** A tool the model may call. `inputSchema` is JSON Schema (both vendors accept it). */
+export interface LlmTool {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+/** Normalized content blocks that make up a message in the running history. */
+export type LlmContentBlock =
+  | { type: 'text'; text: string }
+  | { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> }
+  | { type: 'tool_result'; toolUseId: string; content: string };
+
+export interface LlmMessage {
+  role: 'user' | 'assistant';
+  /** A plain string (simple turn) or a list of normalized blocks (tool turns). */
+  content: string | LlmContentBlock[];
+}
+
+/** A tool the model decided to call this turn. */
+export interface LlmToolCall {
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+export interface LlmTurnResult {
+  /** Assistant text emitted this turn (already streamed via `text` chunks). */
+  text: string;
+  /**
+   * The assistant message content to append to history before the next round —
+   * normalized text + tool_use blocks, so the loop is vendor-independent.
+   */
+  content: LlmContentBlock[];
+  toolCalls: LlmToolCall[];
+  /** Normalized: 'tool_use' when the model wants tools, else 'end_turn'. */
+  stopReason: 'tool_use' | 'end_turn';
+  usage: { inputTokens: number; outputTokens: number };
+}
+
+/** Streamed either as incremental text or a single terminal `final` result. */
+export type LlmStreamChunk =
+  | { type: 'text'; text: string }
+  | { type: 'final'; result: LlmTurnResult };
+
+export interface LlmTurnParams {
+  model: string;
+  maxTokens: number;
+  system: string;
+  tools: LlmTool[];
+  messages: LlmMessage[];
+}
+
+export type LlmProviderId = 'anthropic' | 'openai';
+
+export interface LlmProvider {
+  readonly id: LlmProviderId;
+  /** Run one model turn, streaming text then a single `final` chunk. */
+  streamTurn(params: LlmTurnParams): AsyncIterable<LlmStreamChunk>;
+  /** Cheap credential/model probe. Resolves on success, throws on failure. */
+  testConnection(model: string): Promise<void>;
+}
+
+/** Default model per provider when the user hasn't picked one. */
+export const DEFAULT_MODELS: Record<LlmProviderId, string> = {
+  anthropic: 'claude-opus-4-8',
+  openai: 'gpt-4o',
+};

--- a/apps/api/src/advisor/mcp-client.service.ts
+++ b/apps/api/src/advisor/mcp-client.service.ts
@@ -1,0 +1,142 @@
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import * as path from 'node:path';
+
+/**
+ * Tools from the MCP server that return **aggregates only** and are therefore safe
+ * to expose to the cloud model (per the AI-advisor "aggregates-only to cloud" rule,
+ * epic #36). `get_transactions` and `search_transactions` return raw transaction
+ * rows and are intentionally excluded — they stay local-only.
+ */
+export const AGGREGATE_TOOL_ALLOWLIST = new Set([
+  'get_account_balances',
+  'get_spending_summary',
+  'get_category_breakdown',
+  'get_budget_status',
+  'get_recurring_expenses',
+  'compare_periods',
+]);
+
+/** Anthropic tool definition shape (name + description + JSON schema). */
+export interface AdvisorToolDef {
+  name: string;
+  description: string;
+  input_schema: Record<string, any>;
+}
+
+/**
+ * Filter raw MCP tools down to the aggregate allowlist and map them to Anthropic tool
+ * defs. Pure + exported so the aggregates-only boundary is unit-testable without a
+ * live MCP connection.
+ */
+export function toAdvisorTools(
+  mcpTools: Array<{ name: string; description?: string; inputSchema?: unknown }>,
+): AdvisorToolDef[] {
+  return mcpTools
+    .filter((t) => AGGREGATE_TOOL_ALLOWLIST.has(t.name))
+    .map((t) => ({
+      name: t.name,
+      description: t.description ?? '',
+      input_schema: (t.inputSchema as Record<string, any>) ?? {
+        type: 'object',
+        properties: {},
+      },
+    }));
+}
+
+/**
+ * Connects to the MoneyPulse MCP server (the read-only financial semantic layer) as
+ * a client and exposes its **aggregate** tools to the advisor. One stdio connection
+ * is spawned per user and scoped via `MONEYPULSE_USER_ID`, so a tool call can never
+ * span accounts.
+ */
+@Injectable()
+export class McpClientService implements OnModuleDestroy {
+  private readonly logger = new Logger(McpClientService.name);
+  private readonly clients = new Map<string, Promise<Client>>();
+
+  constructor(private readonly config: ConfigService) {}
+
+  private serverCommand(): { command: string; args: string[] } {
+    const command = this.config.get<string>('MCP_SERVER_CMD') || 'node';
+    const rawArgs = this.config.get<string>('MCP_SERVER_ARGS');
+    if (rawArgs) {
+      return { command, args: rawArgs.split(' ').filter(Boolean) };
+    }
+    // Default: run the built MCP server over stdio. Resolvable in the monorepo and
+    // overridable via env in the deployed container.
+    const entry =
+      this.config.get<string>('MCP_SERVER_ENTRY') ||
+      path.resolve(process.cwd(), '../mcp-server/dist/index.js');
+    return { command, args: [entry, '--stdio'] };
+  }
+
+  /** Lazily spawn + connect a user-scoped MCP client, cached per user. */
+  private getClient(userId: string): Promise<Client> {
+    let existing = this.clients.get(userId);
+    if (existing) return existing;
+
+    const connect = (async () => {
+      const { command, args } = this.serverCommand();
+      const transport = new StdioClientTransport({
+        command,
+        args,
+        env: {
+          ...(process.env as Record<string, string>),
+          MONEYPULSE_USER_ID: userId,
+        },
+      });
+      const client = new Client({ name: 'moneypulse-advisor', version: '1.0.0' });
+      await client.connect(transport);
+      this.logger.log(`MCP client connected (user ${userId})`);
+      return client;
+    })();
+
+    // Cache the promise; drop it on failure so the next call retries.
+    connect.catch((err) => {
+      this.logger.error(`MCP connect failed: ${err.message}`);
+      this.clients.delete(userId);
+    });
+    this.clients.set(userId, connect);
+    return connect;
+  }
+
+  /** Aggregate MCP tools mapped to Anthropic tool definitions (row-level tools excluded). */
+  async listAdvisorTools(userId: string): Promise<AdvisorToolDef[]> {
+    const client = await this.getClient(userId);
+    const { tools } = await client.listTools();
+    return toAdvisorTools(tools);
+  }
+
+  /**
+   * Call an aggregate tool and return its text content. Rejects any name not on the
+   * allowlist — defense in depth so a hallucinated/row-level tool can never run.
+   */
+  async callTool(userId: string, name: string, args: Record<string, any>): Promise<string> {
+    if (!AGGREGATE_TOOL_ALLOWLIST.has(name)) {
+      throw new Error(`Tool "${name}" is not an allowed advisor tool.`);
+    }
+    const client = await this.getClient(userId);
+    const result: any = await client.callTool({ name, arguments: args ?? {} });
+    const blocks = Array.isArray(result?.content) ? result.content : [];
+    const text = blocks
+      .filter((b: any) => b?.type === 'text')
+      .map((b: any) => b.text)
+      .join('\n');
+    return text || '(no data)';
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    for (const [userId, p] of this.clients) {
+      try {
+        const client = await p;
+        await client.close();
+      } catch (err: any) {
+        this.logger.warn(`MCP close failed (user ${userId}): ${err.message}`);
+      }
+    }
+    this.clients.clear();
+  }
+}

--- a/apps/api/src/advisor/telegram.controller.ts
+++ b/apps/api/src/advisor/telegram.controller.ts
@@ -1,0 +1,73 @@
+import { Controller, Post, Param, Body, HttpCode } from '@nestjs/common';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { Logger } from '@nestjs/common';
+import { TelegramService } from './telegram.service';
+import { AdvisorService, ADVISOR_DISCLAIMER } from './advisor.service';
+
+/** Minimal shape of a Telegram update we care about. */
+interface TelegramUpdate {
+  message?: {
+    chat?: { id: number | string };
+    text?: string;
+  };
+}
+
+/**
+ * Public webhook for the Telegram advisor bot. Not JWT-guarded (Telegram calls it) —
+ * authorized by the path secret + chat→user allowlist. Answers are produced by the
+ * same AdvisorService as the web surface.
+ */
+@ApiTags('Advisor')
+@Controller('advisor/telegram')
+export class TelegramController {
+  private readonly logger = new Logger(TelegramController.name);
+
+  constructor(
+    private readonly telegram: TelegramService,
+    private readonly advisor: AdvisorService,
+  ) {}
+
+  @Post('webhook/:secret')
+  @HttpCode(200)
+  @ApiOperation({ summary: 'Telegram bot webhook (secret-guarded)' })
+  async webhook(
+    @Param('secret') secret: string,
+    @Body() update: TelegramUpdate,
+  ): Promise<{ ok: boolean }> {
+    // Always 200 quickly so Telegram doesn't retry; reject unauthorized silently.
+    if (!this.telegram.verifySecret(secret)) return { ok: true };
+
+    const chatId = update?.message?.chat?.id;
+    const text = update?.message?.text?.trim();
+    if (chatId == null || !text) return { ok: true };
+
+    const userId = this.telegram.resolveUser(chatId);
+    if (!userId) {
+      await this.telegram.sendMessage(chatId, 'This chat is not linked to a MoneyPulse account.');
+      return { ok: true };
+    }
+
+    // Process asynchronously — advisor calls can take several seconds; don't block
+    // the webhook response (Telegram would time out and retry).
+    void this.handle(chatId, userId, text);
+    return { ok: true };
+  }
+
+  private async handle(
+    chatId: number | string,
+    userId: string,
+    text: string,
+  ): Promise<void> {
+    await this.telegram.sendTyping(chatId);
+    try {
+      const answer = await this.advisor.chat(userId, text);
+      await this.telegram.sendMessage(chatId, `${answer}\n\n— ${ADVISOR_DISCLAIMER}`);
+    } catch (err: any) {
+      this.logger.warn(`Advisor (telegram) failed: ${err.message}`);
+      await this.telegram.sendMessage(
+        chatId,
+        "Sorry — I couldn't answer that right now.",
+      );
+    }
+  }
+}

--- a/apps/api/src/advisor/telegram.service.ts
+++ b/apps/api/src/advisor/telegram.service.ts
@@ -1,0 +1,84 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+/**
+ * Thin Telegram Bot API client + chat→user authorization for the advisor bot.
+ * Uses `fetch` (matching the app's Ollama client); no telegraf dependency.
+ */
+@Injectable()
+export class TelegramService {
+  private readonly logger = new Logger(TelegramService.name);
+  private readonly token: string | undefined;
+  private readonly chatMap: Map<string, string>;
+  private readonly defaultUserId: string | undefined;
+
+  constructor(private readonly config: ConfigService) {
+    this.token = this.config.get<string>('TELEGRAM_BOT_TOKEN');
+    this.defaultUserId = this.config.get<string>('TELEGRAM_DEFAULT_USER_ID');
+    this.chatMap = this.parseChatMap(this.config.get<string>('TELEGRAM_CHAT_MAP'));
+    if (!this.token) {
+      this.logger.warn('TELEGRAM_BOT_TOKEN not set — Telegram advisor is disabled.');
+    }
+  }
+
+  get enabled(): boolean {
+    return !!this.token;
+  }
+
+  private parseChatMap(raw?: string): Map<string, string> {
+    const map = new Map<string, string>();
+    if (!raw) return map;
+    for (const pair of raw.split(',')) {
+      const [chatId, userId] = pair.split(':').map((s) => s.trim());
+      if (chatId && userId) map.set(chatId, userId);
+    }
+    return map;
+  }
+
+  /** Verify the webhook path secret in constant time. */
+  verifySecret(provided: string): boolean {
+    const expected = this.config.get<string>('TELEGRAM_WEBHOOK_SECRET');
+    if (!expected) return false;
+    if (provided.length !== expected.length) return false;
+    let diff = 0;
+    for (let i = 0; i < expected.length; i++) {
+      diff |= provided.charCodeAt(i) ^ expected.charCodeAt(i);
+    }
+    return diff === 0;
+  }
+
+  /**
+   * Map a Telegram chat id to a MoneyPulse user id. Uses the explicit allowlist if
+   * configured; otherwise falls back to a single configured user. Returns null for
+   * unauthorized chats.
+   */
+  resolveUser(chatId: string | number): string | null {
+    const key = String(chatId);
+    if (this.chatMap.size > 0) return this.chatMap.get(key) ?? null;
+    return this.defaultUserId ?? null;
+  }
+
+  private async api(method: string, body: Record<string, unknown>): Promise<void> {
+    if (!this.token) return;
+    try {
+      const res = await fetch(`https://api.telegram.org/bot${this.token}/${method}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        this.logger.warn(`Telegram ${method} failed: ${res.status}`);
+      }
+    } catch (err: any) {
+      this.logger.warn(`Telegram ${method} error: ${err.message}`);
+    }
+  }
+
+  sendTyping(chatId: string | number): Promise<void> {
+    return this.api('sendChatAction', { chat_id: chatId, action: 'typing' });
+  }
+
+  sendMessage(chatId: string | number, text: string): Promise<void> {
+    return this.api('sendMessage', { chat_id: chatId, text });
+  }
+}

--- a/apps/api/src/ai-logs/ai-logs.service.ts
+++ b/apps/api/src/ai-logs/ai-logs.service.ts
@@ -6,7 +6,7 @@ import { encryptField, decryptField } from '../common/crypto';
 
 export interface CreateAiLogDto {
   userId?: string;
-  promptType: 'categorization' | 'pdf_parse';
+  promptType: 'categorization' | 'pdf_parse' | 'advisor';
   model: string;
   inputText: string;
   outputText?: string;

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -22,6 +22,7 @@ import { AiLogsModule } from './ai-logs/ai-logs.module';
 import { SyncModule } from './sync/sync.module';
 import { BillsModule } from './bills/bills.module';
 import { InvestmentsModule } from './investments/investments.module';
+import { AdvisorModule } from './advisor/advisor.module';
 
 @Module({
   imports: [
@@ -65,6 +66,7 @@ import { InvestmentsModule } from './investments/investments.module';
     AiLogsModule,
     BillsModule,
     InvestmentsModule,
+    AdvisorModule,
     HealthModule,
   ],
   providers: [

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -580,6 +580,20 @@ export const accountBalanceSnapshots = pgTable(
   ],
 );
 
+// ── Advisor settings (global singleton) ─────────────────────
+// One row for the whole app: which LLM provider/model backs the AI advisor and
+// the (AES-256-GCM encrypted) API key entered via the web UI. Env vars take
+// precedence over this row at resolve time; the key is never returned to clients.
+export const advisorSettings = pgTable('advisor_settings', {
+  id: integer('id').primaryKey().default(1),
+  provider: varchar('provider', { length: 20 }).notNull().default('anthropic'),
+  model: varchar('model', { length: 100 }),
+  apiKeyCiphertext: text('api_key_ciphertext'),
+  updatedAt: timestamp('updated_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
 // ── Relations ───────────────────────────────────────────────
 
 export const householdRelations = relations(households, ({ many }) => ({

--- a/apps/web/src/__tests__/mobile-nav.spec.tsx
+++ b/apps/web/src/__tests__/mobile-nav.spec.tsx
@@ -86,7 +86,7 @@ describe('MobileMoreDrawer', () => {
     }
   });
 
-  it('does NOT list tab items (Dashboard, Transactions, Bills)', () => {
+  it('does NOT list tab items (Dashboard, Transactions, Advisor, Bills)', () => {
     render(<MobileMoreDrawer onClose={vi.fn()} />);
 
     for (const item of tabItems) {
@@ -121,8 +121,13 @@ describe('MobileMoreDrawer', () => {
 });
 
 describe('navItems DRY config', () => {
-  it('tab items are Dashboard, Transactions, Bills', () => {
-    expect(tabItems.map((i) => i.label)).toEqual(['Dashboard', 'Transactions', 'Bills']);
+  it('tab items are Dashboard, Transactions, Advisor, Bills', () => {
+    expect(tabItems.map((i) => i.label)).toEqual([
+      'Dashboard',
+      'Transactions',
+      'Advisor',
+      'Bills',
+    ]);
   });
 
   it('drawer items do not include tab items', () => {

--- a/apps/web/src/app/(protected)/advisor/page.tsx
+++ b/apps/web/src/app/(protected)/advisor/page.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { Sparkles, Send, Square } from 'lucide-react';
+import { useAdvisorChat } from '@/lib/hooks/useAdvisorChat';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/api';
+
+const SUGGESTIONS = [
+  'How much did I spend on dining last month?',
+  'Am I over budget in any category?',
+  'Which subscriptions recur every month?',
+  'How did my spending change from last month?',
+];
+
+/** Ask-your-money advisor chat (Phase 1, #38). */
+export default function AdvisorPage() {
+  const { messages, isStreaming, error, send, stop } = useAdvisorChat();
+  const [input, setInput] = useState('');
+  const [status, setStatus] = useState<{ enabled: boolean; disclaimer: string } | null>(null);
+  const endRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    fetch(`${API_BASE}/advisor/status`, { credentials: 'include' })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((j) => j && setStatus(j.data))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  const submit = () => {
+    if (!input.trim() || isStreaming) return;
+    send(input);
+    setInput('');
+  };
+
+  return (
+    <div className="flex flex-col h-[calc(100vh-8rem)] max-w-3xl mx-auto">
+      <div className="flex items-center gap-2 mb-4">
+        <Sparkles className="w-6 h-6 text-[var(--primary)]" />
+        <h1 className="text-2xl font-bold">Advisor</h1>
+      </div>
+
+      {status && !status.enabled && (
+        <div className="mb-4 rounded-lg border border-[var(--border)] bg-[var(--muted)]/50 p-3 text-sm text-[var(--muted-foreground)]">
+          The advisor isn&apos;t configured yet. Set <code>ANTHROPIC_API_KEY</code> in the
+          server environment to enable it.
+        </div>
+      )}
+
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto space-y-4 pr-1">
+        {messages.length === 0 && (
+          <div className="text-sm text-[var(--muted-foreground)]">
+            <p className="mb-3">Ask about your own finances — grounded in your data.</p>
+            <div className="flex flex-wrap gap-2">
+              {SUGGESTIONS.map((s) => (
+                <button
+                  key={s}
+                  type="button"
+                  onClick={() => send(s)}
+                  disabled={isStreaming}
+                  className="rounded-full border border-[var(--border)] px-3 py-1.5 text-xs hover:bg-[var(--muted)]/50 disabled:opacity-50"
+                >
+                  {s}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {messages.map((m, i) => (
+          <div key={i} className={m.role === 'user' ? 'flex justify-end' : 'flex justify-start'}>
+            <div
+              className={`max-w-[85%] rounded-lg px-3 py-2 text-sm whitespace-pre-wrap ${
+                m.role === 'user'
+                  ? 'bg-[var(--primary)] text-[var(--primary-foreground)]'
+                  : 'bg-[var(--card)] border border-[var(--border)]'
+              }`}
+            >
+              {m.content || (isStreaming && i === messages.length - 1 ? '…' : '')}
+            </div>
+          </div>
+        ))}
+
+        {error && <p className="text-sm text-[var(--destructive)]">{error}</p>}
+        <div ref={endRef} />
+      </div>
+
+      {/* Composer */}
+      <div className="mt-4 border-t border-[var(--border)] pt-3">
+        <div className="flex gap-2">
+          <input
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                submit();
+              }
+            }}
+            placeholder="Ask about your finances…"
+            disabled={status ? !status.enabled : false}
+            className="flex-1 rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm disabled:opacity-50"
+          />
+          {isStreaming ? (
+            <button
+              type="button"
+              onClick={stop}
+              aria-label="Stop"
+              className="rounded-md bg-[var(--muted)] px-3 py-2"
+            >
+              <Square className="w-4 h-4" />
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={submit}
+              aria-label="Send"
+              disabled={!input.trim() || (status ? !status.enabled : false)}
+              className="rounded-md bg-[var(--primary)] text-[var(--primary-foreground)] px-3 py-2 disabled:opacity-50"
+            >
+              <Send className="w-4 h-4" />
+            </button>
+          )}
+        </div>
+        <p className="mt-2 text-[10px] text-[var(--muted-foreground)]">
+          {status?.disclaimer ??
+            'Informational insights based on your own data — not personalized financial advice.'}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(protected)/settings/page.tsx
+++ b/apps/web/src/app/(protected)/settings/page.tsx
@@ -4,6 +4,7 @@ import { useState, FormEvent } from 'react';
 import { useAuth } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { ThemeToggle } from '@/components/ThemeToggle';
+import { AdvisorSettingsSection } from '@/components/AdvisorSettingsSection';
 import { useSendTestNotification } from '@/lib/hooks/useNotifications';
 
 export default function SettingsPage() {
@@ -265,6 +266,9 @@ export default function SettingsPage() {
           {saving ? 'Saving...' : 'Save Settings'}
         </button>
       </form>
+
+      {/* AI Advisor (self-contained: own save/test) */}
+      <AdvisorSettingsSection />
 
       {/* Security */}
       <section className="space-y-4 rounded-2xl bg-[var(--surface-container-low)] p-6">

--- a/apps/web/src/components/AdvisorSettingsSection.tsx
+++ b/apps/web/src/components/AdvisorSettingsSection.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Sparkles } from 'lucide-react';
+import { api } from '@/lib/api';
+
+type Provider = 'anthropic' | 'openai';
+
+interface AdvisorSettingsView {
+  provider: Provider;
+  model: string;
+  enabled: boolean;
+  hasKey: boolean;
+  keySource: 'env' | 'db' | null;
+  keyMasked: string | null;
+  canStoreKey: boolean;
+  providers: Provider[];
+  defaultModels: Record<Provider, string>;
+}
+
+const PROVIDER_LABELS: Record<Provider, string> = {
+  anthropic: 'Claude (Anthropic)',
+  openai: 'OpenAI',
+};
+
+/** Global AI-advisor provider/model/key configuration (see /advisor). */
+export function AdvisorSettingsSection() {
+  const [view, setView] = useState<AdvisorSettingsView | null>(null);
+  const [provider, setProvider] = useState<Provider>('anthropic');
+  const [model, setModel] = useState('');
+  const [apiKey, setApiKey] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState('');
+
+  const load = () =>
+    api
+      .get<{ data: AdvisorSettingsView }>('/advisor/settings')
+      .then(({ data }) => {
+        setView(data);
+        setProvider(data.provider);
+        setModel(data.model);
+      })
+      .catch(() => {});
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const isError = message.toLowerCase().includes('fail') || message.includes('✗');
+
+  async function save() {
+    setBusy(true);
+    setMessage('');
+    try {
+      const { data } = await api.put<{ data: AdvisorSettingsView }>('/advisor/settings', {
+        provider,
+        model,
+        // Only send the key when the user typed a new one (write-only field).
+        ...(apiKey.trim() ? { apiKey: apiKey.trim() } : {}),
+      });
+      setView(data);
+      setApiKey('');
+      setMessage('Saved.');
+    } catch (err: any) {
+      setMessage(err.message || 'Failed to save advisor settings');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function test() {
+    setBusy(true);
+    setMessage('');
+    try {
+      const { data } = await api.post<{ data: { ok: boolean; error?: string } }>(
+        '/advisor/settings/test',
+        {
+          provider,
+          model,
+          ...(apiKey.trim() ? { apiKey: apiKey.trim() } : {}),
+        },
+      );
+      setMessage(data.ok ? '✓ Connection OK' : `✗ ${data.error ?? 'Connection failed'}`);
+    } catch (err: any) {
+      setMessage(err.message || 'Failed to test connection');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="space-y-4 rounded-2xl bg-[var(--surface-container-low)] p-6">
+      <div className="flex items-center gap-2">
+        <Sparkles className="h-5 w-5 text-[var(--primary)]" />
+        <h2 className="text-lg font-bold">AI Advisor</h2>
+      </div>
+      <p className="text-sm text-[var(--muted-foreground)]">
+        Choose the model that powers the Advisor chat. Your API key is stored encrypted and
+        never shown again. An <code>ANTHROPIC_API_KEY</code>/<code>OPENAI_API_KEY</code> set in
+        the server environment takes precedence.
+      </p>
+
+      <div>
+        <label htmlFor="advisor-provider" className="block text-sm font-semibold">
+          Provider
+        </label>
+        <select
+          id="advisor-provider"
+          value={provider}
+          onChange={(e) => {
+            const p = e.target.value as Provider;
+            setProvider(p);
+            // Offer the provider's default model as a starting point.
+            if (view) setModel(view.defaultModels[p]);
+          }}
+          className="mt-1.5 block w-full rounded-xl border border-[var(--border)] bg-[var(--card)] px-3 py-2.5 text-sm focus:border-[var(--primary)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)]/30"
+        >
+          {(view?.providers ?? (['anthropic', 'openai'] as Provider[])).map((p) => (
+            <option key={p} value={p}>
+              {PROVIDER_LABELS[p]}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="advisor-model" className="block text-sm font-semibold">
+          Model
+        </label>
+        <input
+          id="advisor-model"
+          type="text"
+          value={model}
+          onChange={(e) => setModel(e.target.value)}
+          placeholder={view?.defaultModels[provider]}
+          className="mt-1.5 block w-full rounded-xl border border-[var(--border)] bg-[var(--card)] px-3 py-2.5 text-sm font-mono placeholder:text-[var(--muted-foreground)] focus:border-[var(--primary)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)]/30"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="advisor-key" className="block text-sm font-semibold">
+          API key
+        </label>
+        <p className="mt-0.5 text-xs text-[var(--muted-foreground)]">
+          {view?.keySource === 'env'
+            ? `Using the server environment key (${view.keyMasked}). Entering one here has no effect while the env var is set.`
+            : view?.hasKey
+              ? `A key is saved (${view.keyMasked}). Enter a new one to replace it.`
+              : view?.canStoreKey === false
+                ? 'Set ENCRYPTION_KEY on the server to store a key here, or use the environment variable.'
+                : 'No key saved yet.'}
+        </p>
+        <input
+          id="advisor-key"
+          type="password"
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          placeholder={view?.hasKey ? '•••••••• (unchanged)' : 'sk-…'}
+          autoComplete="off"
+          className="mt-1.5 block w-full rounded-xl border border-[var(--border)] bg-[var(--card)] px-3 py-2.5 text-sm font-mono placeholder:text-[var(--muted-foreground)] focus:border-[var(--primary)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)]/30"
+        />
+      </div>
+
+      {message && (
+        <p
+          className={`rounded-xl px-4 py-3 text-sm font-medium ${
+            isError
+              ? 'bg-[var(--destructive)]/10 text-[var(--destructive)]'
+              : 'bg-[var(--secondary)]/10 text-[var(--secondary)]'
+          }`}
+        >
+          {message}
+        </p>
+      )}
+
+      <div className="flex flex-wrap gap-3">
+        <button
+          type="button"
+          disabled={busy}
+          onClick={save}
+          className="rounded-full bg-[var(--primary)] px-6 py-2.5 text-sm font-bold text-[var(--primary-foreground)] shadow-lg shadow-[var(--primary)]/20 transition-all hover:opacity-90 active:scale-[0.98] disabled:opacity-50"
+        >
+          {busy ? 'Working…' : 'Save advisor settings'}
+        </button>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={test}
+          className="rounded-full border border-[var(--primary)] px-5 py-2.5 text-sm font-semibold text-[var(--primary)] hover:bg-[var(--primary)] hover:text-[var(--primary-foreground)] transition-colors disabled:opacity-50"
+        >
+          Test connection
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -152,6 +152,8 @@ export const api = {
     request<T>(path, { method: 'POST', body }),
   patch: <T>(path: string, body?: unknown) =>
     request<T>(path, { method: 'PATCH', body }),
+  put: <T>(path: string, body?: unknown) =>
+    request<T>(path, { method: 'PUT', body }),
   delete: <T>(path: string) => request<T>(path, { method: 'DELETE' }),
   upload,
 };

--- a/apps/web/src/lib/hooks/useAdvisorChat.ts
+++ b/apps/web/src/lib/hooks/useAdvisorChat.ts
@@ -1,0 +1,108 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/api';
+
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+/**
+ * Streams the advisor answer over Server-Sent Events (POST /advisor/chat).
+ * EventSource can't POST or send credentials, so we read the fetch body stream
+ * and parse `data: {...}` frames ourselves.
+ */
+export function useAdvisorChat() {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const send = useCallback(
+    async (text: string) => {
+      const message = text.trim();
+      if (!message || isStreaming) return;
+
+      setError(null);
+      // History = everything so far (before this turn).
+      const history = messages;
+      setMessages((m) => [
+        ...m,
+        { role: 'user', content: message },
+        { role: 'assistant', content: '' },
+      ]);
+      setIsStreaming(true);
+
+      const appendToAssistant = (delta: string) =>
+        setMessages((m) => {
+          const next = [...m];
+          next[next.length - 1] = {
+            role: 'assistant',
+            content: next[next.length - 1].content + delta,
+          };
+          return next;
+        });
+
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      try {
+        const res = await fetch(`${API_BASE}/advisor/chat`, {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message, history }),
+          signal: controller.signal,
+        });
+
+        if (!res.ok || !res.body) {
+          throw new Error(`Advisor request failed (${res.status}).`);
+        }
+
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+
+          // Frames are separated by a blank line.
+          let sep: number;
+          while ((sep = buffer.indexOf('\n\n')) !== -1) {
+            const frame = buffer.slice(0, sep);
+            buffer = buffer.slice(sep + 2);
+            const line = frame.split('\n').find((l) => l.startsWith('data:'));
+            if (!line) continue;
+            const payload = JSON.parse(line.slice(5).trim());
+            if (payload.type === 'delta') appendToAssistant(payload.text);
+            else if (payload.type === 'error') setError(payload.text);
+          }
+        }
+      } catch (err: unknown) {
+        if ((err as Error).name !== 'AbortError') {
+          setError((err as Error).message || 'Advisor error.');
+        }
+      } finally {
+        setIsStreaming(false);
+        abortRef.current = null;
+      }
+    },
+    [messages, isStreaming],
+  );
+
+  const stop = useCallback(() => {
+    abortRef.current?.abort();
+  }, []);
+
+  const reset = useCallback(() => {
+    setMessages([]);
+    setError(null);
+  }, []);
+
+  return { messages, isStreaming, error, send, stop, reset };
+}

--- a/apps/web/src/lib/nav-items.ts
+++ b/apps/web/src/lib/nav-items.ts
@@ -13,6 +13,7 @@ import {
   Store,
   CalendarClock,
   Repeat,
+  Sparkles,
 } from 'lucide-react';
 
 export interface NavItem {
@@ -26,6 +27,7 @@ export interface NavItem {
 export const navItems: NavItem[] = [
   { href: '/', label: 'Dashboard', icon: LayoutDashboard, placement: 'tab' },
   { href: '/transactions', label: 'Transactions', icon: ArrowLeftRight, placement: 'tab' },
+  { href: '/advisor', label: 'Advisor', icon: Sparkles, placement: 'tab' },
   { href: '/bills', label: 'Bills', icon: CalendarClock, placement: 'tab' },
   // Drawer items
   { href: '/accounts', label: 'Accounts', icon: Landmark, placement: 'drawer' },

--- a/db/migrations/0007_advisor_settings.sql
+++ b/db/migrations/0007_advisor_settings.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS "advisor_settings" (
+	"id" integer PRIMARY KEY DEFAULT 1 NOT NULL,
+	"provider" varchar(20) DEFAULT 'anthropic' NOT NULL,
+	"model" varchar(100),
+	"api_key_ciphertext" text,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1781143984539,
       "tag": "0006_brainy_titanium_man",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1783200000000,
+      "tag": "0007_advisor_settings",
+      "breakpoints": true
     }
   ]
 }

--- a/docs/advisor-phase1-spec.md
+++ b/docs/advisor-phase1-spec.md
@@ -32,12 +32,20 @@ MCP tools (which compute in Postgres) and narrates their verified results.
 
 | Var | Purpose |
 |---|---|
-| `ANTHROPIC_API_KEY` | Cloud Claude (advisor). |
+| `ANTHROPIC_API_KEY` | Claude provider key. **Optional** — can instead be set via the web Settings UI (stored encrypted). Env takes precedence over the DB value. |
+| `OPENAI_API_KEY` | OpenAI provider key. Same rules as above. |
+| `ENCRYPTION_KEY` | 64-char hex (32 bytes). Reused from PII encryption; **required to store a provider key via the web UI** (AES-256-GCM at rest). |
 | `TELEGRAM_BOT_TOKEN` | Telegram bot (from @BotFather). |
 | `TELEGRAM_WEBHOOK_SECRET` | Random path secret guarding the webhook. |
 | `TELEGRAM_CHAT_MAP` | Optional `chatId:userId,…` allowlist. If unset, single-user mode maps every chat to the sole user. |
 | `MCP_SERVER_CMD` / `MCP_SERVER_ARGS` | How to spawn the MCP server over stdio (default: node on the built `apps/mcp-server`). |
-| `ADVISOR_MODEL` | Override model id (default `claude-opus-4-8`). |
+
+### Provider selection
+
+The advisor is provider-agnostic (Claude / OpenAI), selectable from **Settings → AI Advisor**
+(global, one config for the app). Provider/model/key resolve as: provider env key first,
+then the encrypted DB key. The key is write-only in the UI (shown masked, never returned).
+"Test connection" validates credentials before you rely on them.
 
 ## Architecture
 

--- a/docs/advisor-phase1-spec.md
+++ b/docs/advisor-phase1-spec.md
@@ -1,0 +1,101 @@
+# Phase 1 — Ask-your-money advisor chat (spec)
+
+Part of the AI Financial Advisor epic (#36). Implements #38. Foundation merged in #41 (MCP server).
+
+## Goal
+
+Let the user ask natural-language questions about their finances ("how much did I
+spend on dining in Q2?", "am I over budget?", "which subscriptions recur?") and get
+a **grounded, cited** answer — or an honest refusal — over two surfaces: an in-app
+web chat and a Telegram bot. Both ride one shared streaming advisor endpoint.
+
+## North star (from research)
+
+The **LLM is the interface; deterministic code is the math engine; every number is
+traceable.** The model never writes SQL and never does arithmetic — it calls the
+MCP tools (which compute in Postgres) and narrates their verified results.
+
+## Locked decisions
+
+- **Model:** `claude-opus-4-8`, adaptive thinking, **streaming**, manual tool-use loop.
+- **Data access:** MCP client (agent-native). The advisor connects to the merged
+  `@moneypulse/mcp-server` and passes its tools to Claude.
+- **Aggregates-only to cloud:** of the 8 MCP tools, only the **6 aggregate** tools are
+  exposed to the cloud model. `get_transactions` and `search_transactions` return
+  raw rows and are **excluded** — enforced by an allowlist in the MCP client service.
+- **Refuse-don't-guess:** no tool covers the question → say so; never fabricate a number.
+- **Provenance + disclaimer:** answers reference the tool data behind each figure and
+  carry a persistent "insights, not financial advice" note.
+- **Surfaces:** in-app web chat **and** Telegram bot.
+
+## Required secrets (NAS-only `.env`, user-provided)
+
+| Var | Purpose |
+|---|---|
+| `ANTHROPIC_API_KEY` | Cloud Claude (advisor). |
+| `TELEGRAM_BOT_TOKEN` | Telegram bot (from @BotFather). |
+| `TELEGRAM_WEBHOOK_SECRET` | Random path secret guarding the webhook. |
+| `TELEGRAM_CHAT_MAP` | Optional `chatId:userId,…` allowlist. If unset, single-user mode maps every chat to the sole user. |
+| `MCP_SERVER_CMD` / `MCP_SERVER_ARGS` | How to spawn the MCP server over stdio (default: node on the built `apps/mcp-server`). |
+| `ADVISOR_MODEL` | Override model id (default `claude-opus-4-8`). |
+
+## Architecture
+
+```
+Web chat  ─┐                         ┌─ MCP client (stdio) ─▶ @moneypulse/mcp-server ─▶ Postgres
+Telegram  ─┴─▶ AdvisorService ──────▶│   (6 aggregate tools only)
+                 │  Claude Opus 4.8 streaming tool-use loop
+                 │  system prompt (aggregates-only, refuse-don't-guess, provenance, not-advice)
+                 └─▶ AiLogsService (promptType 'advisor', PII flags)
+```
+
+## Backend (`apps/api/src/advisor/`)
+
+- **`mcp-client.service.ts`** — lazily connects one MCP `Client` over `StdioClientTransport`.
+  `listAdvisorTools()` returns MCP tools **filtered to the aggregate allowlist**
+  (`get_account_balances`, `get_spending_summary`, `get_category_breakdown`,
+  `get_budget_status`, `get_recurring_expenses`, `compare_periods`) mapped to Anthropic
+  tool defs. `callTool(name, args)` proxies to the server (rejects non-allowlisted names).
+  Graceful shutdown closes the transport.
+- **`advisor.service.ts`** — `streamChat(userId, message, history?)` async generator.
+  Builds the system prompt, runs the Claude streaming manual tool-use loop (append full
+  `response.content`; return all `tool_result`s in one user turn; loop to `end_turn`),
+  yields text deltas, and logs the turn to `AiLogsService`. Missing `ANTHROPIC_API_KEY`
+  → a clear, non-crashing error surfaced to the caller.
+- **`advisor.controller.ts`** — `POST /advisor/chat` (JWT-guarded) → SSE stream of
+  `{ type: 'delta'|'done'|'error', text }`. `userId` from `@CurrentUser`.
+- **`telegram.controller.ts` / `telegram.service.ts`** — `POST /advisor/telegram/webhook/:secret`.
+  Verifies the secret, maps `chat_id → userId`, sends a typing action, runs the advisor
+  (collect the stream to a final message), and replies via the Bot API (`fetch`).
+- **`advisor.module.ts`** — wires the above; imports `AiLogsModule`.
+- **`ai-logs.service.ts`** — extend `promptType` union with `'advisor'`.
+
+## Web (`apps/web/`)
+
+- `lib/hooks/useAdvisorChat.ts` — POSTs to `/advisor/chat`, reads the SSE stream, exposes
+  `messages`, `send`, `isStreaming`, `error`.
+- `app/(protected)/advisor/page.tsx` — chat panel (message list, streaming assistant
+  bubble, input, empty/error states) using the now-working design tokens (#30).
+- Sidebar entry.
+
+## Guardrails / system prompt (essentials)
+
+- Answer **only** from tool results; if no tool fits, refuse honestly.
+- **Never compute** — call a tool for every number; quote the tool's figure verbatim.
+- Attach provenance ("based on your spending summary for …").
+- Frame product/rate suggestions as options-with-tradeoffs; append the not-advice note.
+- Keep raw account numbers / statement text out of the conversation (tools return aggregates).
+
+## Testing
+
+- **Vitest (api):** advisor.service tool-loop (mocked Anthropic + mocked MCP client) —
+  grounded answer, refusal path, "narrated number == tool number", and **aggregates-only**
+  (row-level tools never offered to Claude); telegram auth mapping + secret rejection;
+  mcp-client allowlist filtering.
+- **Build gate:** `nest build` + `next build`.
+- **Live E2E is gated on the two secrets** — documented, not a CI gate.
+
+## Out of scope (later phases)
+
+Independent verifier pass (#38 follow-up), weekly digest (#39), goal planners (#40),
+voice surface. MCP compose wiring is #43.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       nodemailer:
         specifier: ^8.0.5
         version: 8.0.5
+      openai:
+        specifier: ^6.45.0
+        version: 6.45.0(zod@4.3.6)
       passport:
         specifier: ^0.7.0
         version: 0.7.0
@@ -4317,6 +4320,26 @@ packages:
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
+
+  openai@6.45.0:
+    resolution: {integrity: sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==}
+    peerDependencies:
+      '@aws-sdk/credential-provider-node': '>=3.972.0 <4'
+      '@smithy/hash-node': '>=4.3.0 <5'
+      '@smithy/signature-v4': '>=5.4.0 <6'
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-node':
+        optional: true
+      '@smithy/hash-node':
+        optional: true
+      '@smithy/signature-v4':
+        optional: true
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -9354,6 +9377,10 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
+
+  openai@6.45.0(zod@4.3.6):
+    optionalDependencies:
+      zod: 4.3.6
 
   optionator@0.9.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,12 @@ importers:
 
   apps/api:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.110.0
+        version: 0.110.0(zod@4.3.6)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.3.6)
       '@moneypulse/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -355,6 +361,15 @@ packages:
   '@angular-devkit/schematics@19.2.19':
     resolution: {integrity: sha512-J4Jarr0SohdrHcb40gTL4wGPCQ952IMWF1G/MSAQfBAPvA9ZKApYhpxcY7PmehVePve+ujpus1dGsJ7dPxz8Kg==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
+
+  '@anthropic-ai/sdk@0.110.0':
+    resolution: {integrity: sha512-hOP4bNYXDFHDxxiEgzlILXrxZIYCDnhe8sry0RDRKD/QnsEpvZcQpablCdm9X/WuD/YgOiSIkkqsL1mLLlTqJw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@asamuzakjp/css-color@5.0.1':
     resolution: {integrity: sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==}
@@ -1724,6 +1739,9 @@ packages:
 
   '@scarf/scarf@1.4.0':
     resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
+
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -3321,6 +3339,9 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
@@ -3797,6 +3818,10 @@ packages:
 
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -4804,6 +4829,9 @@ packages:
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -5001,6 +5029,9 @@ packages:
 
   traverse@0.3.9:
     resolution: {integrity: sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -5469,6 +5500,13 @@ snapshots:
       rxjs: 7.8.1
     transitivePeerDependencies:
       - chokidar
+
+  '@anthropic-ai/sdk@0.110.0(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 4.3.6
 
   '@asamuzakjp/css-color@5.0.1':
     dependencies:
@@ -6190,6 +6228,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.27)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.27
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
+
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     optional: true
 
@@ -6569,6 +6629,8 @@ snapshots:
   '@rtsao/scc@1.1.0': {}
 
   '@scarf/scarf@1.4.0': {}
+
+  '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -8326,6 +8388,8 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-uri@3.1.2: {}
 
   fastq@1.20.1:
@@ -8844,6 +8908,11 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-parse-even-better-errors@2.3.1: {}
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}
 
@@ -9893,6 +9962,11 @@ snapshots:
 
   standard-as-callback@2.1.0: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   statuses@2.0.2: {}
 
   std-env@4.0.0: {}
@@ -10107,6 +10181,8 @@ snapshots:
       punycode: 2.3.1
 
   traverse@0.3.9: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
@@ -10514,6 +10590,10 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
+
+  zod-to-json-schema@3.25.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
 
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:

--- a/tasks.md
+++ b/tasks.md
@@ -1,0 +1,38 @@
+# MoneyPulse — Roadmap & Tasks
+
+Living index of in-flight work. GitHub issues are the source of truth; this is the map.
+
+## 🚀 Epic: AI Financial Advisor (#36)
+
+Private, self-hosted advisor over real finances. **LLM is the interface; deterministic code is the math engine; every number is traceable.** Aggregates-only leave the NAS.
+
+| Phase | Issue | Status |
+|---|---|---|
+| Phase 0 — MCP server (semantic layer, 8 user-scoped tools) | #37 | ✅ Merged (#41) |
+| Phase 1 — Ask-your-money NL chat (MVP) | #38 | 🔜 In progress |
+| Phase 2 — Weekly digest (proactive) | #39 | ⏳ Planned |
+| Phase 3 — Goal planners (car / college / safe-to-spend) | #40 | ⏳ Planned |
+
+**Deferred / later:** real-time nudges, in-app insights feed, draft-actions-to-approve, mortgage & insurance modules.
+
+### Supporting tasks
+| Task | Issue | Status |
+|---|---|---|
+| Wire MCP server into NAS docker-compose | #43 | ⏳ Open |
+| Triage leftover sync-status/transactions branch | #42 | ⏳ Open |
+
+### Locked design decisions
+- Cloud Claude (`claude-opus-4-8`) for reasoning; **aggregates only** to cloud (raw statements/account numbers stay on NAS).
+- MCP tools = semantic layer; **refuse-don't-guess**, never free-form SQL, LLM never does arithmetic.
+- Provenance on every number; independent verifier pass; "insights, not advice" framing.
+- External data via free APIs (FRED, BLS CE); recurrence = merchant-group + modal-interval + tolerance + jitter (≥3).
+
+## ✅ Recently shipped (notification thread)
+- #28 — notification dropdown opaque/readable
+- #30 — Tailwind v4 `@theme` design tokens (fixed app-wide `bg-card` no-op)
+- #32 — statistical spending-anomaly baselines (cut false positives)
+- #34 — notification center v2 (dismiss, grouping, severity, timestamps)
+
+## Backlog (unscheduled)
+- #22 — Year-over-Year comparison
+- #27 — Dependabot deps bump


### PR DESCRIPTION
Part of #38. Closes #44, #45, #46.

The first pillar of the AI Financial Advisor: a chat that answers questions **grounded strictly in the user's own data**, served from the phase7 MCP server (#41).

## What's included
- **AdvisorService** — Anthropic tool-use loop (`claude-opus-4-8`, adaptive thinking, streaming via `.finalMessage()`). System prompt rules: every number must come from a tool, never compute, cite provenance, refuse honestly when no tool fits. Each turn logged to AiLogs (`promptType: 'advisor'`) with token usage.
- **McpClientService** — per-user stdio MCP client. `AGGREGATE_TOOL_ALLOWLIST` (6 of 8 tools) is the **aggregates-only-to-cloud** enforcement point: `get_transactions`/`search_transactions` are never offered to Claude, and `callTool()` throws for non-allowlisted names as defense-in-depth.
- **AdvisorController** — JWT-guarded `GET /advisor/status` + SSE `POST /advisor/chat`.
- **Telegram** — `TelegramService` (constant-time webhook-secret check, chat-id→user allowlist, single-default fallback) + public webhook controller that returns 200 fast and processes async.
- **Web** — `/advisor` chat page + `useAdvisorChat` SSE hook (fetch + ReadableStream; EventSource can't POST with credentials). New Advisor nav tab.

## Privacy boundary
Raw transaction text / account numbers never leave the NAS — only derived aggregates reach Claude. Enforced at the allowlist and re-checked in `callTool()`.

## Required secrets (NAS `.env`, not in git)
- `ANTHROPIC_API_KEY` — enables the advisor (absent ⇒ `/advisor/status` reports disabled, UI shows a config hint).
- `TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET`, and `TELEGRAM_CHAT_MAP` (or `TELEGRAM_DEFAULT_USER_ID`) — enable the Telegram surface. Webhook set via `setWebhook` to `/api/advisor/telegram/webhook/<secret>`.

## Test plan
- Advisor/MCP/Telegram unit specs — 13/13 pass.
- Full API suite — 425/426 (the one failure is the pre-existing forecast tz bug, fixed by #48).
- Full web suite — 64/64 (nav test updated for the new tab).
- `pnpm build` — API + web both clean; `/advisor` route present.

Depends on #48 (forecast tz fix) for a fully-green API suite on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)