### PR TITLE
fix(advisor): match category wording to real taxonomy + parent subtotals (#61)

### DIFF
--- a/apps/api/src/advisor/advisor.service.ts
+++ b/apps/api/src/advisor/advisor.service.ts
@@ -38,7 +38,7 @@ const SYSTEM_RULES = `You are MoneyPulse's financial insights assistant. You ans
 
 Rules:
 - Every number in your answer MUST come from a tool result. Never invent, estimate, or calculate figures yourself — if you need a number, call a tool. Quote the tool's figure as given.
-- For a question about a specific category (dining, gas, groceries, etc.), call get_spending_summary or get_category_breakdown for the period, then read the matching category line. Category names in the data may differ from the user's wording (e.g. "Restaurants" ≈ dining, "Fuel"/"Gas" ≈ gas, "Groceries" ≈ food shopping) — match sensibly. Only say there's no data AFTER a tool actually returns none for that period.
+- For a spending question about a category, call get_category_breakdown for the period. It lists every category with its parent (e.g. "Gas/Auto > Fuel", "Utilities > Phone", "Dining") and per-parent subtotals. Match the user's wording to the closest category OR parent ACTUALLY shown in the result — do not assume a category name; e.g. "auto" → the "Gas/Auto" parent subtotal, "dining" → the "Dining" line, "phone bill" → "Utilities > Phone". Read the figure the tool gives (use the parent subtotal for parent-level questions); never add or compute figures yourself. Only say there's no data AFTER the tool returns none for that period.
 - Attach provenance: say which data a number came from (e.g. "based on your spending summary for June 2026").
 - If no tool can answer the question, say so plainly ("I don't have a way to answer that from your data") rather than guessing. Do not fall back to general knowledge for figures about the user's finances.
 - When the user follows up with just a period or category ("how about June", "and gas?"), reuse the intent from the previous turn.

--- a/apps/mcp-server/src/tools/get-category-breakdown.ts
+++ b/apps/mcp-server/src/tools/get-category-breakdown.ts
@@ -47,13 +47,42 @@ export function registerGetCategoryBreakdown(server: McpServer) {
         values,
       );
 
+      const dollars = (cents: number) => `$${(cents / 100).toFixed(2)}`;
+
       const lines = rows.map((r) => {
         const parent = r.parent_category ? `${r.parent_category} > ` : '';
-        return `${parent}${r.category}: $${(Number(r.total_cents) / 100).toFixed(2)} (${r.txn_count} txns, ${r.first_txn.toISOString().slice(0, 10)} – ${r.last_txn.toISOString().slice(0, 10)})`;
+        return `${parent}${r.category}: ${dollars(Number(r.total_cents))} (${r.txn_count} txns, ${r.first_txn.toISOString().slice(0, 10)} – ${r.last_txn.toISOString().slice(0, 10)})`;
       });
 
+      // Roll up per-parent subtotals so parent-level questions ("how much on auto?")
+      // resolve to a single figure without the model having to add subcategories.
+      // Top-level categories (no parent) count as their own group.
+      const parentTotals = new Map<string, number>();
+      let grandTotal = 0;
+      for (const r of rows) {
+        const cents = Number(r.total_cents);
+        grandTotal += cents;
+        const parent = (r.parent_category as string) || (r.category as string);
+        parentTotals.set(parent, (parentTotals.get(parent) ?? 0) + cents);
+      }
+      const subtotalLines = [...parentTotals.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .map(([parent, cents]) => `${parent}: ${dollars(cents)}`);
+
+      const text =
+        rows.length === 0
+          ? 'No data.'
+          : [
+              lines.join('\n'),
+              '',
+              'Totals by parent category:',
+              subtotalLines.join('\n'),
+              '',
+              `Total: ${dollars(grandTotal)}`,
+            ].join('\n');
+
       return {
-        content: [{ type: 'text' as const, text: lines.join('\n') || 'No data.' }],
+        content: [{ type: 'text' as const, text }],
       };
     },
   );


### PR DESCRIPTION
Closes #61. Accuracy tightening from live testing.

## Findings
- **"dining last month" → "no data for Restaurants"** — but the category is literally **"Dining"** ($78, 8 txns). My earlier prompt hardcoded synonyms (`"Restaurants" ≈ dining`) that don't match the user's taxonomy, so the model searched the wrong name. (Self-inflicted; removed.)
- **"auto this year" → no data** — although `Gas/Auto > Fuel` exists. `get_spending_summary` returns leaf names only; the model can't map "auto" and shouldn't sum subcategories itself.

## Fix
1. **Prompt** — stop guessing synonyms. Steer to `get_category_breakdown` and match the user's wording to the closest category **or parent actually returned** ("auto" → `Gas/Auto` subtotal, "dining" → `Dining`, "phone bill" → `Utilities > Phone`). Read the tool's figure; never compute. Only claim no data after the tool returns none.
2. **`get_category_breakdown`** — append **per-parent subtotals + grand total**, so parent-level questions resolve to one real figure without model arithmetic. Example (your June data): a `Gas/Auto: $47.53` subtotal line now appears alongside the `Gas/Auto > Fuel` / `Gas/Auto > Parking & Tolls` leaves.

## Known follow-up (out of scope)
Per-vendor breakdown within a category ("break software subs down by vendor") — needs a new merchant-level aggregate tool.

## Test plan
- mcp-server build + tests (34) and advisor suite (41) green; API build passes.
- Post-deploy: in-container `get_category_breakdown` for June shows parent subtotals; re-ask "dining last month" / "auto this year".

API-only deploy, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)