### PR TITLE
fix(advisor): Gemini thought_signature + inject current date (#59)

### DIFF
--- a/apps/api/src/advisor/advisor.service.ts
+++ b/apps/api/src/advisor/advisor.service.ts
@@ -20,15 +20,38 @@ export const ADVISOR_DISCLAIMER =
   'Informational insights based on your own data — not personalized financial, ' +
   'investment, or tax advice. Verify before acting.';
 
-const SYSTEM_PROMPT = `You are MoneyPulse's financial insights assistant. You answer the user's questions about their own finances using ONLY the data returned by your tools.
+/** Default timezone for resolving "today"/"this month" (matches the digest default). */
+const ADVISOR_TIMEZONE = process.env.ADVISOR_TIMEZONE || 'America/New_York';
+
+/** Today's date + weekday in the advisor timezone, e.g. "2026-07-06 (Monday)". */
+function todayContext(): string {
+  const now = new Date();
+  const date = now.toLocaleDateString('en-CA', { timeZone: ADVISOR_TIMEZONE }); // YYYY-MM-DD
+  const weekday = now.toLocaleDateString('en-US', {
+    timeZone: ADVISOR_TIMEZONE,
+    weekday: 'long',
+  });
+  return `${date} (${weekday})`;
+}
+
+const SYSTEM_RULES = `You are MoneyPulse's financial insights assistant. You answer the user's questions about their own finances using ONLY the data returned by your tools.
 
 Rules:
 - Every number in your answer MUST come from a tool result. Never invent, estimate, or calculate figures yourself — if you need a number, call a tool. Quote the tool's figure as given.
-- Attach provenance: say which data a number came from (e.g. "based on your spending summary for June").
+- For a question about a specific category (dining, gas, groceries, etc.), call get_spending_summary or get_category_breakdown for the period, then read the matching category line. Category names in the data may differ from the user's wording (e.g. "Restaurants" ≈ dining, "Fuel"/"Gas" ≈ gas, "Groceries" ≈ food shopping) — match sensibly. Only say there's no data AFTER a tool actually returns none for that period.
+- Attach provenance: say which data a number came from (e.g. "based on your spending summary for June 2026").
 - If no tool can answer the question, say so plainly ("I don't have a way to answer that from your data") rather than guessing. Do not fall back to general knowledge for figures about the user's finances.
+- When the user follows up with just a period or category ("how about June", "and gas?"), reuse the intent from the previous turn.
 - You receive aggregated data only (category totals, balances, budgets, recurring merchants). You cannot see individual raw transactions or account numbers — don't claim to.
 - Keep answers concise and specific to the user's numbers. Lead with the answer.
 - For any suggestion about products, rates, or big decisions, present options with trade-offs and note this is informational, not personalized financial advice. Do not give reckless or absolute directives.`;
+
+/** Build the system prompt with the current date so relative periods resolve correctly. */
+function buildSystemPrompt(): string {
+  return `${SYSTEM_RULES}
+
+Today's date is ${todayContext()}. Resolve relative periods ("today", "this week", "this month", "last month", "year to date") against THIS date — never assume a different year or month. Spending tools take explicit from/to dates (YYYY-MM-DD); "this month" is the 1st of the current month through today, "last month" is the full previous calendar month.`;
+}
 
 export interface ChatTurn {
   role: 'user' | 'assistant';
@@ -82,6 +105,8 @@ export class AdvisorService {
       { role: 'user', content: message },
     ];
 
+    const system = buildSystemPrompt();
+
     const startMs = Date.now();
     let answer = '';
     let tokensIn = 0;
@@ -93,7 +118,7 @@ export class AdvisorService {
         for await (const chunk of provider.streamTurn({
           model: resolved.model,
           maxTokens: MAX_TOKENS,
-          system: SYSTEM_PROMPT,
+          system,
           tools,
           messages,
         })) {

--- a/apps/api/src/advisor/llm/__tests__/google.provider.spec.ts
+++ b/apps/api/src/advisor/llm/__tests__/google.provider.spec.ts
@@ -11,6 +11,16 @@ function fakeStream(chunks: any[]) {
   };
 }
 
+/** A streaming chunk carrying the given candidate parts (+ optional usage). */
+function chunk(parts: any[], usage?: { in: number; out: number }) {
+  return {
+    candidates: [{ content: { parts } }],
+    ...(usage
+      ? { usageMetadata: { promptTokenCount: usage.in, candidatesTokenCount: usage.out } }
+      : {}),
+  };
+}
+
 function withClient(chunks: any[]) {
   const provider = new GoogleProvider('g-test');
   const generateContentStream = vi.fn(async () => fakeStream(chunks));
@@ -20,7 +30,7 @@ function withClient(chunks: any[]) {
 
 async function run(provider: GoogleProvider, params: LlmTurnParams) {
   const out: LlmStreamChunk[] = [];
-  for await (const chunk of provider.streamTurn(params)) out.push(chunk);
+  for await (const c of provider.streamTurn(params)) out.push(c);
   return out;
 }
 
@@ -35,11 +45,11 @@ const baseParams: LlmTurnParams = {
 describe('GoogleProvider', () => {
   it('streams text and captures a function call as a tool_use', async () => {
     const { provider } = withClient([
-      { text: 'Let me check.' },
-      {
-        functionCalls: [{ name: 'get_spending_summary', args: { from: '2026-06-01' } }],
-        usageMetadata: { promptTokenCount: 42, candidatesTokenCount: 7 },
-      },
+      chunk([{ text: 'Let me check.' }]),
+      chunk([{ functionCall: { name: 'get_spending_summary', args: { from: '2026-06-01' } } }], {
+        in: 42,
+        out: 7,
+      }),
     ]);
 
     const chunks = await run(provider, baseParams);
@@ -56,10 +66,17 @@ describe('GoogleProvider', () => {
     expect(final.result.usage).toEqual({ inputTokens: 42, outputTokens: 7 });
   });
 
-  it('ends the turn (end_turn) for a plain text answer', async () => {
+  it('does not stream the model’s internal thought text', async () => {
     const { provider } = withClient([
-      { text: 'You spent $10.', usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 4 } },
+      chunk([{ text: 'reasoning...', thought: true }, { text: 'The answer.' }]),
     ]);
+    const chunks = await run(provider, baseParams);
+    const text = chunks.filter((c) => c.type === 'text').map((c: any) => c.text).join('');
+    expect(text).toBe('The answer.');
+  });
+
+  it('ends the turn (end_turn) for a plain text answer', async () => {
+    const { provider } = withClient([chunk([{ text: 'You spent $10.' }], { in: 5, out: 4 })]);
     const chunks = await run(provider, baseParams);
     const final = chunks.find((c) => c.type === 'final') as any;
     expect(final.result.stopReason).toBe('end_turn');
@@ -68,7 +85,7 @@ describe('GoogleProvider', () => {
   });
 
   it('translates history to Gemini contents (functionCall / functionResponse) + config', async () => {
-    const { provider, generateContentStream } = withClient([{ text: 'ok' }]);
+    const { provider, generateContentStream } = withClient([chunk([{ text: 'ok' }])]);
     await run(provider, {
       ...baseParams,
       messages: [
@@ -82,10 +99,8 @@ describe('GoogleProvider', () => {
     });
 
     const arg = generateContentStream.mock.calls[0][0];
-    // system + max tokens land in config
     expect(arg.config.systemInstruction).toBe('be helpful');
     expect(arg.config.maxOutputTokens).toBe(100);
-    // tools mapped to functionDeclarations
     expect(arg.config.tools[0].functionDeclarations[0]).toEqual({
       name: 'get_spending_summary',
       description: 'sum',
@@ -93,12 +108,10 @@ describe('GoogleProvider', () => {
     });
 
     const contents = arg.contents;
-    // assistant → model with a functionCall part
     const model = contents.find((c: any) => c.role === 'model');
     expect(model.parts[0]).toEqual({
       functionCall: { name: 'get_spending_summary', args: { from: 'x' } },
     });
-    // tool_result → user functionResponse, name resolved from the matching call id
     const fnResponse = contents
       .flatMap((c: any) => c.parts)
       .find((p: any) => p.functionResponse);
@@ -108,8 +121,45 @@ describe('GoogleProvider', () => {
     });
   });
 
+  it('captures a functionCall thoughtSignature and echoes it back on the next turn', async () => {
+    const provider = new GoogleProvider('g');
+    const streams = [
+      fakeStream([
+        chunk(
+          [{ functionCall: { name: 'get_budget_status', args: {} }, thoughtSignature: 'sig-abc' }],
+          { in: 1, out: 1 },
+        ),
+      ]),
+      fakeStream([chunk([{ text: 'Budget is fine.' }])]),
+    ];
+    const gen = vi.fn(async () => streams.shift());
+    (provider as any).client = { models: { generateContentStream: gen } };
+
+    // Turn 1 → model asks for a tool; grab the synthesized call id
+    const t1 = await run(provider, baseParams);
+    const call = (t1.find((c) => c.type === 'final') as any).result.toolCalls[0];
+    expect(call.name).toBe('get_budget_status');
+
+    // Turn 2 → same provider instance, history carries the tool_use + tool_result
+    await run(provider, {
+      ...baseParams,
+      messages: [
+        { role: 'user', content: 'budget?' },
+        {
+          role: 'assistant',
+          content: [{ type: 'tool_use', id: call.id, name: call.name, input: call.input }],
+        },
+        { role: 'user', content: [{ type: 'tool_result', toolUseId: call.id, content: 'ok' }] },
+      ],
+    });
+
+    const modelPart = gen.mock.calls[1][0].contents.find((c: any) => c.role === 'model').parts[0];
+    expect(modelPart.functionCall).toEqual({ name: 'get_budget_status', args: {} });
+    expect(modelPart.thoughtSignature).toBe('sig-abc');
+  });
+
   it('omits tools from config when there are none (batch narration)', async () => {
-    const { provider, generateContentStream } = withClient([{ text: 'hi' }]);
+    const { provider, generateContentStream } = withClient([chunk([{ text: 'hi' }])]);
     await run(provider, { ...baseParams, tools: [] });
     expect(generateContentStream.mock.calls[0][0].config.tools).toBeUndefined();
   });

--- a/apps/api/src/advisor/llm/google.provider.ts
+++ b/apps/api/src/advisor/llm/google.provider.ts
@@ -14,10 +14,19 @@ import type {
  * tool_result→`functionResponse`) and back. Gemini function calls carry no id of their
  * own, so we synthesize a stable one per call and resolve the name from history when
  * translating tool results back.
+ *
+ * Gemini 2.5 returns an opaque `thoughtSignature` on each functionCall part that MUST be
+ * echoed back on the next turn (else a 400 "missing thought_signature"). We keep an
+ * instance-scoped map (this provider lives for one chat request, spanning all tool rounds)
+ * from synthesized call id → signature, and re-attach it when rebuilding the model turn.
  */
 export class GoogleProvider implements LlmProvider {
   readonly id = 'google' as const;
   private readonly client: GoogleGenAI;
+  /** Monotonic across all tool rounds of this request, so ids never collide. */
+  private callSeq = 0;
+  /** Synthesized call id → Gemini thoughtSignature, preserved across rounds. */
+  private readonly signatures = new Map<string, string>();
 
   constructor(apiKey: string) {
     this.client = new GoogleGenAI({ apiKey });
@@ -43,7 +52,11 @@ export class GoogleProvider implements LlmProvider {
           parts.push({ text: b.text });
         } else if (b.type === 'tool_use') {
           idToName.set(b.id, b.name);
-          parts.push({ functionCall: { name: b.name, args: b.input } });
+          const part: Part = { functionCall: { name: b.name, args: b.input } };
+          // Echo the thought signature Gemini gave us for this call — required.
+          const sig = this.signatures.get(b.id);
+          if (sig) part.thoughtSignature = sig;
+          parts.push(part);
         } else if (b.type === 'tool_result') {
           const name = idToName.get(b.toolUseId) ?? b.toolUseId;
           parts.push({
@@ -86,17 +99,23 @@ export class GoogleProvider implements LlmProvider {
     const toolCalls: LlmToolCall[] = [];
 
     for await (const chunk of stream) {
-      const delta = chunk.text;
-      if (delta) {
-        text += delta;
-        yield { type: 'text', text: delta };
-      }
-      for (const call of chunk.functionCalls ?? []) {
-        toolCalls.push({
-          id: `call_${toolCalls.length}_${call.name}`,
-          name: call.name ?? '',
-          input: (call.args ?? {}) as Record<string, unknown>,
-        });
+      // Read raw parts (not the `.text` / `.functionCalls` getters) so we can capture
+      // the per-call thoughtSignature and skip the model's internal "thought" text.
+      const parts = chunk.candidates?.[0]?.content?.parts ?? [];
+      for (const part of parts) {
+        if (part.text && !part.thought) {
+          text += part.text;
+          yield { type: 'text', text: part.text };
+        }
+        if (part.functionCall) {
+          const id = `call_${this.callSeq++}`;
+          if (part.thoughtSignature) this.signatures.set(id, part.thoughtSignature);
+          toolCalls.push({
+            id,
+            name: part.functionCall.name ?? '',
+            input: (part.functionCall.args ?? {}) as Record<string, unknown>,
+          });
+        }
       }
       if (chunk.usageMetadata) {
         usageIn = chunk.usageMetadata.promptTokenCount ?? usageIn;


### PR DESCRIPTION
Closes #59. Two bugs found while testing the advisor on the NAS.

## 1. Gemini 400 — missing `thought_signature`
Gemini 2.5 returns an opaque `thoughtSignature` on each `functionCall` part that **must be echoed back** on the next turn, or the follow-up round 400s:
> Function call is missing a thought_signature in functionCall parts … `get_budget_status`

`GoogleProvider` used the `chunk.functionCalls` convenience getter, which drops it. Now it reads the raw `candidates[0].content.parts`, captures each signature into an **instance-scoped map** (keyed by a globally-unique synthesized call id — the provider lives for one chat request spanning all tool rounds), and re-attaches it when rebuilding the model turn in `toGoogleContents`. Also skips the model's internal `thought` text from the user-visible stream.

## 2. Unhelpful answers — model didn't know today's date
The system prompt never stated the current date, so the model resolved "last month"/"this month" to the **wrong months** (observed: "last month" → September, "this month" → November on 2026‑07) and then refused ("I don't have data … for September").

Now the prompt is built **per request** with today's date (in `ADVISOR_TIMEZONE`, default `America/New_York`) and instructs the model to resolve relative periods against it — never assume a different year/month. Added:
- category-matching guidance (`"Restaurants" ≈ dining`, `"Fuel" ≈ gas`, …) so it reads the right line instead of refusing,
- follow-up intent reuse ("how about June" / "and gas?"),
- only claim "no data" **after** a tool actually returns none.

## Test plan
- **vitest**: `google.provider.spec` reworked to raw-parts fixtures; new tests for **thoughtSignature capture + echo-back** and **thought-text suppression**. Advisor suite green (**41**).
- API + shared builds pass.

API-only deploy, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)