### PR TITLE
fix(migrations): idempotent 0002/0003/0006 + advisor prompt type

### DIFF
--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -461,6 +461,7 @@ export const investmentSnapshots = pgTable('investment_snapshots', {
 export const aiPromptTypeEnum = pgEnum('ai_prompt_type', [
   'categorization',
   'pdf_parse',
+  'advisor',
 ]);
 
 export const aiPromptLogs = pgTable(

--- a/db/migrations/0002_messy_trish_tilby.sql
+++ b/db/migrations/0002_messy_trish_tilby.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "notifications" ADD COLUMN "metadata" jsonb;
+ALTER TABLE "notifications" ADD COLUMN IF NOT EXISTS "metadata" jsonb;

--- a/db/migrations/0003_furry_talisman.sql
+++ b/db/migrations/0003_furry_talisman.sql
@@ -1,5 +1,7 @@
-CREATE TYPE "public"."ai_prompt_type" AS ENUM('categorization', 'pdf_parse');--> statement-breakpoint
-CREATE TABLE "ai_prompt_logs" (
+DO $$ BEGIN
+ CREATE TYPE "public"."ai_prompt_type" AS ENUM('categorization', 'pdf_parse');
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "ai_prompt_logs" (
 	"id" bigserial PRIMARY KEY NOT NULL,
 	"user_id" uuid,
 	"prompt_type" "ai_prompt_type" NOT NULL,
@@ -17,7 +19,7 @@ CREATE TABLE "ai_prompt_logs" (
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
-CREATE TABLE "outbox_events" (
+CREATE TABLE IF NOT EXISTS "outbox_events" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"event_type" varchar(80) NOT NULL,
 	"aggregate_type" varchar(80) NOT NULL,
@@ -42,7 +44,7 @@ CREATE TABLE "outbox_events" (
 	CONSTRAINT "outbox_events_idempotency_key_unique" UNIQUE("idempotency_key")
 );
 --> statement-breakpoint
-CREATE TABLE "sync_audit_logs" (
+CREATE TABLE IF NOT EXISTS "sync_audit_logs" (
 	"id" bigserial PRIMARY KEY NOT NULL,
 	"outbox_event_id" uuid NOT NULL,
 	"user_id" uuid,
@@ -58,16 +60,26 @@ CREATE TABLE "sync_audit_logs" (
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
-ALTER TABLE "ai_prompt_logs" ADD CONSTRAINT "ai_prompt_logs_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "outbox_events" ADD CONSTRAINT "outbox_events_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "outbox_events" ADD CONSTRAINT "outbox_events_household_id_households_id_fk" FOREIGN KEY ("household_id") REFERENCES "public"."households"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "sync_audit_logs" ADD CONSTRAINT "sync_audit_logs_outbox_event_id_outbox_events_id_fk" FOREIGN KEY ("outbox_event_id") REFERENCES "public"."outbox_events"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "sync_audit_logs" ADD CONSTRAINT "sync_audit_logs_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-CREATE INDEX "idx_ai_log_user" ON "ai_prompt_logs" USING btree ("user_id");--> statement-breakpoint
-CREATE INDEX "idx_ai_log_type" ON "ai_prompt_logs" USING btree ("prompt_type");--> statement-breakpoint
-CREATE INDEX "idx_ai_log_created" ON "ai_prompt_logs" USING btree ("created_at");--> statement-breakpoint
-CREATE INDEX "idx_outbox_status_next_attempt" ON "outbox_events" USING btree ("status","next_attempt_at");--> statement-breakpoint
-CREATE INDEX "idx_outbox_user_created" ON "outbox_events" USING btree ("user_id","created_at");--> statement-breakpoint
-CREATE INDEX "idx_outbox_aggregate" ON "outbox_events" USING btree ("aggregate_type","aggregate_id");--> statement-breakpoint
-CREATE INDEX "idx_sync_audit_outbox" ON "sync_audit_logs" USING btree ("outbox_event_id");--> statement-breakpoint
-CREATE INDEX "idx_sync_audit_created" ON "sync_audit_logs" USING btree ("created_at");
+DO $$ BEGIN
+ ALTER TABLE "ai_prompt_logs" ADD CONSTRAINT "ai_prompt_logs_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "outbox_events" ADD CONSTRAINT "outbox_events_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "outbox_events" ADD CONSTRAINT "outbox_events_household_id_households_id_fk" FOREIGN KEY ("household_id") REFERENCES "public"."households"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "sync_audit_logs" ADD CONSTRAINT "sync_audit_logs_outbox_event_id_outbox_events_id_fk" FOREIGN KEY ("outbox_event_id") REFERENCES "public"."outbox_events"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "sync_audit_logs" ADD CONSTRAINT "sync_audit_logs_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_ai_log_user" ON "ai_prompt_logs" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_ai_log_type" ON "ai_prompt_logs" USING btree ("prompt_type");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_ai_log_created" ON "ai_prompt_logs" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_outbox_status_next_attempt" ON "outbox_events" USING btree ("status","next_attempt_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_outbox_user_created" ON "outbox_events" USING btree ("user_id","created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_outbox_aggregate" ON "outbox_events" USING btree ("aggregate_type","aggregate_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_sync_audit_outbox" ON "sync_audit_logs" USING btree ("outbox_event_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_sync_audit_created" ON "sync_audit_logs" USING btree ("created_at");

--- a/db/migrations/0006_brainy_titanium_man.sql
+++ b/db/migrations/0006_brainy_titanium_man.sql
@@ -53,12 +53,24 @@ ALTER TABLE "transactions" ADD COLUMN IF NOT EXISTS "currency_code" varchar(3);-
 ALTER TABLE "user_settings" ADD COLUMN IF NOT EXISTS "daily_digest_enabled" boolean DEFAULT false NOT NULL;--> statement-breakpoint
 ALTER TABLE "user_settings" ADD COLUMN IF NOT EXISTS "monthly_digest_enabled" boolean DEFAULT false NOT NULL;--> statement-breakpoint
 ALTER TABLE "user_settings" ADD COLUMN IF NOT EXISTS "firebase_uid" varchar(128);--> statement-breakpoint
-ALTER TABLE "account_balance_snapshots" ADD CONSTRAINT "account_balance_snapshots_account_id_accounts_id_fk" FOREIGN KEY ("account_id") REFERENCES "public"."accounts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "merchant_aliases" ADD CONSTRAINT "merchant_aliases_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "recurring_bills" ADD CONSTRAINT "recurring_bills_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "recurring_bills" ADD CONSTRAINT "recurring_bills_category_id_categories_id_fk" FOREIGN KEY ("category_id") REFERENCES "public"."categories"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "transaction_attachments" ADD CONSTRAINT "transaction_attachments_transaction_id_transactions_id_fk" FOREIGN KEY ("transaction_id") REFERENCES "public"."transactions"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-ALTER TABLE "transaction_attachments" ADD CONSTRAINT "transaction_attachments_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "account_balance_snapshots" ADD CONSTRAINT "account_balance_snapshots_account_id_accounts_id_fk" FOREIGN KEY ("account_id") REFERENCES "public"."accounts"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "merchant_aliases" ADD CONSTRAINT "merchant_aliases_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "recurring_bills" ADD CONSTRAINT "recurring_bills_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "recurring_bills" ADD CONSTRAINT "recurring_bills_category_id_categories_id_fk" FOREIGN KEY ("category_id") REFERENCES "public"."categories"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "transaction_attachments" ADD CONSTRAINT "transaction_attachments_transaction_id_transactions_id_fk" FOREIGN KEY ("transaction_id") REFERENCES "public"."transactions"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "transaction_attachments" ADD CONSTRAINT "transaction_attachments_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_snapshot_account" ON "account_balance_snapshots" USING btree ("account_id","snapshot_date");--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "idx_merchant_alias_user" ON "merchant_aliases" USING btree ("user_id");--> statement-breakpoint
 CREATE UNIQUE INDEX IF NOT EXISTS "uq_bills_user_merchant" ON "recurring_bills" USING btree ("user_id","merchant_pattern");--> statement-breakpoint

--- a/db/migrations/0008_advisor_prompt_type.sql
+++ b/db/migrations/0008_advisor_prompt_type.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."ai_prompt_type" ADD VALUE IF NOT EXISTS 'advisor';

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1783200000000,
       "tag": "0007_advisor_settings",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1783200100000,
+      "tag": "0008_advisor_prompt_type",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Unblocks `db:migrate` on the NAS, which has been failing due to pre-existing migration drift (discovered while deploying the advisor, #49).

## Root cause
Drizzle's `__drizzle_migrations` on the NAS only recorded **0000–0001**, but the schema was actually built up to ~0006 by other means (drizzle push / partial runs). The migrator's run decision is **timestamp-based** (`last recorded created_at < migration.folderMillis`), so it replays every migration after 0001 **in a single transaction**. Non-idempotent statements (`ADD COLUMN`, `CREATE TABLE`, `ADD CONSTRAINT` on already-existing objects) abort the whole run — so **every** deploy's migrate step failed, and `advisor_settings` (0007) never got created. Two legacy tables (`ai_prompt_logs`, `account_balance_snapshots`) had also gone missing.

## Fix
- **0002** — `ADD COLUMN IF NOT EXISTS`.
- **0003** — `CREATE TYPE` guarded (DO/duplicate_object), `CREATE TABLE IF NOT EXISTS`, `ADD CONSTRAINT` guarded, `CREATE INDEX IF NOT EXISTS`.
- **0006** — guard the six `ADD CONSTRAINT` statements.
- **0008** (new) — `ALTER TYPE ai_prompt_type ADD VALUE IF NOT EXISTS 'advisor'` + `schema.ts` enum, so advisor turns can be logged (I'd added `'advisor'` to the TS union but not the DB enum).

## Safety
Editing historical migration files is safe: the run decision is timestamp-based, not per-hash, so already-migrated environments skip 0002–0006 regardless of content. The replay is one transaction — any failure rolls back cleanly with no partial state. Replaying the idempotent 0002–0006 then applying 0007/0008 brings the NAS to the correct schema and records all hashes, so future `db:migrate` runs are clean.

## Test plan
- CI unit tests + build (schema.ts enum change).
- Applied via `./deploy-to-nas.sh db:migrate` against the NAS (transactional) — verified `advisor_settings`, `ai_prompt_logs`, `account_balance_snapshots` exist and the migrations table is fully recorded afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)