### PR TITLE
feat(advisor): add get_merchant_breakdown tool (#63)

### DIFF
--- a/apps/api/src/advisor/__tests__/mcp-client.service.spec.ts
+++ b/apps/api/src/advisor/__tests__/mcp-client.service.spec.ts
@@ -5,20 +5,21 @@ import {
   McpClientService,
 } from '../mcp-client.service';
 
-const ALL_EIGHT = [
+const ALL_TOOLS = [
   { name: 'get_account_balances', description: 'a', inputSchema: { type: 'object' } },
   { name: 'get_spending_summary', description: 'b', inputSchema: { type: 'object' } },
   { name: 'get_category_breakdown', description: 'c', inputSchema: { type: 'object' } },
   { name: 'get_budget_status', description: 'd', inputSchema: { type: 'object' } },
   { name: 'get_recurring_expenses', description: 'e', inputSchema: { type: 'object' } },
+  { name: 'get_merchant_breakdown', description: 'g', inputSchema: { type: 'object' } },
   { name: 'compare_periods', description: 'f', inputSchema: { type: 'object' } },
   { name: 'get_transactions', description: 'ROW-LEVEL', inputSchema: { type: 'object' } },
   { name: 'search_transactions', description: 'ROW-LEVEL', inputSchema: { type: 'object' } },
 ];
 
 describe('MCP advisor tool boundary (aggregates-only)', () => {
-  it('exposes exactly the 6 aggregate tools and excludes the 2 row-level tools', () => {
-    const out = toAdvisorTools(ALL_EIGHT);
+  it('exposes exactly the aggregate tools and excludes the 2 row-level tools', () => {
+    const out = toAdvisorTools(ALL_TOOLS);
     const names = out.map((t) => t.name).sort();
     expect(names).toEqual([...AGGREGATE_TOOL_ALLOWLIST].sort());
     expect(names).not.toContain('get_transactions');
@@ -26,7 +27,7 @@ describe('MCP advisor tool boundary (aggregates-only)', () => {
   });
 
   it('maps inputSchema → input_schema for Anthropic', () => {
-    const out = toAdvisorTools([ALL_EIGHT[0]]);
+    const out = toAdvisorTools([ALL_TOOLS[0]]);
     expect(out[0]).toMatchObject({
       name: 'get_account_balances',
       description: 'a',

--- a/apps/api/src/advisor/mcp-client.service.ts
+++ b/apps/api/src/advisor/mcp-client.service.ts
@@ -16,6 +16,7 @@ export const AGGREGATE_TOOL_ALLOWLIST = new Set([
   'get_category_breakdown',
   'get_budget_status',
   'get_recurring_expenses',
+  'get_merchant_breakdown',
   'compare_periods',
 ]);
 

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -9,6 +9,7 @@ import { registerGetAccountBalances } from './tools/get-account-balances.js';
 import { registerGetCategoryBreakdown } from './tools/get-category-breakdown.js';
 import { registerComparePeriods } from './tools/compare-periods.js';
 import { registerGetRecurringExpenses } from './tools/get-recurring-expenses.js';
+import { registerGetMerchantBreakdown } from './tools/get-merchant-breakdown.js';
 import { close } from './db.js';
 import http from 'node:http';
 
@@ -25,6 +26,7 @@ registerGetAccountBalances(server);
 registerGetCategoryBreakdown(server);
 registerComparePeriods(server);
 registerGetRecurringExpenses(server);
+registerGetMerchantBreakdown(server);
 
 const mode = process.argv.includes('--sse') ? 'sse' : 'stdio';
 

--- a/apps/mcp-server/src/tools/get-merchant-breakdown.ts
+++ b/apps/mcp-server/src/tools/get-merchant-breakdown.ts
@@ -1,0 +1,82 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { query, getUserId } from '../db.js';
+
+export function registerGetMerchantBreakdown(server: McpServer) {
+  server.tool(
+    'get_merchant_breakdown',
+    'Top merchants/vendors by spend for a date range, optionally filtered to a category (or its parent). Answers "who did I pay the most" and "break <category> down by vendor". Uses cleaned merchant names only.',
+    {
+      from: z.string().describe('Start date (YYYY-MM-DD)'),
+      to: z.string().describe('End date (YYYY-MM-DD)'),
+      category: z
+        .string()
+        .optional()
+        .describe('Filter to a category name (matches the category or its parent)'),
+      limit: z.number().min(1).max(50).default(15).describe('Max merchants to return'),
+    },
+    async (params) => {
+      const userId = await getUserId();
+
+      // Cleaned merchant label only — never the raw description (keeps raw transaction
+      // text on the NAS, per the aggregates-only cloud boundary).
+      const merchantExpr = `COALESCE(t.normalized_merchant_name, t.merchant_name, 'Other')`;
+
+      const conditions = [
+        't.is_split_parent = false',
+        't.deleted_at IS NULL',
+        't.is_credit = false',
+        't.date >= $1',
+        't.date <= $2',
+      ];
+      const values: any[] = [params.from, params.to];
+
+      conditions.push(`t.user_id = $${values.length + 1}`);
+      values.push(userId);
+
+      if (params.category) {
+        conditions.push(
+          `(c.name ILIKE $${values.length + 1} OR parent.name ILIKE $${values.length + 1})`,
+        );
+        values.push(`%${params.category}%`);
+      }
+
+      const limitPlaceholder = `$${values.length + 1}`;
+      values.push(params.limit);
+
+      const rows = await query(
+        `SELECT
+           ${merchantExpr} AS merchant,
+           COALESCE(c.name, 'Uncategorized') AS category,
+           SUM(t.amount_cents) AS total_cents,
+           COUNT(*) AS txn_count
+         FROM transactions t
+         LEFT JOIN categories c ON t.category_id = c.id
+         LEFT JOIN categories parent ON c.parent_id = parent.id
+         WHERE ${conditions.join(' AND ')}
+         GROUP BY ${merchantExpr}, c.name
+         ORDER BY total_cents DESC
+         LIMIT ${limitPlaceholder}`,
+        values,
+      );
+
+      if (rows.length === 0) {
+        return { content: [{ type: 'text' as const, text: 'No data.' }] };
+      }
+
+      const total = rows.reduce((s, r) => s + Number(r.total_cents), 0);
+      const lines = rows.map(
+        (r) =>
+          `${r.merchant} (${r.category}): $${(Number(r.total_cents) / 100).toFixed(2)} (${r.txn_count} txns)`,
+      );
+
+      const text = [
+        lines.join('\n'),
+        '',
+        `Total (top ${rows.length}): $${(total / 100).toFixed(2)}`,
+      ].join('\n');
+
+      return { content: [{ type: 'text' as const, text }] };
+    },
+  );
+}


### PR DESCRIPTION
Closes #63. Makes "break \<category\> down by vendor" and "who did I pay the most" answerable.

## What
- **`get_merchant_breakdown(from, to, category?, limit=15)`** — top merchants by spend for a date range, optional category filter (matches the category **or its parent**), with a total.
- Merchant label is `COALESCE(normalized_merchant_name, merchant_name, 'Other')` — **never the raw description**, so raw transaction text stays on the NAS (aggregates-only cloud boundary).
- Registered in the MCP server and added to the advisor **aggregate allowlist**.

## Test plan
- mcp-server user-scoping guardrail auto-covers the new tool (**38**); advisor boundary test updated so the allowlist round-trips.
- Builds pass. Post-deploy: in-container `get_merchant_breakdown` for software subscriptions this year; re-ask "break software subs down by vendor".

API-only deploy, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)