### PR TITLE
fix(deploy): prune stale source on NAS before extract

### DIFF
--- a/deploy-to-nas.sh
+++ b/deploy-to-nas.sh
@@ -81,7 +81,10 @@ sync_code() {
     scp -O "$TMP_ARCHIVE" "$NAS_HOST:/tmp/"
 
     log "Extracting on NAS..."
-    ssh "$NAS_HOST" "cd $NAS_REPO && tar xzf /tmp/moneypulse-sync.tar.gz && rm /tmp/moneypulse-sync.tar.gz"
+    # Prune the source trees first — tar extraction overlays but never deletes, so a
+    # file removed/renamed in git would otherwise linger on the NAS and get compiled
+    # (stale build context). Wiping apps/ + packages/ makes the sync authoritative.
+    ssh "$NAS_HOST" "cd ${NAS_REPO:?} && rm -rf apps packages && tar xzf /tmp/moneypulse-sync.tar.gz && rm /tmp/moneypulse-sync.tar.gz"
 
     rm -f "$TMP_ARCHIVE"
     ok "Code synced to NAS"


### PR DESCRIPTION
## Problem
`deploy-to-nas.sh` syncs the repo by extracting a tarball over the existing NAS source dir. tar **overlays** files but never **deletes** them, so any file removed or renamed in git lingers in the NAS build context and gets compiled.

This bit the #53 (Telegram polling) deploy: the deleted `telegram.controller.ts` was still on the NAS, referencing the removed `verifySecret`, and failed the in-container `nest build`:

```
src/advisor/telegram.controller.ts:38:24 - error TS2339: Property 'verifySecret' does not exist on type 'TelegramService'.
```

## Fix
Wipe `apps/` and `packages/` before extracting, so the sync is authoritative. `${NAS_REPO:?}` guards against an empty var. The Docker build runs `pnpm install` in-container, so nothing else in the NAS repo dir is needed to rebuild.

Verified: after this change the api deploy succeeded and is healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)