### PR TITLE
feat(advisor): add Google Gemini as a third provider (#56)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,7 @@ OLLAMA_MODEL=mistral:7b
 # the web-app key. Only aggregates ever reach the provider — raw transactions stay local.
 # ANTHROPIC_API_KEY=
 # OPENAI_API_KEY=
+# GOOGLE_API_KEY=   # Gemini (get from Google AI Studio)
 
 # ── AI Advisor — Telegram surface (optional) ─────────────
 # Enables the advisor over Telegram. All optional. The API long-polls Telegram

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.110.0",
+    "@google/genai": "^2.10.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@moneypulse/shared": "workspace:*",
     "@nestjs/bullmq": "^11.0.4",

--- a/apps/api/src/advisor/advisor-settings.service.ts
+++ b/apps/api/src/advisor/advisor-settings.service.ts
@@ -6,12 +6,13 @@ import { advisorSettings } from '../db/schema';
 import { encryptField, decryptField } from '../common/crypto';
 import { DEFAULT_MODELS, type LlmProviderId } from './llm/types';
 
-const PROVIDERS: LlmProviderId[] = ['anthropic', 'openai'];
+const PROVIDERS: LlmProviderId[] = ['anthropic', 'openai', 'google'];
 
 /** Env var that carries the API key for each provider (takes precedence over DB). */
 const ENV_KEY: Record<LlmProviderId, string> = {
   anthropic: 'ANTHROPIC_API_KEY',
   openai: 'OPENAI_API_KEY',
+  google: 'GOOGLE_API_KEY',
 };
 
 /** What the advisor loop needs to run: which provider, which model, and the key. */

--- a/apps/api/src/advisor/llm/__tests__/google.provider.spec.ts
+++ b/apps/api/src/advisor/llm/__tests__/google.provider.spec.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi } from 'vitest';
+import { GoogleProvider } from '../google.provider';
+import type { LlmStreamChunk, LlmTurnParams } from '../types';
+
+/** Build an async-iterable of Gemini streaming chunks. */
+function fakeStream(chunks: any[]) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const c of chunks) yield c;
+    },
+  };
+}
+
+function withClient(chunks: any[]) {
+  const provider = new GoogleProvider('g-test');
+  const generateContentStream = vi.fn(async () => fakeStream(chunks));
+  (provider as any).client = { models: { generateContentStream } };
+  return { provider, generateContentStream };
+}
+
+async function run(provider: GoogleProvider, params: LlmTurnParams) {
+  const out: LlmStreamChunk[] = [];
+  for await (const chunk of provider.streamTurn(params)) out.push(chunk);
+  return out;
+}
+
+const baseParams: LlmTurnParams = {
+  model: 'gemini-2.5-flash',
+  maxTokens: 100,
+  system: 'be helpful',
+  tools: [{ name: 'get_spending_summary', description: 'sum', inputSchema: { type: 'object' } }],
+  messages: [{ role: 'user', content: 'hi' }],
+};
+
+describe('GoogleProvider', () => {
+  it('streams text and captures a function call as a tool_use', async () => {
+    const { provider } = withClient([
+      { text: 'Let me check.' },
+      {
+        functionCalls: [{ name: 'get_spending_summary', args: { from: '2026-06-01' } }],
+        usageMetadata: { promptTokenCount: 42, candidatesTokenCount: 7 },
+      },
+    ]);
+
+    const chunks = await run(provider, baseParams);
+    const text = chunks.filter((c) => c.type === 'text').map((c: any) => c.text).join('');
+    const final = chunks.find((c) => c.type === 'final') as any;
+
+    expect(text).toBe('Let me check.');
+    expect(final.result.stopReason).toBe('tool_use');
+    expect(final.result.toolCalls).toHaveLength(1);
+    expect(final.result.toolCalls[0]).toMatchObject({
+      name: 'get_spending_summary',
+      input: { from: '2026-06-01' },
+    });
+    expect(final.result.usage).toEqual({ inputTokens: 42, outputTokens: 7 });
+  });
+
+  it('ends the turn (end_turn) for a plain text answer', async () => {
+    const { provider } = withClient([
+      { text: 'You spent $10.', usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 4 } },
+    ]);
+    const chunks = await run(provider, baseParams);
+    const final = chunks.find((c) => c.type === 'final') as any;
+    expect(final.result.stopReason).toBe('end_turn');
+    expect(final.result.text).toBe('You spent $10.');
+    expect(final.result.toolCalls).toEqual([]);
+  });
+
+  it('translates history to Gemini contents (functionCall / functionResponse) + config', async () => {
+    const { provider, generateContentStream } = withClient([{ text: 'ok' }]);
+    await run(provider, {
+      ...baseParams,
+      messages: [
+        { role: 'user', content: 'how much dining?' },
+        {
+          role: 'assistant',
+          content: [{ type: 'tool_use', id: 'c1', name: 'get_spending_summary', input: { from: 'x' } }],
+        },
+        { role: 'user', content: [{ type: 'tool_result', toolUseId: 'c1', content: '$420' }] },
+      ],
+    });
+
+    const arg = generateContentStream.mock.calls[0][0];
+    // system + max tokens land in config
+    expect(arg.config.systemInstruction).toBe('be helpful');
+    expect(arg.config.maxOutputTokens).toBe(100);
+    // tools mapped to functionDeclarations
+    expect(arg.config.tools[0].functionDeclarations[0]).toEqual({
+      name: 'get_spending_summary',
+      description: 'sum',
+      parameters: { type: 'object' },
+    });
+
+    const contents = arg.contents;
+    // assistant → model with a functionCall part
+    const model = contents.find((c: any) => c.role === 'model');
+    expect(model.parts[0]).toEqual({
+      functionCall: { name: 'get_spending_summary', args: { from: 'x' } },
+    });
+    // tool_result → user functionResponse, name resolved from the matching call id
+    const fnResponse = contents
+      .flatMap((c: any) => c.parts)
+      .find((p: any) => p.functionResponse);
+    expect(fnResponse.functionResponse).toEqual({
+      name: 'get_spending_summary',
+      response: { result: '$420' },
+    });
+  });
+
+  it('omits tools from config when there are none (batch narration)', async () => {
+    const { provider, generateContentStream } = withClient([{ text: 'hi' }]);
+    await run(provider, { ...baseParams, tools: [] });
+    expect(generateContentStream.mock.calls[0][0].config.tools).toBeUndefined();
+  });
+});

--- a/apps/api/src/advisor/llm/google.provider.ts
+++ b/apps/api/src/advisor/llm/google.provider.ts
@@ -1,0 +1,132 @@
+import { GoogleGenAI, type Content, type Part } from '@google/genai';
+import type {
+  LlmContentBlock,
+  LlmMessage,
+  LlmProvider,
+  LlmStreamChunk,
+  LlmToolCall,
+  LlmTurnParams,
+} from './types';
+
+/**
+ * Adapter for Google Gemini via the `@google/genai` SDK. Translates the normalized
+ * message shape to Gemini `Content[]` (assistant→`model`, tool_use→`functionCall`,
+ * tool_result→`functionResponse`) and back. Gemini function calls carry no id of their
+ * own, so we synthesize a stable one per call and resolve the name from history when
+ * translating tool results back.
+ */
+export class GoogleProvider implements LlmProvider {
+  readonly id = 'google' as const;
+  private readonly client: GoogleGenAI;
+
+  constructor(apiKey: string) {
+    this.client = new GoogleGenAI({ apiKey });
+  }
+
+  private toGoogleContents(messages: LlmMessage[]): Content[] {
+    // Map a synthesized tool-call id → its function name, so tool_result blocks
+    // (which only carry the id) can be emitted as functionResponse with a name.
+    const idToName = new Map<string, string>();
+    const contents: Content[] = [];
+
+    for (const m of messages) {
+      const role = m.role === 'assistant' ? 'model' : 'user';
+
+      if (typeof m.content === 'string') {
+        contents.push({ role, parts: [{ text: m.content }] });
+        continue;
+      }
+
+      const parts: Part[] = [];
+      for (const b of m.content) {
+        if (b.type === 'text') {
+          parts.push({ text: b.text });
+        } else if (b.type === 'tool_use') {
+          idToName.set(b.id, b.name);
+          parts.push({ functionCall: { name: b.name, args: b.input } });
+        } else if (b.type === 'tool_result') {
+          const name = idToName.get(b.toolUseId) ?? b.toolUseId;
+          parts.push({
+            functionResponse: { name, response: { result: b.content } },
+          });
+        }
+      }
+      if (parts.length) contents.push({ role, parts });
+    }
+    return contents;
+  }
+
+  async *streamTurn(params: LlmTurnParams): AsyncIterable<LlmStreamChunk> {
+    const stream = await this.client.models.generateContentStream({
+      model: params.model,
+      contents: this.toGoogleContents(params.messages),
+      config: {
+        systemInstruction: params.system,
+        maxOutputTokens: params.maxTokens,
+        // Omit tools entirely when there are none (e.g. the batch digest narration).
+        ...(params.tools.length
+          ? {
+              tools: [
+                {
+                  functionDeclarations: params.tools.map((t) => ({
+                    name: t.name,
+                    description: t.description,
+                    parameters: t.inputSchema as Record<string, unknown>,
+                  })),
+                },
+              ],
+            }
+          : {}),
+      },
+    });
+
+    let text = '';
+    let usageIn = 0;
+    let usageOut = 0;
+    const toolCalls: LlmToolCall[] = [];
+
+    for await (const chunk of stream) {
+      const delta = chunk.text;
+      if (delta) {
+        text += delta;
+        yield { type: 'text', text: delta };
+      }
+      for (const call of chunk.functionCalls ?? []) {
+        toolCalls.push({
+          id: `call_${toolCalls.length}_${call.name}`,
+          name: call.name ?? '',
+          input: (call.args ?? {}) as Record<string, unknown>,
+        });
+      }
+      if (chunk.usageMetadata) {
+        usageIn = chunk.usageMetadata.promptTokenCount ?? usageIn;
+        usageOut = chunk.usageMetadata.candidatesTokenCount ?? usageOut;
+      }
+    }
+
+    const content: LlmContentBlock[] = [];
+    if (text) content.push({ type: 'text', text });
+    for (const call of toolCalls) {
+      content.push({ type: 'tool_use', id: call.id, name: call.name, input: call.input });
+    }
+
+    yield {
+      type: 'final',
+      result: {
+        text,
+        content,
+        toolCalls,
+        stopReason: toolCalls.length ? 'tool_use' : 'end_turn',
+        usage: { inputTokens: usageIn, outputTokens: usageOut },
+      },
+    };
+  }
+
+  async testConnection(model: string): Promise<void> {
+    await this.client.models.generateContent({
+      model,
+      contents: 'ping',
+      config: { maxOutputTokens: 1 },
+    });
+  }
+}

--- a/apps/api/src/advisor/llm/provider-factory.ts
+++ b/apps/api/src/advisor/llm/provider-factory.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import type { LlmProvider, LlmProviderId } from './types';
 import { AnthropicProvider } from './anthropic.provider';
 import { OpenAIProvider } from './openai.provider';
+import { GoogleProvider } from './google.provider';
 
 /** Constructs the right provider adapter for a resolved (provider, apiKey) pair. */
 @Injectable()
@@ -12,6 +13,8 @@ export class LlmProviderFactory {
         return new AnthropicProvider(apiKey);
       case 'openai':
         return new OpenAIProvider(apiKey);
+      case 'google':
+        return new GoogleProvider(apiKey);
       default:
         throw new Error(`Unknown LLM provider: ${provider as string}`);
     }

--- a/apps/api/src/advisor/llm/types.ts
+++ b/apps/api/src/advisor/llm/types.ts
@@ -58,7 +58,7 @@ export interface LlmTurnParams {
   messages: LlmMessage[];
 }
 
-export type LlmProviderId = 'anthropic' | 'openai';
+export type LlmProviderId = 'anthropic' | 'openai' | 'google';
 
 export interface LlmProvider {
   readonly id: LlmProviderId;
@@ -72,4 +72,5 @@ export interface LlmProvider {
 export const DEFAULT_MODELS: Record<LlmProviderId, string> = {
   anthropic: 'claude-opus-4-8',
   openai: 'gpt-4o',
+  google: 'gemini-2.5-flash',
 };

--- a/apps/web/src/components/AdvisorSettingsSection.tsx
+++ b/apps/web/src/components/AdvisorSettingsSection.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { Sparkles } from 'lucide-react';
 import { api } from '@/lib/api';
 
-type Provider = 'anthropic' | 'openai';
+type Provider = 'anthropic' | 'openai' | 'google';
 
 interface AdvisorSettingsView {
   provider: Provider;
@@ -21,6 +21,7 @@ interface AdvisorSettingsView {
 const PROVIDER_LABELS: Record<Provider, string> = {
   anthropic: 'Claude (Anthropic)',
   openai: 'OpenAI',
+  google: 'Gemini (Google)',
 };
 
 /** Global AI-advisor provider/model/key configuration (see /advisor). */
@@ -115,7 +116,7 @@ export function AdvisorSettingsSection() {
           }}
           className="mt-1.5 block w-full rounded-xl border border-[var(--border)] bg-[var(--card)] px-3 py-2.5 text-sm focus:border-[var(--primary)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)]/30"
         >
-          {(view?.providers ?? (['anthropic', 'openai'] as Provider[])).map((p) => (
+          {(view?.providers ?? (['anthropic', 'openai', 'google'] as Provider[])).map((p) => (
             <option key={p} value={p}>
               {PROVIDER_LABELS[p]}
             </option>

--- a/docs/advisor-phase1-spec.md
+++ b/docs/advisor-phase1-spec.md
@@ -34,6 +34,7 @@ MCP tools (which compute in Postgres) and narrates their verified results.
 |---|---|
 | `ANTHROPIC_API_KEY` | Claude provider key. **Optional** — can instead be set via the web Settings UI (stored encrypted). Env takes precedence over the DB value. |
 | `OPENAI_API_KEY` | OpenAI provider key. Same rules as above. |
+| `GOOGLE_API_KEY` | Google Gemini provider key (from Google AI Studio). Same rules as above. |
 | `ENCRYPTION_KEY` | 64-char hex (32 bytes). Reused from PII encryption; **required to store a provider key via the web UI** (AES-256-GCM at rest). |
 | `TELEGRAM_BOT_TOKEN` | Telegram bot (from @BotFather). The API **long-polls** (out-dials `getUpdates`) — no inbound URL is exposed (LAN-only deployment). |
 | `TELEGRAM_CHAT_MAP` | Optional `chatId:userId,…` allowlist. If unset, single-user mode maps every chat to the sole user. |
@@ -42,7 +43,7 @@ MCP tools (which compute in Postgres) and narrates their verified results.
 
 ### Provider selection
 
-The advisor is provider-agnostic (Claude / OpenAI), selectable from **Settings → AI Advisor**
+The advisor is provider-agnostic (Claude / OpenAI / Gemini), selectable from **Settings → AI Advisor**
 (global, one config for the app). Provider/model/key resolve as: provider env key first,
 then the encrypted DB key. The key is write-only in the UI (shown masked, never returned).
 "Test connection" validates credentials before you rely on them.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.110.0
         version: 0.110.0(zod@4.3.6)
+      '@google/genai':
+        specifier: ^2.10.0
+        version: 2.10.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
@@ -124,7 +127,7 @@ importers:
         version: 8.0.5
       openai:
         specifier: ^6.45.0
-        version: 6.45.0(zod@4.3.6)
+        version: 6.45.0(ws@8.21.0)(zod@4.3.6)
       passport:
         specifier: ^0.7.0
         version: 0.7.0
@@ -896,6 +899,15 @@ packages:
   '@fast-csv/parse@4.3.6':
     resolution: {integrity: sha512-uRsLYksqpbDmWaSmzvJcuApSEe38+6NQZBUsuAyMZKqHxH0g1wcJgsKUvN3WC8tewaqFjBMMGrkHmC+T7k8LvA==}
 
+  '@google/genai@2.10.0':
+    resolution: {integrity: sha512-e4cFxj3tiuMtsgOT4G9c1hXyGJhg7/Buj7VVeBacRY3fRtkRZZ59Q3nuVp2xbq8BGQXLXCDB253qMhklMOeUDg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
@@ -1527,6 +1539,33 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
+
   '@reduxjs/toolkit@2.11.2':
     resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
     peerDependencies:
@@ -2065,6 +2104,9 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
   '@types/send@1.2.1':
     resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
 
@@ -2367,6 +2409,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
@@ -2539,6 +2585,9 @@ packages:
   big-integer@1.6.52:
     resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
     engines: {node: '>=0.6'}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
   binary@0.3.0:
     resolution: {integrity: sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==}
@@ -2849,6 +2898,10 @@ packages:
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
 
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
@@ -3322,6 +3375,9 @@ packages:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   fast-csv@4.3.6:
     resolution: {integrity: sha512-2RNSpuwwsJGP0frGsOmTb9oUF+VkFSM4SyLTDgwf2ciHWTarN0lQTC+F2f/t5J9QjW+c65VFIAAu85GsvMIusw==}
     engines: {node: '>=10.0.0'}
@@ -3359,6 +3415,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -3401,6 +3461,10 @@ packages:
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
 
   formidable@3.5.4:
     resolution: {integrity: sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==}
@@ -3452,6 +3516,14 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
+  gaxios@7.1.5:
+    resolution: {integrity: sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
+
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
@@ -3501,6 +3573,14 @@ packages:
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
+
+  google-auth-library@10.9.0:
+    resolution: {integrity: sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -3560,6 +3640,10 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -3816,6 +3900,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -4051,6 +4138,9 @@ packages:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -4249,12 +4339,21 @@ packages:
     resolution: {integrity: sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==}
     engines: {node: ^18 || ^20 || >= 21}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-emoji@1.11.0:
     resolution: {integrity: sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==}
 
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-gyp-build-optional-packages@5.2.2:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
@@ -4360,6 +4459,10 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
 
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
@@ -4534,6 +4637,10 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
+    engines: {node: '>=12.0.0'}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -4668,6 +4775,10 @@ packages:
   restore-cursor@3.1.0:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
     engines: {node: '>=8'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -5329,6 +5440,10 @@ packages:
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
@@ -5395,6 +5510,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -5944,6 +6071,19 @@ snapshots:
       lodash.isnil: 4.0.0
       lodash.isundefined: 3.0.1
       lodash.uniq: 4.5.0
+
+  '@google/genai@2.10.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))':
+    dependencies:
+      google-auth-library: 10.9.0
+      p-retry: 4.6.2
+      protobufjs: 7.6.5
+      ws: 8.21.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   '@hono/node-server@1.19.14(hono@4.12.27)':
     dependencies:
@@ -6533,6 +6673,26 @@ snapshots:
     dependencies:
       playwright: 1.60.0
 
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.2': {}
+
   '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -6959,6 +7119,8 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/retry@0.12.0': {}
+
   '@types/send@1.2.1':
     dependencies:
       '@types/node': 25.5.0
@@ -7289,6 +7451,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv-formats@2.1.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
@@ -7491,6 +7655,8 @@ snapshots:
       require-from-string: 2.0.2
 
   big-integer@1.6.52: {}
+
+  bignumber.js@9.3.1: {}
 
   binary@0.3.0:
     dependencies:
@@ -7797,6 +7963,8 @@ snapshots:
   d3-timer@3.0.1: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-uri-to-buffer@4.0.1: {}
 
   data-urls@7.0.0(@noble/hashes@1.8.0):
     dependencies:
@@ -8390,6 +8558,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  extend@3.0.2: {}
+
   fast-csv@4.3.6:
     dependencies:
       '@fast-csv/format': 4.3.5
@@ -8422,6 +8592,11 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -8492,6 +8667,10 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   formidable@3.5.4:
     dependencies:
       '@paralleldrive/cuid2': 2.3.1
@@ -8539,6 +8718,22 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  gaxios@7.1.5:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.5
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   generator-function@2.0.1: {}
 
@@ -8604,6 +8799,19 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
+  google-auth-library@10.9.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.5
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -8655,6 +8863,13 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   iconv-lite@0.7.2:
     dependencies:
@@ -8928,6 +9143,10 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
 
   json-parse-even-better-errors@2.3.1: {}
@@ -9128,6 +9347,8 @@ snapshots:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
 
+  long@5.3.2: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -9298,6 +9519,8 @@ snapshots:
 
   node-addon-api@8.6.0: {}
 
+  node-domexception@1.0.0: {}
+
   node-emoji@1.11.0:
     dependencies:
       lodash: 4.18.1
@@ -9308,6 +9531,12 @@ snapshots:
       es-errors: 1.3.0
       object.entries: 1.1.9
       semver: 6.3.1
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-gyp-build-optional-packages@5.2.2:
     dependencies:
@@ -9378,8 +9607,9 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  openai@6.45.0(zod@4.3.6):
+  openai@6.45.0(ws@8.21.0)(zod@4.3.6):
     optionalDependencies:
+      ws: 8.21.0
       zod: 4.3.6
 
   optionator@0.9.4:
@@ -9416,6 +9646,11 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
 
   pako@1.0.11: {}
 
@@ -9564,6 +9799,20 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  protobufjs@7.6.5:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.2
+      '@types/node': 25.5.0
+      long: 5.3.2
 
   proxy-addr@2.0.7:
     dependencies:
@@ -9717,6 +9966,8 @@ snapshots:
     dependencies:
       onetime: 5.1.2
       signal-exit: 3.0.7
+
+  retry@0.13.1: {}
 
   reusify@1.1.0: {}
 
@@ -10486,6 +10737,8 @@ snapshots:
     dependencies:
       defaults: 1.0.4
 
+  web-streams-polyfill@3.3.3: {}
+
   webidl-conversions@8.0.1: {}
 
   webpack-node-externals@3.0.0: {}
@@ -10593,6 +10846,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   wrappy@1.0.2: {}
+
+  ws@8.21.0: {}
 
   xml-name-validator@5.0.0: {}
 


### PR DESCRIPTION
Closes #56. Adds **Google Gemini** to the advisor provider abstraction (Claude / OpenAI → now +Gemini), selectable from Settings → AI Advisor exactly like the others.

## What
- **`GoogleProvider`** (`@google/genai`) implements `LlmProvider`: streaming + function calling over the MCP tools. Translates the normalized history to Gemini `Content[]` — assistant→`model`, `tool_use`→`functionCall`, `tool_result`→`functionResponse`. Gemini function calls carry no id, so we synthesize a stable one per call and resolve the name from history when emitting the `functionResponse`. Tools are omitted when empty (the batch digest's no-tools narration). Usage from `usageMetadata`.
- Registered `google` across `LlmProviderId`, `DEFAULT_MODELS` (`gemini-2.5-flash`), `PROVIDERS`, `ENV_KEY` (`GOOGLE_API_KEY`), and the factory.
- Web Settings dropdown label (“Gemini (Google)”) + fallback list.
- `.env.example` + advisor spec updated.

## Posture (unchanged)
Aggregates-only to the provider; refuse-don't-guess. Key resolves as `GOOGLE_API_KEY` env (precedence) → encrypted DB key, same as Claude/OpenAI. The model string is user-editable in the UI — set the exact Gemini model when you add the key.

## Test plan
- **vitest**: new `google.provider.spec` — text streaming, function-call→`tool_use` (+usage), plain-text `end_turn`, history→`contents` translation (incl. `functionResponse` name resolution from the call id), tools-omitted-when-empty. Full advisor suite green (**39 tests**).
- **pnpm build** (api — typechecks the adapter against the real SDK types — + web) pass.

No migration. API-only deploy after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)