### PR TITLE
feat(deploy): bundle MCP server into the API image (#43)

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -7,6 +7,7 @@ FROM base AS deps
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY packages/shared/package.json ./packages/shared/
 COPY apps/api/package.json ./apps/api/
+COPY apps/mcp-server/package.json ./apps/mcp-server/
 RUN pnpm install --frozen-lockfile
 
 # Build shared package
@@ -22,13 +23,23 @@ RUN pnpm --filter @moneypulse/api build && \
     pnpm --filter @moneypulse/api deploy --prod --legacy /deploy && \
     cp -r /app/apps/api/dist /deploy/dist
 
+# Build MCP server (the advisor's data layer; spawned over stdio by the API)
+FROM shared-build AS mcp-build
+COPY apps/mcp-server/ ./apps/mcp-server/
+RUN pnpm --filter @moneypulse/mcp-server build && \
+    pnpm --filter @moneypulse/mcp-server deploy --prod --legacy /deploy-mcp && \
+    cp -r /app/apps/mcp-server/dist /deploy-mcp/dist
+
 # Production
 FROM node:22-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
+# The API spawns the co-located MCP server over stdio; pin its entrypoint.
+ENV MCP_SERVER_ENTRY=/app/mcp-server/dist/index.js
 RUN apk add --no-cache curl
 
 COPY --from=api-build /deploy ./
+COPY --from=mcp-build /deploy-mcp ./mcp-server
 COPY db/migrations ./db/migrations
 
 EXPOSE 4000

--- a/apps/mcp-server/src/db.ts
+++ b/apps/mcp-server/src/db.ts
@@ -1,13 +1,19 @@
 import pg from 'pg';
 
-const pool = new pg.Pool({
-  host: process.env.DB_HOST || 'localhost',
-  port: Number(process.env.DB_PORT) || 5432,
-  database: process.env.DB_NAME || 'moneypulse',
-  user: process.env.DB_USER || 'moneypulse',
-  password: process.env.DB_PASSWORD!,
-  max: 5,
-});
+// Prefer a single DATABASE_URL (the API passes its own env down when it spawns us over
+// stdio), falling back to discrete DB_* vars for standalone/dev use.
+const pool = new pg.Pool(
+  process.env.DATABASE_URL
+    ? { connectionString: process.env.DATABASE_URL, max: 5 }
+    : {
+        host: process.env.DB_HOST || 'localhost',
+        port: Number(process.env.DB_PORT) || 5432,
+        database: process.env.DB_NAME || 'moneypulse',
+        user: process.env.DB_USER || 'moneypulse',
+        password: process.env.DB_PASSWORD!,
+        max: 5,
+      },
+);
 
 export async function query<T = any>(
   text: string,


### PR DESCRIPTION
Closes #43.

## Why
The advisor reads user-scoped aggregates by spawning the MCP server over stdio (`MCP_SERVER_ENTRY --stdio`, per-user via `MONEYPULSE_USER_ID`). But the MCP server was **never built into the deployed API image**, so on the NAS the advisor chat + weekly digest would fail the moment they try to load tools:

```
$ docker exec moneypulse-api ls /app/apps/mcp-server/dist  →  MCP_DIST_MISSING
```

## What
- **`apps/api/Dockerfile`**: install `apps/mcp-server` deps in the `deps` stage; add an `mcp-build` stage that builds the server and `pnpm deploy --prod`s it into a self-contained `dist`+`node_modules`; copy that to `/app/mcp-server` in the runner; set `ENV MCP_SERVER_ENTRY=/app/mcp-server/dist/index.js` so the API spawns the co-located server. No compose change required.
- **`apps/mcp-server/src/db.ts`**: prefer `DATABASE_URL` (the API passes its own env down when it spawns the server) with the discrete `DB_*` vars as fallback for standalone/dev. The API container already has `DATABASE_URL`, so no new env is needed.

## Test plan
- `pnpm --filter @moneypulse/mcp-server build` + tests green (**34**).
- Validated `pnpm deploy --prod` yields a runnable tree — `node --check dist/index.js` passes; `pg` / `zod` / `@modelcontextprotocol/sdk` present in `node_modules`.
- API build passes.
- **Post-merge deploy check**: `docker exec moneypulse-api ls /app/mcp-server/dist` present; advisor lists tools / answers a grounded question once a provider key is set.

API-only deploy, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)