### PR TITLE
feat(advisor): Phase 2 — proactive weekly digest (#39)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,25 @@ OLLAMA_MODEL=mistral:7b
 # OLLAMA_HEALTH_CACHE_TTL_MS=30000
 # OLLAMA_PROBE_TIMEOUT_MS=2000
 
+# ── AI Advisor — cloud LLM (Phase 1/2) ───────────────────
+# Powers the ask-your-money chat and the proactive weekly digest.
+# Provider + model are chosen in the web app (Settings → AI Advisor); the key
+# can be stored encrypted in the DB there instead of here. If set, the matching
+# env var below TAKES PRECEDENCE over the DB-stored key. Leave blank to rely on
+# the web-app key. Only aggregates ever reach the provider — raw transactions stay local.
+# ANTHROPIC_API_KEY=
+# OPENAI_API_KEY=
+
+# ── AI Advisor — Telegram surface (optional) ─────────────
+# Enables the advisor over Telegram. All optional.
+# TELEGRAM_BOT_TOKEN=
+# Secret path segment validated on the inbound webhook.
+# TELEGRAM_WEBHOOK_SECRET=
+# Maps Telegram chat IDs → MoneyPulse user IDs, e.g. 123456789:uuid,987654321:uuid
+# TELEGRAM_CHAT_MAP=
+# Fallback user id for unmapped chats (single-user setups).
+# TELEGRAM_DEFAULT_USER_ID=
+
 # ── PDF Parser ────────────────────────────────────────────
 PDF_PARSER_URL=http://localhost:5000
 

--- a/apps/api/src/advisor/advisor.module.ts
+++ b/apps/api/src/advisor/advisor.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { AiLogsModule } from '../ai-logs/ai-logs.module';
+import { NotificationsModule } from '../notifications/notifications.module';
 import { McpClientService } from './mcp-client.service';
 import { AdvisorService } from './advisor.service';
 import { AdvisorController } from './advisor.controller';
@@ -7,17 +8,21 @@ import { AdvisorSettingsService } from './advisor-settings.service';
 import { LlmProviderFactory } from './llm/provider-factory';
 import { TelegramService } from './telegram.service';
 import { TelegramController } from './telegram.controller';
+import { DigestSignalsService } from './digest/digest-signals.service';
+import { AdvisorDigestService } from './digest/advisor-digest.service';
 
 @Module({
-  imports: [AiLogsModule],
+  imports: [AiLogsModule, NotificationsModule],
   providers: [
     McpClientService,
     AdvisorService,
     AdvisorSettingsService,
     LlmProviderFactory,
     TelegramService,
+    DigestSignalsService,
+    AdvisorDigestService,
   ],
   controllers: [AdvisorController, TelegramController],
-  exports: [AdvisorService],
+  exports: [AdvisorService, AdvisorDigestService],
 })
 export class AdvisorModule {}

--- a/apps/api/src/advisor/digest/__tests__/advisor-digest.service.spec.ts
+++ b/apps/api/src/advisor/digest/__tests__/advisor-digest.service.spec.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AdvisorDigestService } from '../advisor-digest.service';
+import type { DigestSignal } from '../types';
+import type { LlmStreamChunk, LlmTurnResult } from '../../llm/types';
+
+function turn(text: string, final?: Partial<LlmTurnResult>): AsyncIterable<LlmStreamChunk> {
+  const result: LlmTurnResult = {
+    text,
+    content: [{ type: 'text', text }],
+    toolCalls: [],
+    stopReason: 'end_turn',
+    usage: { inputTokens: 30, outputTokens: 10 },
+    ...final,
+  };
+  return {
+    async *[Symbol.asyncIterator]() {
+      if (text) yield { type: 'text', text };
+      yield { type: 'final', result };
+    },
+  };
+}
+
+const SIGNALS: DigestSignal[] = [
+  {
+    kind: 'top_driver',
+    label: 'Top spend: Rent',
+    amountCents: 50000,
+    detail: 'Rent was your biggest category last week at $500.00.',
+    provenance: 'category spending totals for last week',
+  },
+  {
+    kind: 'category_delta',
+    label: 'Dining up week-over-week',
+    amountCents: 15000,
+    detail: 'Dining spending was $400.00 last week vs $250.00 the week before — up $150.00.',
+    provenance: 'category spending, last week vs the week before',
+  },
+];
+
+function build(opts: { signals?: DigestSignal[]; resolved?: any; narration?: string } = {}) {
+  const resolved =
+    'resolved' in opts
+      ? opts.resolved
+      : { provider: 'anthropic', model: 'claude-opus-4-8', apiKey: 'sk-test' };
+
+  const signals = { gather: vi.fn().mockResolvedValue(opts.signals ?? SIGNALS) };
+  const settings = { resolve: vi.fn().mockResolvedValue(resolved) };
+
+  const turnParams: any[] = [];
+  const provider = {
+    id: 'anthropic',
+    streamTurn: vi.fn((p: any) => {
+      turnParams.push(p);
+      return turn(opts.narration ?? '- Rent was your biggest category last week at $500.00.');
+    }),
+    testConnection: vi.fn(),
+  };
+  const factory = { create: vi.fn().mockReturnValue(provider) };
+
+  const notifications = {
+    findByMetadata: vi.fn().mockResolvedValue(false),
+    createAndDispatch: vi.fn().mockResolvedValue(undefined),
+  };
+  const aiLogs = { create: vi.fn().mockResolvedValue(undefined) };
+
+  // db is only used by deliverAllEnabled's select chain
+  const rowsToReturn: any[] = [];
+  const db = {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue(rowsToReturn),
+        }),
+      }),
+    }),
+    _rows: rowsToReturn,
+  };
+
+  const service = new AdvisorDigestService(
+    db as any,
+    signals as any,
+    settings as any,
+    factory as any,
+    notifications as any,
+    aiLogs as any,
+  );
+  return { service, signals, settings, provider, factory, notifications, aiLogs, db, turnParams };
+}
+
+describe('AdvisorDigestService.buildDigest', () => {
+  it('returns null when there are no signals (no LLM call)', async () => {
+    const c = build({ signals: [] });
+    const digest = await c.service.buildDigest('u1');
+    expect(digest).toBeNull();
+    expect(c.provider.streamTurn).not.toHaveBeenCalled();
+  });
+
+  it('narrates with no tools and grounds the voice summary in the top signal', async () => {
+    const c = build();
+    const digest = await c.service.buildDigest('u1', 'America/New_York');
+
+    expect(digest).not.toBeNull();
+    expect(digest!.title).toBe('Weekly Money Recap');
+    expect(digest!.message).toContain('$500.00');
+    // Voice summary is deterministic from the highest-dollar signal
+    expect(digest!.voiceSummary).toContain('Rent was your biggest category');
+
+    // Batch narration must send NO tools (aggregates-only, single turn)
+    expect(c.turnParams[0].tools).toEqual([]);
+    // Only pre-computed detail/provenance reach the model — no raw fields
+    const userMsg = c.turnParams[0].messages[0].content as string;
+    expect(userMsg).toContain('Rent was your biggest category last week at $500.00.');
+    expect(userMsg).not.toContain('amountCents');
+
+    // Logged as an advisor turn
+    expect(c.aiLogs.create).toHaveBeenCalledTimes(1);
+    expect(c.aiLogs.create.mock.calls[0][0].promptType).toBe('advisor');
+  });
+
+  it('falls back to a deterministic bullet list if the model returns no text', async () => {
+    const c = build({ narration: '' });
+    const digest = await c.service.buildDigest('u1');
+    expect(digest!.message).toBe(
+      '- Rent was your biggest category last week at $500.00.\n' +
+        '- Dining spending was $400.00 last week vs $250.00 the week before — up $150.00.',
+    );
+  });
+
+  it('throws if signals exist but the advisor is unconfigured', async () => {
+    const c = build({ resolved: null });
+    await expect(c.service.buildDigest('u1')).rejects.toThrow(/not configured/);
+  });
+});
+
+describe('AdvisorDigestService.deliver', () => {
+  it('dispatches an advisor_digest notification with a weekly dedupe key', async () => {
+    const c = build();
+    const sent = await c.service.deliver('u1', 'America/New_York');
+
+    expect(sent).toBe(true);
+    expect(c.notifications.createAndDispatch).toHaveBeenCalledTimes(1);
+    const arg = c.notifications.createAndDispatch.mock.calls[0][0];
+    expect(arg.type).toBe('advisor_digest');
+    expect(arg.dedupeKey).toMatch(/^advisor_digest_weekly_u1_\d{4}-W\d{2}$/);
+    expect(arg.voiceSummary).toContain('weekly money recap');
+    expect(arg.metadata.signals).toHaveLength(2);
+  });
+
+  it('is idempotent — skips when this week already went out', async () => {
+    const c = build();
+    c.notifications.findByMetadata.mockResolvedValue(true);
+    const sent = await c.service.deliver('u1', 'America/New_York');
+    expect(sent).toBe(false);
+    expect(c.notifications.createAndDispatch).not.toHaveBeenCalled();
+  });
+});
+
+describe('AdvisorDigestService.deliverAllEnabled', () => {
+  it('skips the whole sweep when the advisor is not configured', async () => {
+    const c = build({ resolved: null });
+    await c.service.deliverAllEnabled();
+    expect(c.db.select).not.toHaveBeenCalled();
+  });
+
+  it('delivers to each opted-in user', async () => {
+    const c = build();
+    c.db._rows.push(
+      { userId: 'u1', timezone: 'America/New_York' },
+      { userId: 'u2', timezone: 'Europe/London' },
+    );
+    const spy = vi.spyOn(c.service, 'deliver').mockResolvedValue(true);
+    await c.service.deliverAllEnabled();
+    expect(spy).toHaveBeenCalledWith('u1', 'America/New_York');
+    expect(spy).toHaveBeenCalledWith('u2', 'Europe/London');
+  });
+});

--- a/apps/api/src/advisor/digest/__tests__/digest-signals.service.spec.ts
+++ b/apps/api/src/advisor/digest/__tests__/digest-signals.service.spec.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from 'vitest';
+import { DigestSignalsService, localWeekWindows } from '../digest-signals.service';
+
+/**
+ * `gather` fires its five queries via Promise.all; each async method calls
+ * `db.execute` synchronously up to its first await, so the calls resolve in
+ * array order: categoryDeltas, topDrivers, upcomingBills, subscriptionChanges,
+ * recentAnomalies. We queue results in that order.
+ */
+function buildDb(results: Array<{ rows: any[] }>) {
+  const execute = vi.fn();
+  for (const r of results) execute.mockResolvedValueOnce(r);
+  return { execute };
+}
+
+describe('DigestSignalsService.gather', () => {
+  it('ranks candidates by dollar magnitude, drops sub-threshold category moves, formats dollars', async () => {
+    const db = buildDb([
+      // categoryDeltas: one big move ($150 up), one tiny ($5) that must be filtered out
+      {
+        rows: [
+          { category_name: 'Dining', recap_total: 40000, prior_total: 25000, delta: 15000 },
+          { category_name: 'Coffee', recap_total: 1200, prior_total: 700, delta: 500 },
+        ],
+      },
+      // topDrivers: biggest category
+      { rows: [{ category_name: 'Rent', total: 50000 }] },
+      // upcomingBills
+      {
+        rows: [
+          {
+            normalized_name: 'Electric',
+            expected_amount_cents: 20000,
+            next_expected_date: '2026-07-08T00:00:00Z',
+          },
+        ],
+      },
+      // subscriptionChanges
+      {
+        rows: [
+          {
+            normalized_name: 'Streaming+',
+            expected_amount_cents: 1500,
+            last_amount_cents: 4500,
+            amount_tolerance_percent: 15,
+          },
+        ],
+      },
+      // recentAnomalies
+      { rows: [{ message: 'Large purchase: $80.00 at Store.', metadata: { amountCents: 8000 } }] },
+    ]);
+
+    const service = new DigestSignalsService(db as any);
+    const signals = await service.gather('u1', 'America/New_York');
+
+    // Ranked strictly by amountCents desc: Rent 50000, Electric 20000, Dining 15000, anomaly 8000, sub 3000
+    expect(signals.map((s) => s.amountCents)).toEqual([50000, 20000, 15000, 8000, 3000]);
+    expect(signals[0].kind).toBe('top_driver');
+
+    // Sub-threshold ($5) category move was filtered out
+    expect(signals.some((s) => s.label.includes('Coffee'))).toBe(false);
+
+    // Deltas carry both figures and direction, formatted as dollars
+    const dining = signals.find((s) => s.kind === 'category_delta')!;
+    expect(dining.detail).toContain('$400.00');
+    expect(dining.detail).toContain('$250.00');
+    expect(dining.detail).toContain('up $150.00');
+
+    // Subscription change surfaces the increase
+    const sub = signals.find((s) => s.kind === 'subscription_change')!;
+    expect(sub.detail).toContain('$45.00');
+    expect(sub.detail).toContain('$15.00');
+
+    // Anomaly reuses the engine's message verbatim
+    const anomaly = signals.find((s) => s.kind === 'anomaly')!;
+    expect(anomaly.detail).toBe('Large purchase: $80.00 at Store.');
+  });
+
+  it('returns an empty list when there is nothing to report', async () => {
+    const db = buildDb([{ rows: [] }, { rows: [] }, { rows: [] }, { rows: [] }, { rows: [] }]);
+    const service = new DigestSignalsService(db as any);
+    expect(await service.gather('u1')).toEqual([]);
+  });
+});
+
+describe('localWeekWindows', () => {
+  it('yields the last completed Mon–Sun week and the week before it', () => {
+    // Wed 2026-07-08 local → recap = Mon 06-29..Sun 07-05, prior = Mon 06-22..Sun 06-28
+    const now = new Date('2026-07-08T12:00:00-04:00');
+    const w = localWeekWindows('America/New_York', now);
+    expect(w.recapStart).toBe('2026-06-29');
+    expect(w.recapEnd).toBe('2026-07-06'); // exclusive (Mon of current week)
+    expect(w.priorStart).toBe('2026-06-22');
+    expect(w.priorEnd).toBe('2026-06-29'); // exclusive
+  });
+});

--- a/apps/api/src/advisor/digest/advisor-digest.service.ts
+++ b/apps/api/src/advisor/digest/advisor-digest.service.ts
@@ -1,0 +1,202 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { eq } from 'drizzle-orm';
+import { DATABASE_CONNECTION } from '../../db/db.module';
+import * as schema from '../../db/schema';
+import { NotificationsService } from '../../notifications/notifications.service';
+import { AiLogsService } from '../../ai-logs/ai-logs.service';
+import { AdvisorSettingsService } from '../advisor-settings.service';
+import { LlmProviderFactory } from '../llm/provider-factory';
+import type { LlmTurnResult } from '../llm/types';
+import { DigestSignalsService } from './digest-signals.service';
+import type { AdvisorDigest, DigestSignal } from './types';
+
+const MAX_TOKENS = 1024;
+const DIGEST_TITLE = 'Weekly Money Recap';
+
+/** ISO-week key (e.g. 2026-W27) in the user's timezone, for once-a-week dedupe. */
+function isoWeekKey(timezone: string, now = new Date()): string {
+  const d = new Date(now.toLocaleString('en-US', { timeZone: timezone }));
+  d.setHours(0, 0, 0, 0);
+  const dayOfWeek = (d.getDay() + 6) % 7; // Mon=0
+  const thursday = new Date(d);
+  thursday.setDate(d.getDate() - dayOfWeek + 3);
+  const firstThursday = new Date(thursday.getFullYear(), 0, 4);
+  const weekNum =
+    1 + Math.round((thursday.getTime() - firstThursday.getTime()) / 604800000);
+  return `${thursday.getFullYear()}-W${String(weekNum).padStart(2, '0')}`;
+}
+
+const DIGEST_SYSTEM_PROMPT = `You are MoneyPulse's weekly money digest writer. You receive a JSON array of PRE-COMPUTED, verified signals about the user's finances over the past week. Each signal has a "detail" sentence that already contains the exact dollar figures.
+
+Write a short weekly recap:
+- Select only the 3–5 MOST important signals (biggest dollar impact / most actionable). Ignore the rest.
+- Order them most-important first, as a markdown bullet list ("- " per line).
+- For each, write ONE tight sentence, leading with what happened and the dollar figure.
+- Use ONLY numbers that appear in the signals' "detail" text. Never invent, add, recompute, or total figures. If a number isn't in the signals, don't state it.
+- Neutral, informational tone — surface facts and gentle observations, not directives or advice.
+- No preamble, no heading, no closing paragraph. Just the bullet list.`;
+
+/**
+ * Builds and delivers the proactive weekly advisor digest.
+ *
+ * Pipeline: deterministic signals (the math engine) → cloud LLM ranks & narrates the
+ * top 3–5 (never inventing numbers) → delivered through the notification + Home Assistant
+ * pipeline, deduped once per ISO week. Only aggregate figures reach the model.
+ */
+@Injectable()
+export class AdvisorDigestService {
+  private readonly logger = new Logger(AdvisorDigestService.name);
+
+  constructor(
+    @Inject(DATABASE_CONNECTION) private readonly db: any,
+    private readonly signals: DigestSignalsService,
+    private readonly settings: AdvisorSettingsService,
+    private readonly factory: LlmProviderFactory,
+    private readonly notifications: NotificationsService,
+    private readonly aiLogs: AiLogsService,
+  ) {}
+
+  /**
+   * Assemble the digest for a user. Gathers signals, then narrates the top few via the
+   * configured provider. Returns `null` if there's nothing worth sending this week.
+   */
+  async buildDigest(
+    userId: string,
+    timezone = 'America/New_York',
+  ): Promise<AdvisorDigest | null> {
+    const signals = await this.signals.gather(userId, timezone);
+    if (signals.length === 0) {
+      this.logger.debug(`No digest signals for user ${userId} — skipping.`);
+      return null;
+    }
+
+    const resolved = await this.settings.resolve();
+    if (!resolved) {
+      throw new Error('Advisor is not configured; cannot narrate the weekly digest.');
+    }
+
+    const message = await this.narrate(userId, resolved, signals);
+    const top = signals[0];
+    const voiceSummary = `Your weekly money recap is ready. ${top.detail}`;
+
+    return { title: DIGEST_TITLE, message, voiceSummary, signals };
+  }
+
+  /** Single no-tools LLM turn that ranks and narrates the pre-computed signals. */
+  private async narrate(
+    userId: string,
+    resolved: { provider: any; model: string; apiKey: string },
+    signals: DigestSignal[],
+  ): Promise<string> {
+    const provider = this.factory.create(resolved.provider, resolved.apiKey);
+    const payload = signals.map((s) => ({ detail: s.detail, provenance: s.provenance }));
+    const userMessage = `Here are this week's signals as JSON. Write the recap.\n\n${JSON.stringify(
+      payload,
+      null,
+      2,
+    )}`;
+
+    const startMs = Date.now();
+    let text = '';
+    let final: LlmTurnResult | undefined;
+    for await (const chunk of provider.streamTurn({
+      model: resolved.model,
+      maxTokens: MAX_TOKENS,
+      system: DIGEST_SYSTEM_PROMPT,
+      tools: [],
+      messages: [{ role: 'user', content: userMessage }],
+    })) {
+      if (chunk.type === 'text') text += chunk.text;
+      else final = chunk.result;
+    }
+
+    this.aiLogs
+      .create({
+        userId,
+        promptType: 'advisor',
+        model: resolved.model,
+        inputText: 'weekly-digest',
+        outputText: text || undefined,
+        tokenCountIn: final?.usage.inputTokens,
+        tokenCountOut: final?.usage.outputTokens,
+        latencyMs: Date.now() - startMs,
+        piiDetected: false,
+        piiTypesFound: [],
+      })
+      .catch((err) => this.logger.warn(`Digest log failed: ${err.message}`));
+
+    const narrated = text.trim();
+    // Deterministic fallback if the model returns nothing usable.
+    return narrated.length > 0 ? narrated : this.templateBody(signals);
+  }
+
+  /** Plain top-5 bullet list, used when the LLM produces no text. */
+  private templateBody(signals: DigestSignal[]): string {
+    return signals
+      .slice(0, 5)
+      .map((s) => `- ${s.detail}`)
+      .join('\n');
+  }
+
+  /**
+   * Deliver the digest to one user. Idempotent — skips if this ISO week's digest already went out.
+   * Returns true if a new digest was dispatched.
+   */
+  async deliver(userId: string, timezone: string): Promise<boolean> {
+    const weekKey = isoWeekKey(timezone);
+    const dedupeKey = `advisor_digest_weekly_${userId}_${weekKey}`;
+
+    if (await this.notifications.findByMetadata(userId, dedupeKey)) {
+      this.logger.debug(`Advisor digest already sent: ${dedupeKey}`);
+      return false;
+    }
+
+    const digest = await this.buildDigest(userId, timezone);
+    if (!digest) return false;
+
+    await this.notifications.createAndDispatch({
+      userId,
+      type: 'advisor_digest',
+      title: digest.title,
+      message: digest.message,
+      voiceSummary: digest.voiceSummary,
+      dedupeKey,
+      metadata: { weekKey, signals: digest.signals },
+    });
+
+    this.logger.log(`Advisor digest delivered: ${dedupeKey}`);
+    return true;
+  }
+
+  /**
+   * Scheduler entrypoint. Runs only when the advisor is configured, then delivers to every
+   * user who opted in (`advisor_digest_enabled`).
+   */
+  async deliverAllEnabled(): Promise<void> {
+    if (!(await this.settings.resolve())) {
+      this.logger.log('Advisor not configured — skipping weekly digest sweep.');
+      return;
+    }
+
+    const rows = await this.db
+      .select({
+        userId: schema.userSettings.userId,
+        timezone: schema.userSettings.timezone,
+      })
+      .from(schema.userSettings)
+      .where(eq(schema.userSettings.advisorDigestEnabled, true))
+      .limit(10000);
+
+    this.logger.log(`Advisor digest sweep: ${rows.length} user(s) opted in`);
+
+    for (const { userId, timezone } of rows) {
+      try {
+        await this.deliver(userId, timezone ?? 'America/New_York');
+      } catch (err) {
+        this.logger.error(
+          `Advisor digest failed for user ${userId}: ${(err as Error).message}`,
+        );
+      }
+    }
+  }
+}

--- a/apps/api/src/advisor/digest/digest-signals.service.ts
+++ b/apps/api/src/advisor/digest/digest-signals.service.ts
@@ -1,0 +1,250 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { sql } from 'drizzle-orm';
+import { DATABASE_CONNECTION } from '../../db/db.module';
+import * as schema from '../../db/schema';
+import type { DigestSignal } from './types';
+
+/** Minimum dollar swing (cents) for a week-over-week category move to be worth surfacing. */
+const CATEGORY_DELTA_FLOOR_CENTS = 2000; // $20
+/** How many candidate signals to hand to the ranker (it narrows to the top 3–5). */
+const MAX_CANDIDATES = 12;
+
+function formatDollars(cents: number): string {
+  return `$${(Math.abs(cents) / 100).toFixed(2)}`;
+}
+
+function fmtDate(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(
+    d.getDate(),
+  ).padStart(2, '0')}`;
+}
+
+/**
+ * Timezone-local week windows for the digest.
+ * `recap` is the most recently completed Mon–Sun week; `prior` is the week before it.
+ * Boundaries are local calendar dates (end-exclusive) compared against the `date` column.
+ */
+export function localWeekWindows(timezone: string, now = new Date()) {
+  const local = new Date(now.toLocaleString('en-US', { timeZone: timezone }));
+  local.setHours(0, 0, 0, 0);
+  const mondayOffset = (local.getDay() + 6) % 7; // Mon=0 … Sun=6
+  const mondayThisWeek = new Date(local);
+  mondayThisWeek.setDate(local.getDate() - mondayOffset);
+
+  const recapStart = new Date(mondayThisWeek);
+  recapStart.setDate(mondayThisWeek.getDate() - 7);
+  const priorStart = new Date(mondayThisWeek);
+  priorStart.setDate(mondayThisWeek.getDate() - 14);
+
+  return {
+    recapStart: fmtDate(recapStart),
+    recapEnd: fmtDate(mondayThisWeek), // exclusive
+    priorStart: fmtDate(priorStart),
+    priorEnd: fmtDate(recapStart), // exclusive
+  };
+}
+
+/**
+ * Deterministic math engine for the weekly advisor digest.
+ *
+ * Produces dollar-quantified, provenance-tagged candidate signals from the user's own data.
+ * Every number here is computed in SQL — the LLM downstream only ranks and narrates these,
+ * it never invents figures. Output is aggregate (category totals, bill amounts, anomaly
+ * amounts) — no raw transaction descriptions or account numbers.
+ */
+@Injectable()
+export class DigestSignalsService {
+  private readonly logger = new Logger(DigestSignalsService.name);
+
+  constructor(@Inject(DATABASE_CONNECTION) private readonly db: any) {}
+
+  /** Gather and pre-rank (by dollar magnitude) the week's candidate signals for a user. */
+  async gather(userId: string, timezone = 'America/New_York'): Promise<DigestSignal[]> {
+    const win = localWeekWindows(timezone);
+
+    const [deltas, drivers, bills, subs, anomalies] = await Promise.all([
+      this.categoryDeltas(userId, win),
+      this.topDrivers(userId, win),
+      this.upcomingBills(userId),
+      this.subscriptionChanges(userId),
+      this.recentAnomalies(userId, win.recapStart),
+    ]);
+
+    const all = [...deltas, ...drivers, ...bills, ...subs, ...anomalies];
+    all.sort((a, b) => b.amountCents - a.amountCents);
+    return all.slice(0, MAX_CANDIDATES);
+  }
+
+  private rows(result: any): any[] {
+    return (result.rows ?? result) as any[];
+  }
+
+  /** Week-over-week spend change per category; surfaces the largest swings (either direction). */
+  private async categoryDeltas(
+    userId: string,
+    win: { recapStart: string; recapEnd: string; priorStart: string; priorEnd: string },
+  ): Promise<DigestSignal[]> {
+    const result = await this.db.execute(sql`
+      WITH recap AS (
+        SELECT category_id, SUM(amount_cents) AS total
+        FROM ${schema.transactions}
+        WHERE user_id = ${userId} AND is_credit = false AND is_split_parent = false
+          AND deleted_at IS NULL
+          AND date >= ${win.recapStart}::date AND date < ${win.recapEnd}::date
+        GROUP BY category_id
+      ),
+      prior AS (
+        SELECT category_id, SUM(amount_cents) AS total
+        FROM ${schema.transactions}
+        WHERE user_id = ${userId} AND is_credit = false AND is_split_parent = false
+          AND deleted_at IS NULL
+          AND date >= ${win.priorStart}::date AND date < ${win.priorEnd}::date
+        GROUP BY category_id
+      )
+      SELECT c.name AS category_name,
+             COALESCE(r.total, 0) AS recap_total,
+             COALESCE(p.total, 0) AS prior_total,
+             COALESCE(r.total, 0) - COALESCE(p.total, 0) AS delta
+      FROM recap r
+      FULL OUTER JOIN prior p USING (category_id)
+      JOIN ${schema.categories} c ON c.id = COALESCE(r.category_id, p.category_id)
+      WHERE COALESCE(c.is_transfer, false) = false
+      ORDER BY ABS(COALESCE(r.total, 0) - COALESCE(p.total, 0)) DESC
+      LIMIT 5
+    `);
+
+    return this.rows(result)
+      .map((r) => {
+        const delta = Number(r.delta);
+        const recap = Number(r.recap_total);
+        const prior = Number(r.prior_total);
+        return { delta, recap, prior, name: r.category_name as string };
+      })
+      .filter((r) => Math.abs(r.delta) >= CATEGORY_DELTA_FLOOR_CENTS)
+      .map((r) => {
+        const up = r.delta > 0;
+        return {
+          kind: 'category_delta' as const,
+          label: `${r.name} ${up ? 'up' : 'down'} week-over-week`,
+          amountCents: Math.abs(r.delta),
+          detail: `${r.name} spending was ${formatDollars(r.recap)} last week vs ${formatDollars(
+            r.prior,
+          )} the week before — ${up ? 'up' : 'down'} ${formatDollars(r.delta)}.`,
+          provenance: 'category spending, last week vs the week before',
+        };
+      });
+  }
+
+  /** Largest categories by spend in the recap week (context, not necessarily a change). */
+  private async topDrivers(
+    userId: string,
+    win: { recapStart: string; recapEnd: string },
+  ): Promise<DigestSignal[]> {
+    const result = await this.db.execute(sql`
+      SELECT c.name AS category_name, SUM(t.amount_cents) AS total
+      FROM ${schema.transactions} t
+      JOIN ${schema.categories} c ON t.category_id = c.id
+      WHERE t.user_id = ${userId} AND t.is_credit = false AND t.is_split_parent = false
+        AND t.deleted_at IS NULL AND COALESCE(c.is_transfer, false) = false
+        AND t.date >= ${win.recapStart}::date AND t.date < ${win.recapEnd}::date
+      GROUP BY c.name
+      ORDER BY total DESC
+      LIMIT 3
+    `);
+
+    return this.rows(result).map((r) => {
+      const total = Number(r.total);
+      return {
+        kind: 'top_driver' as const,
+        label: `Top spend: ${r.category_name}`,
+        amountCents: total,
+        detail: `${r.category_name} was your biggest category last week at ${formatDollars(total)}.`,
+        provenance: 'category spending totals for last week',
+      };
+    });
+  }
+
+  /** Recurring bills due in the next 7 days. */
+  private async upcomingBills(userId: string): Promise<DigestSignal[]> {
+    const result = await this.db.execute(sql`
+      SELECT normalized_name, expected_amount_cents, next_expected_date
+      FROM ${schema.recurringBills}
+      WHERE user_id = ${userId} AND is_active = true
+        AND next_expected_date IS NOT NULL
+        AND next_expected_date >= NOW()
+        AND next_expected_date < NOW() + interval '7 days'
+      ORDER BY expected_amount_cents DESC
+      LIMIT 5
+    `);
+
+    return this.rows(result).map((r) => {
+      const amount = Number(r.expected_amount_cents);
+      const due = new Date(r.next_expected_date).toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+      });
+      return {
+        kind: 'upcoming_bill' as const,
+        label: `${r.normalized_name} due soon`,
+        amountCents: amount,
+        detail: `${r.normalized_name} (${formatDollars(amount)}) is due around ${due}.`,
+        provenance: 'your tracked recurring bills',
+      };
+    });
+  }
+
+  /** Recurring bills whose most recent charge broke out of their tolerance band (price change). */
+  private async subscriptionChanges(userId: string): Promise<DigestSignal[]> {
+    const result = await this.db.execute(sql`
+      SELECT normalized_name, expected_amount_cents, last_amount_cents, amount_tolerance_percent
+      FROM ${schema.recurringBills}
+      WHERE user_id = ${userId} AND is_active = true
+        AND last_amount_cents IS NOT NULL
+        AND ABS(last_amount_cents - expected_amount_cents)
+            > (expected_amount_cents * amount_tolerance_percent / 100.0)
+      ORDER BY ABS(last_amount_cents - expected_amount_cents) DESC
+      LIMIT 5
+    `);
+
+    return this.rows(result).map((r) => {
+      const expected = Number(r.expected_amount_cents);
+      const last = Number(r.last_amount_cents);
+      const diff = last - expected;
+      const up = diff > 0;
+      return {
+        kind: 'subscription_change' as const,
+        label: `${r.normalized_name} price ${up ? 'increase' : 'drop'}`,
+        amountCents: Math.abs(diff),
+        detail: `${r.normalized_name} last charged ${formatDollars(last)}, ${
+          up ? 'up' : 'down'
+        } ${formatDollars(diff)} from its usual ${formatDollars(expected)}.`,
+        provenance: 'your tracked recurring bills',
+      };
+    });
+  }
+
+  /** Spending anomalies flagged by the anomaly engine (#32) during the recap week. */
+  private async recentAnomalies(userId: string, sinceDate: string): Promise<DigestSignal[]> {
+    const result = await this.db.execute(sql`
+      SELECT message, metadata
+      FROM ${schema.notifications}
+      WHERE user_id = ${userId}
+        AND type = 'spending_anomaly'
+        AND created_at >= ${sinceDate}::date
+      ORDER BY created_at DESC
+      LIMIT 5
+    `);
+
+    return this.rows(result).map((r) => {
+      const meta = (r.metadata ?? {}) as { amountCents?: number };
+      const amount = Number(meta.amountCents ?? 0);
+      return {
+        kind: 'anomaly' as const,
+        label: 'Unusual charge flagged',
+        amountCents: amount,
+        detail: r.message as string,
+        provenance: 'MoneyPulse anomaly detection',
+      };
+    });
+  }
+}

--- a/apps/api/src/advisor/digest/types.ts
+++ b/apps/api/src/advisor/digest/types.ts
@@ -1,0 +1,32 @@
+/**
+ * A single deterministic, dollar-quantified candidate for the weekly advisor digest.
+ * All figures are computed in code (the math engine); the LLM only ranks and narrates.
+ */
+export interface DigestSignal {
+  /** Coarse signal family, used for grouping/telemetry. */
+  kind:
+    | 'category_delta'
+    | 'top_driver'
+    | 'upcoming_bill'
+    | 'subscription_change'
+    | 'anomaly';
+  /** Short human label, e.g. "Dining up week-over-week". */
+  label: string;
+  /** Absolute dollar magnitude (cents) used to rank candidates. */
+  amountCents: number;
+  /** One factual sentence with the concrete figure(s) — the LLM must reuse these numbers verbatim. */
+  detail: string;
+  /** Where the number came from, e.g. "category spending, last week vs the week before". */
+  provenance: string;
+}
+
+/** The assembled weekly digest ready for delivery. */
+export interface AdvisorDigest {
+  title: string;
+  /** Markdown body: the ranked, narrated top items. */
+  message: string;
+  /** Short spoken summary for the Home Assistant / voice surface. */
+  voiceSummary: string;
+  /** The ranked signals the narration was built from (for provenance in metadata). */
+  signals: DigestSignal[];
+}

--- a/apps/api/src/advisor/llm/anthropic.provider.ts
+++ b/apps/api/src/advisor/llm/anthropic.provider.ts
@@ -46,11 +46,16 @@ export class AnthropicProvider implements LlmProvider {
       max_tokens: params.maxTokens,
       thinking: { type: 'adaptive' },
       system: params.system,
-      tools: params.tools.map((t) => ({
-        name: t.name,
-        description: t.description,
-        input_schema: t.inputSchema as Anthropic.Tool.InputSchema,
-      })),
+      // Omit `tools` entirely when there are none (e.g. the batch digest narration).
+      ...(params.tools.length
+        ? {
+            tools: params.tools.map((t) => ({
+              name: t.name,
+              description: t.description,
+              input_schema: t.inputSchema as Anthropic.Tool.InputSchema,
+            })),
+          }
+        : {}),
       messages: this.toAnthropicMessages(params.messages),
     });
 

--- a/apps/api/src/advisor/llm/openai.provider.ts
+++ b/apps/api/src/advisor/llm/openai.provider.ts
@@ -72,14 +72,19 @@ export class OpenAIProvider implements LlmProvider {
       stream: true,
       stream_options: { include_usage: true },
       messages: this.toOpenAIMessages(params.system, params.messages),
-      tools: params.tools.map((t) => ({
-        type: 'function' as const,
-        function: {
-          name: t.name,
-          description: t.description,
-          parameters: t.inputSchema,
-        },
-      })),
+      // Omit `tools` entirely when there are none — OpenAI rejects an empty array.
+      ...(params.tools.length
+        ? {
+            tools: params.tools.map((t) => ({
+              type: 'function' as const,
+              function: {
+                name: t.name,
+                description: t.description,
+                parameters: t.inputSchema,
+              },
+            })),
+          }
+        : {}),
     });
 
     let text = '';

--- a/apps/api/src/analytics/anomaly-detector.service.ts
+++ b/apps/api/src/analytics/anomaly-detector.service.ts
@@ -171,6 +171,7 @@ export class AnomalyDetectorService {
         dedupeKey,
         transactionId: txn.id,
         rule: 'amount_anomaly',
+        amountCents: txn.amountCents,
         avgCents: Math.round(stats.avgCents),
         zScore: Number(zScore(txn.amountCents, stats).toFixed(2)),
       },
@@ -216,7 +217,7 @@ export class AnomalyDetectorService {
       title: 'Possible duplicate transaction',
       message: `Possible duplicate: ${formatCents(txn.amountCents)} at ${merchantKey} on ${dateLabel}.`,
       dedupeKey,
-      metadata: { dedupeKey, transactionId: txn.id, rule: 'duplicate' },
+      metadata: { dedupeKey, transactionId: txn.id, rule: 'duplicate', amountCents: txn.amountCents },
     });
   }
 
@@ -248,7 +249,7 @@ export class AnomalyDetectorService {
       title: 'Large purchase detected',
       message: `Large purchase: ${formatCents(txn.amountCents)} at ${label}.`,
       dedupeKey,
-      metadata: { dedupeKey, transactionId: txn.id, rule: 'large_debit' },
+      metadata: { dedupeKey, transactionId: txn.id, rule: 'large_debit', amountCents: txn.amountCents },
     });
   }
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -104,6 +104,9 @@ export const userSettings = pgTable('user_settings', {
   monthlyDigestEnabled: boolean('monthly_digest_enabled')
     .notNull()
     .default(false),
+  advisorDigestEnabled: boolean('advisor_digest_enabled')
+    .notNull()
+    .default(false),
   notificationEmail: varchar('notification_email', { length: 255 }),
   firebaseUid: varchar('firebase_uid', { length: 128 }),
   createdAt: timestamp('created_at', { withTimezone: true })

--- a/apps/api/src/jobs/alert-cron.processor.ts
+++ b/apps/api/src/jobs/alert-cron.processor.ts
@@ -5,6 +5,7 @@ import { AlertEngineService } from '../notifications/alert-engine.service';
 import { DigestService } from '../analytics/digest.service';
 import { BalanceSnapshotService } from '../analytics/balance-snapshot.service';
 import { ForecastService } from '../analytics/forecast.service';
+import { AdvisorDigestService } from '../advisor/digest/advisor-digest.service';
 
 @Processor('alerts')
 export class AlertCronProcessor extends WorkerHost {
@@ -15,6 +16,7 @@ export class AlertCronProcessor extends WorkerHost {
     private readonly digestService: DigestService,
     private readonly balanceSnapshotService: BalanceSnapshotService,
     private readonly forecastService: ForecastService,
+    private readonly advisorDigestService: AdvisorDigestService,
   ) {
     super();
   }
@@ -47,6 +49,10 @@ export class AlertCronProcessor extends WorkerHost {
 
       case 'digest-monthly':
         await this.digestService.deliverAllEnabled('monthly');
+        break;
+
+      case 'advisor-digest-weekly':
+        await this.advisorDigestService.deliverAllEnabled();
         break;
 
       case 'snapshot-all':

--- a/apps/api/src/jobs/jobs.module.ts
+++ b/apps/api/src/jobs/jobs.module.ts
@@ -7,6 +7,7 @@ import { NotificationsModule } from '../notifications/notifications.module';
 import { SyncModule } from '../sync/sync.module';
 import { SyncDeliveryProcessor } from './sync-delivery.processor';
 import { AnalyticsModule } from '../analytics/analytics.module';
+import { AdvisorModule } from '../advisor/advisor.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { AnalyticsModule } from '../analytics/analytics.module';
     NotificationsModule,
     SyncModule,
     AnalyticsModule,
+    AdvisorModule,
   ],
   providers: [AlertCronProcessor, ReminderProcessor, SyncDeliveryProcessor],
 })
@@ -49,6 +51,14 @@ export class JobsModule implements OnModuleInit {
       'monthly-digest',
       { pattern: '0 8 1 * *' },
       { name: 'digest-monthly' },
+    );
+
+    // Proactive weekly advisor recap — Monday 13:00 UTC (~8–9 AM ET), after the
+    // basic weekly digest. ISO-week dedupe handles timezone spread.
+    await this.alertsQueue.upsertJobScheduler(
+      'advisor-digest-weekly',
+      { pattern: '0 13 * * 1' },
+      { name: 'advisor-digest-weekly' },
     );
 
     // Weekly bank balance reminder (Monday 9 AM)

--- a/apps/web/src/app/(protected)/settings/page.tsx
+++ b/apps/web/src/app/(protected)/settings/page.tsx
@@ -21,6 +21,9 @@ export default function SettingsPage() {
   const [monthlyDigest, setMonthlyDigest] = useState(
     settings?.monthlyDigestEnabled ?? false,
   );
+  const [advisorDigest, setAdvisorDigest] = useState(
+    settings?.advisorDigestEnabled ?? false,
+  );
   const [haWebhookUrl, setHaWebhookUrl] = useState(
     settings?.haWebhookUrl ?? '',
   );
@@ -44,6 +47,7 @@ export default function SettingsPage() {
         weeklyDigestEnabled: weeklyDigest,
         dailyDigestEnabled: dailyDigest,
         monthlyDigestEnabled: monthlyDigest,
+        advisorDigestEnabled: advisorDigest,
         haWebhookUrl: haWebhookUrl || null,
         firebaseUid: firebaseUid || null,
       });
@@ -163,6 +167,22 @@ export default function SettingsPage() {
             />
             <label htmlFor="monthlyDigest" className="text-sm font-medium">
               Enable monthly spending digest
+            </label>
+          </div>
+          <div className="flex items-start gap-3">
+            <input
+              id="advisorDigest"
+              type="checkbox"
+              checked={advisorDigest}
+              onChange={(e) => setAdvisorDigest(e.target.checked)}
+              className="mt-1 h-4 w-4 rounded border-[var(--border)]"
+            />
+            <label htmlFor="advisorDigest" className="text-sm font-medium">
+              Enable weekly AI advisor recap
+              <span className="block text-xs font-normal text-[var(--on-surface-variant)]">
+                A ranked, dollar-quantified &ldquo;what changed this week&rdquo; narrated by
+                your configured AI advisor. Requires an advisor provider set up above.
+              </span>
             </label>
           </div>
         </section>

--- a/db/migrations/0009_advisor_digest_enabled.sql
+++ b/db/migrations/0009_advisor_digest_enabled.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user_settings" ADD COLUMN IF NOT EXISTS "advisor_digest_enabled" boolean DEFAULT false NOT NULL;

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1783200100000,
       "tag": "0008_advisor_prompt_type",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1783200200000,
+      "tag": "0009_advisor_digest_enabled",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -53,6 +53,7 @@ export interface UserSettings {
   weeklyDigestEnabled: boolean;
   dailyDigestEnabled: boolean;
   monthlyDigestEnabled: boolean;
+  advisorDigestEnabled: boolean;
   notificationEmail: string | null;
   firebaseUid: string | null;
 }

--- a/packages/shared/src/validation/index.ts
+++ b/packages/shared/src/validation/index.ts
@@ -210,6 +210,7 @@ export const updateUserSettingsSchema = z.object({
   weeklyDigestEnabled: z.boolean().optional(),
   dailyDigestEnabled: z.boolean().optional(),
   monthlyDigestEnabled: z.boolean().optional(),
+  advisorDigestEnabled: z.boolean().optional(),
   notificationEmail: z.email().nullable().optional(),
   firebaseUid: z.string().max(128).nullable().optional(),
 });

--- a/tasks.md
+++ b/tasks.md
@@ -10,7 +10,7 @@ Private, self-hosted advisor over real finances. **LLM is the interface; determi
 |---|---|---|
 | Phase 0 — MCP server (semantic layer, 8 user-scoped tools) | #37 | ✅ Merged (#41) |
 | Phase 1 — Ask-your-money NL chat (MVP) | #38 | ✅ Merged (#49) — deployed |
-| Phase 2 — Weekly digest (proactive) | #39 | ⏳ Planned |
+| Phase 2 — Weekly digest (proactive) | #39 | 🔀 In review (#51) |
 | Phase 3 — Goal planners (car / college / safe-to-spend) | #40 | ⏳ Planned |
 
 **Deferred / later:** real-time nudges, in-app insights feed, draft-actions-to-approve, mortgage & insurance modules.
@@ -23,6 +23,7 @@ Private, self-hosted advisor over real finances. **LLM is the interface; determi
 
 ### Locked design decisions
 - **Provider abstraction (shipped in #49):** Claude *or* OpenAI, selectable in Settings → AI Advisor. Single normalized LLM adapter layer; MCP tools passed as JSON-Schema to either. API key stored write-only (AES-256-GCM in DB via `ENCRYPTION_KEY`) with env-var precedence (`ANTHROPIC_API_KEY`/`OPENAI_API_KEY`). Global (one config per app). Ollama skipped (weak tool-calling breaks grounding).
+- **Weekly digest (#51):** deterministic signals (category WoW deltas, top drivers, upcoming bills, subscription price changes, anomalies from #32) → LLM ranks/narrates top 3–5 with **no tools**, no new numbers → notification center + Home Assistant, ISO-week dedupe. Opt-in via `user_settings.advisor_digest_enabled`; sweep gated on advisor configured. Cron `advisor-digest-weekly` Mon 13:00 UTC.
 - Cloud Claude (`claude-opus-4-8`) default for reasoning; **aggregates only** to cloud (raw statements/account numbers stay on NAS).
 - MCP tools = semantic layer; **refuse-don't-guess**, never free-form SQL, LLM never does arithmetic.
 - Provenance on every number; independent verifier pass; "insights, not advice" framing.

--- a/tasks.md
+++ b/tasks.md
@@ -9,7 +9,7 @@ Private, self-hosted advisor over real finances. **LLM is the interface; determi
 | Phase | Issue | Status |
 |---|---|---|
 | Phase 0 — MCP server (semantic layer, 8 user-scoped tools) | #37 | ✅ Merged (#41) |
-| Phase 1 — Ask-your-money NL chat (MVP) | #38 | 🔜 In progress |
+| Phase 1 — Ask-your-money NL chat (MVP) | #38 | ✅ Merged (#49) — deployed |
 | Phase 2 — Weekly digest (proactive) | #39 | ⏳ Planned |
 | Phase 3 — Goal planners (car / college / safe-to-spend) | #40 | ⏳ Planned |
 
@@ -22,12 +22,16 @@ Private, self-hosted advisor over real finances. **LLM is the interface; determi
 | Triage leftover sync-status/transactions branch | #42 | ⏳ Open |
 
 ### Locked design decisions
-- Cloud Claude (`claude-opus-4-8`) for reasoning; **aggregates only** to cloud (raw statements/account numbers stay on NAS).
+- **Provider abstraction (shipped in #49):** Claude *or* OpenAI, selectable in Settings → AI Advisor. Single normalized LLM adapter layer; MCP tools passed as JSON-Schema to either. API key stored write-only (AES-256-GCM in DB via `ENCRYPTION_KEY`) with env-var precedence (`ANTHROPIC_API_KEY`/`OPENAI_API_KEY`). Global (one config per app). Ollama skipped (weak tool-calling breaks grounding).
+- Cloud Claude (`claude-opus-4-8`) default for reasoning; **aggregates only** to cloud (raw statements/account numbers stay on NAS).
 - MCP tools = semantic layer; **refuse-don't-guess**, never free-form SQL, LLM never does arithmetic.
 - Provenance on every number; independent verifier pass; "insights, not advice" framing.
 - External data via free APIs (FRED, BLS CE); recurrence = merchant-group + modal-interval + tolerance + jitter (≥3).
 
 ## ✅ Recently shipped (notification thread)
+- #49 — Advisor Phase 1 chat + provider abstraction (Claude/OpenAI, web-configurable, encrypted key)
+- #50 — migration idempotency: made 0002/0003/0006 replay-safe + added 0007/0008; fixed NAS `__drizzle_migrations` drift (only 0000/0001 were recorded), so `db:migrate` now succeeds cleanly
+- #48 — forecast bill dates parsed as local calendar dates (UTC off-by-one)
 - #28 — notification dropdown opaque/readable
 - #30 — Tailwind v4 `@theme` design tokens (fixed app-wide `bg-card` no-op)
 - #32 — statistical spending-anomaly baselines (cut false positives)


### PR DESCRIPTION
Closes #39. Part of the AI Financial Advisor epic (#36); builds on Phase 1 (#49).

## What
A proactive **Weekly Money Recap** driven by the cloud LLM (Claude/OpenAI via the Phase-1 provider abstraction), delivered through the notification + Home Assistant pipeline. Ranked, dollar-quantified, capped to the top 3–5 items.

## How it respects the epic's locked rules
- **Deterministic code is the math engine** — `DigestSignalsService` computes every figure in SQL: category week-over-week deltas, top spend drivers, upcoming recurring bills, subscription/recurring price changes, and anomalies (from #32). Each candidate is dollar-quantified with provenance.
- **LLM only ranks & narrates** — `AdvisorDigestService` hands the pre-computed signals (as JSON) to the configured provider with **no tools**, instructing it to pick the top 3–5 and narrate each using only the numbers present. **Refuse-don't-guess**: it can't introduce a figure that isn't in the signals; a deterministic bullet-list fallback covers an empty model response.
- **Aggregates only** — only category totals / bill amounts / anomaly amounts reach the model; no raw transaction text or account numbers.

## Delivery & scheduling
- `NotificationsService.createAndDispatch` (type `advisor_digest`) → in-app bell + outbox + **Home Assistant** webhook, with a short grounded `voiceSummary`. Deduped once per **ISO week**.
- New BullMQ cron `advisor-digest-weekly` (Mon 13:00 UTC) → `deliverAllEnabled()` via `AlertCronProcessor`.

## Opt-in
- New `user_settings.advisor_digest_enabled` (idempotent migration `0009` + shared type/validation) with a **Settings** toggle. The sweep runs only when the advisor is configured AND the user opted in.

## Incidental
- Providers now omit an empty `tools` array (OpenAI rejects `tools: []`) — needed for the no-tools narration turn.
- Anomaly notifications carry `amountCents` in metadata so the digest can rank them by dollar impact.

## Test plan
- **vitest** (11 new): signal ranking / sub-threshold filtering / dollar formatting + ISO-week window math; digest build (null when quiet, no-tools narration, deterministic fallback, throws when unconfigured); deliver dedupe; sweep gating. Full advisor + anomaly suites green (**54 tests**).
- **pnpm build** (api + web) pass.

Not deployed yet — will deploy (incl. \`db:migrate\` for 0009) after review/merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)