### PR TITLE
feat(advisor): per-provider API keys + inline switcher (#73)

### DIFF
--- a/apps/api/src/advisor/__tests__/advisor-settings.service.spec.ts
+++ b/apps/api/src/advisor/__tests__/advisor-settings.service.spec.ts
@@ -33,49 +33,89 @@ function make(env: Record<string, string | undefined>, row: any = null) {
   return { svc, db };
 }
 
-describe('AdvisorSettingsService', () => {
+describe('AdvisorSettingsService (per-provider keys)', () => {
   it('resolve prefers the provider env key over the stored DB key', async () => {
-    const row = { provider: 'anthropic', model: 'claude-opus-4-8', apiKeyCiphertext: encryptField('db-key') };
+    const row = {
+      provider: 'anthropic',
+      model: 'claude-opus-4-8',
+      anthropicKeyCiphertext: encryptField('db-key'),
+    };
     const { svc } = make({ ENCRYPTION_KEY: HEX_KEY, ANTHROPIC_API_KEY: 'env-key' }, row);
-    const resolved = await svc.resolve();
-    expect(resolved).toMatchObject({ provider: 'anthropic', apiKey: 'env-key', keySource: 'env' });
+    expect(await svc.resolve()).toMatchObject({
+      provider: 'anthropic',
+      apiKey: 'env-key',
+      keySource: 'env',
+    });
   });
 
-  it('resolve falls back to the decrypted DB key when no env key', async () => {
-    const row = { provider: 'openai', model: 'gpt-4o', apiKeyCiphertext: encryptField('sk-db-secret') };
+  it('resolve falls back to the decrypted per-provider DB key', async () => {
+    const row = {
+      provider: 'openai',
+      model: 'gpt-4o',
+      openaiKeyCiphertext: encryptField('sk-db-secret'),
+    };
     const { svc } = make({ ENCRYPTION_KEY: HEX_KEY }, row);
-    const resolved = await svc.resolve();
-    expect(resolved).toMatchObject({ provider: 'openai', model: 'gpt-4o', apiKey: 'sk-db-secret', keySource: 'db' });
+    expect(await svc.resolve()).toMatchObject({
+      provider: 'openai',
+      model: 'gpt-4o',
+      apiKey: 'sk-db-secret',
+      keySource: 'db',
+    });
   });
 
-  it('resolve returns null when no key is available anywhere', async () => {
-    const { svc } = make({ ENCRYPTION_KEY: HEX_KEY }, { provider: 'anthropic', model: null, apiKeyCiphertext: null });
+  it('resolve returns null when the active provider has no key — even if another does', async () => {
+    // The bug this fixes: provider switched to google, but only an OpenAI key is stored.
+    const row = {
+      provider: 'google',
+      model: null,
+      openaiKeyCiphertext: encryptField('sk-openai'),
+    };
+    const { svc } = make({ ENCRYPTION_KEY: HEX_KEY }, row);
     expect(await svc.resolve()).toBeNull();
   });
 
-  it('view masks the key and never returns it in full', async () => {
-    const row = { provider: 'anthropic', model: null, apiKeyCiphertext: encryptField('sk-abcdefgh1234') };
+  it('view masks each provider key and reports configured providers', async () => {
+    const row = {
+      provider: 'google',
+      model: 'gemini-3.5-flash',
+      openaiKeyCiphertext: encryptField('sk-abcdefgh1234'),
+      googleKeyCiphertext: encryptField('AIzaSyXXXXwxyz'),
+    };
     const { svc } = make({ ENCRYPTION_KEY: HEX_KEY }, row);
     const view = await svc.view();
-    expect(view.enabled).toBe(true);
-    expect(view.keySource).toBe('db');
-    expect(view.keyMasked).toBe('sk-…1234');
-    expect(view.model).toBe('claude-opus-4-8'); // default filled in
+
+    expect(view.enabled).toBe(true); // active = google, which has a key
+    expect(view.provider).toBe('google');
+    expect(view.model).toBe('gemini-3.5-flash');
+    expect(view.configuredProviders.sort()).toEqual(['google', 'openai']);
+    expect(view.providerStatus.openai.keyMasked).toBe('sk-…1234');
+    expect(view.providerStatus.google.keyMasked).toBe('AIz…wxyz');
+    expect(view.providerStatus.anthropic.hasKey).toBe(false);
     expect(JSON.stringify(view)).not.toContain('abcdefgh');
   });
 
-  it('update encrypts the API key and persists provider/model', async () => {
-    const { svc, db } = make({ ENCRYPTION_KEY: HEX_KEY });
-    await svc.update({ provider: 'openai', model: 'gpt-4o', apiKey: 'sk-plaintext' });
+  it('update stores the key in the selected provider column, leaving others untouched', async () => {
+    const row = { provider: 'openai', model: 'gpt-4o', openaiKeyCiphertext: encryptField('sk-old') };
+    const { svc, db } = make({ ENCRYPTION_KEY: HEX_KEY }, row);
+    await svc.update({ provider: 'google', model: 'gemini-3.5-flash', apiKey: 'AIza-new' });
     const stored = (db as any).captured.values;
-    expect(stored.provider).toBe('openai');
-    expect(stored.model).toBe('gpt-4o');
-    expect(stored.apiKeyCiphertext).not.toBe('sk-plaintext');
-    expect(stored.apiKeyCiphertext).toContain(':'); // iv:tag:ciphertext
+    expect(stored.provider).toBe('google');
+    expect(stored.model).toBe('gemini-3.5-flash');
+    expect(stored.googleKeyCiphertext).toContain(':'); // iv:tag:ciphertext
+    expect(stored.googleKeyCiphertext).not.toBe('AIza-new');
+    expect(stored.openaiKeyCiphertext).toBeUndefined(); // not overwritten
+  });
+
+  it('switching provider without a key leaves all keys untouched', async () => {
+    const { svc, db } = make({ ENCRYPTION_KEY: HEX_KEY });
+    await svc.update({ provider: 'anthropic' });
+    const stored = (db as any).captured.values;
+    expect(stored.provider).toBe('anthropic');
+    expect(stored.anthropicKeyCiphertext).toBeUndefined();
   });
 
   it('update refuses to store a key when ENCRYPTION_KEY is absent', async () => {
-    const { svc } = make({}); // canStoreKey() false
+    const { svc } = make({});
     await expect(svc.update({ provider: 'openai', apiKey: 'sk-x' })).rejects.toThrow(
       /ENCRYPTION_KEY/,
     );

--- a/apps/api/src/advisor/advisor-settings.service.ts
+++ b/apps/api/src/advisor/advisor-settings.service.ts
@@ -15,13 +15,26 @@ const ENV_KEY: Record<LlmProviderId, string> = {
   google: 'GOOGLE_API_KEY',
 };
 
+/** Row column holding each provider's encrypted key. */
+const KEY_COLUMN: Record<LlmProviderId, string> = {
+  anthropic: 'anthropicKeyCiphertext',
+  openai: 'openaiKeyCiphertext',
+  google: 'googleKeyCiphertext',
+};
+
 /** What the advisor loop needs to run: which provider, which model, and the key. */
 export interface ResolvedAdvisorConfig {
   provider: LlmProviderId;
   model: string;
   apiKey: string;
-  /** Where the key came from — surfaced (not the key) so the UI can explain state. */
   keySource: 'env' | 'db';
+}
+
+/** Per-provider key state (no secret — just whether/where a key exists + a mask). */
+export interface ProviderKeyStatus {
+  hasKey: boolean;
+  keySource: 'env' | 'db' | null;
+  keyMasked: string | null;
 }
 
 /** Public, key-free view of the current settings for the web UI. */
@@ -29,22 +42,23 @@ export interface AdvisorSettingsView {
   provider: LlmProviderId;
   model: string;
   enabled: boolean;
-  /** True when a key is available from either env or the DB. */
   hasKey: boolean;
   keySource: 'env' | 'db' | null;
-  /** Masked hint like `sk-…a1b2`, or null. Never the full key. */
   keyMasked: string | null;
-  /** True when at-rest key storage is possible (ENCRYPTION_KEY present). */
   canStoreKey: boolean;
   providers: LlmProviderId[];
   defaultModels: Record<LlmProviderId, string>;
+  /** Per-provider key state so the UI can show configured providers + drive the switcher. */
+  providerStatus: Record<LlmProviderId, ProviderKeyStatus>;
+  /** Providers that currently have a key (env or DB) — ready to be selected. */
+  configuredProviders: LlmProviderId[];
 }
 
 /**
  * Reads/writes the global advisor settings singleton and resolves the effective
- * provider/model/key. Precedence for the key: provider env var first, then the
- * (decrypted) DB value — so ops can always pin a key via the NAS .env while the
- * web UI stays a convenience layer. The key is never returned to callers.
+ * provider/model/key. Each provider has its own encrypted key so switching provider
+ * never sends the wrong key. Key precedence: provider env var first, then the
+ * (decrypted) per-provider DB value. Keys are never returned to callers.
  */
 @Injectable()
 export class AdvisorSettingsService {
@@ -64,12 +78,7 @@ export class AdvisorSettingsService {
     return !!hex && hex.length === 64;
   }
 
-  /** Load the singleton row (id=1), or null if never saved. */
-  private async loadRow(): Promise<{
-    provider: string;
-    model: string | null;
-    apiKeyCiphertext: string | null;
-  } | null> {
+  private async loadRow(): Promise<any | null> {
     const rows = await this.db
       .select()
       .from(advisorSettings)
@@ -82,66 +91,90 @@ export class AdvisorSettingsService {
     return this.config.get<string>(ENV_KEY[provider]);
   }
 
-  /** Resolve the effective config, or null if no key is available anywhere. */
-  async resolve(): Promise<ResolvedAdvisorConfig | null> {
-    const row = await this.loadRow();
-    const provider: LlmProviderId =
-      row && this.isProvider(row.provider) ? row.provider : 'anthropic';
-    const model = row?.model || DEFAULT_MODELS[provider];
+  private ciphertext(row: any | null, provider: LlmProviderId): string | null {
+    return (row?.[KEY_COLUMN[provider]] as string | null) ?? null;
+  }
 
-    const envKey = this.envKey(provider);
-    if (envKey) {
-      return { provider, model, apiKey: envKey, keySource: 'env' };
-    }
-    if (row?.apiKeyCiphertext && this.canStoreKey()) {
+  /** Effective key for a provider (env → per-provider DB), or null. */
+  private keyFor(
+    row: any | null,
+    provider: LlmProviderId,
+  ): { apiKey: string; keySource: 'env' | 'db' } | null {
+    const env = this.envKey(provider);
+    if (env) return { apiKey: env, keySource: 'env' };
+    const ct = this.ciphertext(row, provider);
+    if (ct && this.canStoreKey()) {
       try {
-        const apiKey = decryptField(row.apiKeyCiphertext);
-        if (apiKey) return { provider, model, apiKey, keySource: 'db' };
+        const apiKey = decryptField(ct);
+        if (apiKey) return { apiKey, keySource: 'db' };
       } catch (err: any) {
-        this.logger.error(`Failed to decrypt advisor API key: ${err.message}`);
+        this.logger.error(`Failed to decrypt ${provider} advisor key: ${err.message}`);
       }
     }
     return null;
   }
 
+  private activeProvider(row: any | null): LlmProviderId {
+    return row && this.isProvider(row.provider) ? row.provider : 'anthropic';
+  }
+
+  /** Resolve the effective config for the active provider, or null if it has no key. */
+  async resolve(): Promise<ResolvedAdvisorConfig | null> {
+    const row = await this.loadRow();
+    const provider = this.activeProvider(row);
+    const model = row?.model || DEFAULT_MODELS[provider];
+    const key = this.keyFor(row, provider);
+    return key ? { provider, model, apiKey: key.apiKey, keySource: key.keySource } : null;
+  }
+
+  /** Resolve for a specific provider (used to test a provider's stored key). */
+  async resolveFor(
+    provider: LlmProviderId,
+    model?: string,
+  ): Promise<{ model: string; apiKey: string } | null> {
+    const row = await this.loadRow();
+    const key = this.keyFor(row, provider);
+    if (!key) return null;
+    return { model: model?.trim() || row?.model || DEFAULT_MODELS[provider], apiKey: key.apiKey };
+  }
+
   /** Key-free settings view for the web UI. */
   async view(): Promise<AdvisorSettingsView> {
     const row = await this.loadRow();
-    const provider: LlmProviderId =
-      row && this.isProvider(row.provider) ? row.provider : 'anthropic';
+    const provider = this.activeProvider(row);
     const model = row?.model || DEFAULT_MODELS[provider];
 
-    const envKey = this.envKey(provider);
-    const hasDbKey = !!row?.apiKeyCiphertext && this.canStoreKey();
-    const keySource: 'env' | 'db' | null = envKey ? 'env' : hasDbKey ? 'db' : null;
-
-    let keyMasked: string | null = null;
-    if (envKey) {
-      keyMasked = this.mask(envKey);
-    } else if (hasDbKey) {
-      try {
-        keyMasked = this.mask(decryptField(row!.apiKeyCiphertext!));
-      } catch {
-        keyMasked = null;
-      }
+    const providerStatus = {} as Record<LlmProviderId, ProviderKeyStatus>;
+    for (const p of PROVIDERS) {
+      const key = this.keyFor(row, p);
+      providerStatus[p] = {
+        hasKey: !!key,
+        keySource: key?.keySource ?? null,
+        keyMasked: key ? this.mask(key.apiKey) : null,
+      };
     }
+    const active = providerStatus[provider];
+    const configuredProviders = PROVIDERS.filter((p) => providerStatus[p].hasKey);
 
     return {
       provider,
       model,
-      enabled: keySource !== null,
-      hasKey: keySource !== null,
-      keySource,
-      keyMasked,
+      enabled: active.hasKey,
+      hasKey: active.hasKey,
+      keySource: active.keySource,
+      keyMasked: active.keyMasked,
       canStoreKey: this.canStoreKey(),
       providers: PROVIDERS,
       defaultModels: DEFAULT_MODELS,
+      providerStatus,
+      configuredProviders,
     };
   }
 
   /**
-   * Update provider/model, and optionally the API key. Passing an apiKey stores
-   * it encrypted; omitting it leaves the stored key untouched (write-only field).
+   * Update the active provider/model, and optionally a key. A provided apiKey is stored
+   * (encrypted) in the *selected provider's* column; omitting it leaves keys untouched —
+   * so switching provider never overwrites or misuses another provider's key.
    */
   async update(input: {
     provider?: string;
@@ -152,30 +185,27 @@ export class AdvisorSettingsService {
     const provider =
       input.provider && this.isProvider(input.provider)
         ? input.provider
-        : row && this.isProvider(row.provider)
-          ? row.provider
-          : 'anthropic';
+        : this.activeProvider(row);
 
-    // Empty string ⇒ leave model default (null); non-empty ⇒ set it.
     const model =
       input.model !== undefined ? input.model.trim() || null : (row?.model ?? null);
 
-    let apiKeyCiphertext = row?.apiKeyCiphertext ?? null;
+    const keyUpdate: Record<string, string> = {};
     if (input.apiKey !== undefined && input.apiKey.trim()) {
       if (!this.canStoreKey()) {
         throw new Error(
           'Cannot store an API key: ENCRYPTION_KEY is not configured on the server.',
         );
       }
-      apiKeyCiphertext = encryptField(input.apiKey.trim());
+      keyUpdate[KEY_COLUMN[provider]] = encryptField(input.apiKey.trim());
     }
 
     await this.db
       .insert(advisorSettings)
-      .values({ id: 1, provider, model, apiKeyCiphertext, updatedAt: new Date() })
+      .values({ id: 1, provider, model, ...keyUpdate, updatedAt: new Date() })
       .onConflictDoUpdate({
         target: advisorSettings.id,
-        set: { provider, model, apiKeyCiphertext, updatedAt: new Date() },
+        set: { provider, model, ...keyUpdate, updatedAt: new Date() },
       });
 
     return this.view();

--- a/apps/api/src/advisor/advisor.controller.ts
+++ b/apps/api/src/advisor/advisor.controller.ts
@@ -48,6 +48,8 @@ export class AdvisorController {
         provider: view.provider,
         model: view.model,
         disclaimer: ADVISOR_DISCLAIMER,
+        configuredProviders: view.configuredProviders,
+        defaultModels: view.defaultModels,
       },
     };
   }
@@ -81,6 +83,14 @@ export class AdvisorController {
         provider = (body.provider as LlmProviderId) ?? 'anthropic';
         model = body.model?.trim() || DEFAULT_MODELS[provider];
         apiKey = body.apiKey.trim();
+      } else if (body.provider) {
+        // Test the selected provider's stored key.
+        provider = body.provider as LlmProviderId;
+        const resolved = await this.settings.resolveFor(provider, body.model);
+        if (!resolved) {
+          return { data: { ok: false, error: `No API key configured for ${provider}.` } };
+        }
+        ({ model, apiKey } = resolved);
       } else {
         const resolved = await this.settings.resolve();
         if (!resolved) {

--- a/apps/api/src/advisor/llm/types.ts
+++ b/apps/api/src/advisor/llm/types.ts
@@ -72,5 +72,5 @@ export interface LlmProvider {
 export const DEFAULT_MODELS: Record<LlmProviderId, string> = {
   anthropic: 'claude-opus-4-8',
   openai: 'gpt-4o',
-  google: 'gemini-2.5-flash',
+  google: 'gemini-3.5-flash',
 };

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -592,7 +592,11 @@ export const advisorSettings = pgTable('advisor_settings', {
   id: integer('id').primaryKey().default(1),
   provider: varchar('provider', { length: 20 }).notNull().default('anthropic'),
   model: varchar('model', { length: 100 }),
+  /** Legacy single key (pre per-provider); migrated into the per-provider columns below. */
   apiKeyCiphertext: text('api_key_ciphertext'),
+  anthropicKeyCiphertext: text('anthropic_key_ciphertext'),
+  openaiKeyCiphertext: text('openai_key_ciphertext'),
+  googleKeyCiphertext: text('google_key_ciphertext'),
   updatedAt: timestamp('updated_at', { withTimezone: true })
     .notNull()
     .defaultNow(),

--- a/apps/web/src/app/(protected)/advisor/page.tsx
+++ b/apps/web/src/app/(protected)/advisor/page.tsx
@@ -29,15 +29,38 @@ export default function AdvisorPage() {
     disclaimer: string;
     provider?: string;
     model?: string;
+    configuredProviders?: string[];
+    defaultModels?: Record<string, string>;
   } | null>(null);
+  const [switching, setSwitching] = useState(false);
   const endRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
+  const loadStatus = () =>
     fetch(`${API_BASE}/advisor/status`, { credentials: 'include' })
       .then((r) => (r.ok ? r.json() : null))
       .then((j) => j && setStatus(j.data))
       .catch(() => {});
+
+  useEffect(() => {
+    loadStatus();
   }, []);
+
+  /** Switch the active provider inline (uses that provider's stored key). */
+  const switchProvider = async (next: string) => {
+    if (!next || next === status?.provider) return;
+    setSwitching(true);
+    try {
+      await fetch(`${API_BASE}/advisor/settings`, {
+        method: 'PUT',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ provider: next, model: status?.defaultModels?.[next] }),
+      });
+      await loadStatus();
+    } finally {
+      setSwitching(false);
+    }
+  };
 
   useEffect(() => {
     endRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -55,13 +78,33 @@ export default function AdvisorPage() {
         <Sparkles className="w-6 h-6 text-[var(--primary)]" />
         <h1 className="text-2xl font-bold">Advisor</h1>
         {status?.enabled && status.provider && (
-          <span
-            title="Configured in Settings → AI Advisor"
-            className="ml-1 rounded-full border border-[var(--border)] bg-[var(--muted)]/50 px-2 py-0.5 text-xs text-[var(--muted-foreground)]"
-          >
-            via {PROVIDER_LABELS[status.provider] ?? status.provider}
-            {status.model ? ` · ${status.model}` : ''}
-          </span>
+          <div className="ml-1 flex items-center gap-1.5">
+            {(status.configuredProviders?.length ?? 0) > 1 ? (
+              <select
+                value={status.provider}
+                disabled={switching}
+                onChange={(e) => switchProvider(e.target.value)}
+                title="Switch provider — uses that provider's saved key"
+                className="rounded-full border border-[var(--border)] bg-[var(--muted)]/50 px-2 py-0.5 text-xs text-[var(--muted-foreground)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)]/30 disabled:opacity-50"
+              >
+                {status.configuredProviders!.map((p) => (
+                  <option key={p} value={p}>
+                    via {PROVIDER_LABELS[p] ?? p}
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <span
+                title="Configured in Settings → AI Advisor"
+                className="rounded-full border border-[var(--border)] bg-[var(--muted)]/50 px-2 py-0.5 text-xs text-[var(--muted-foreground)]"
+              >
+                via {PROVIDER_LABELS[status.provider] ?? status.provider}
+              </span>
+            )}
+            {status.model && (
+              <span className="text-xs text-[var(--muted-foreground)]">· {status.model}</span>
+            )}
+          </div>
         )}
       </div>
 

--- a/apps/web/src/components/AdvisorSettingsSection.tsx
+++ b/apps/web/src/components/AdvisorSettingsSection.tsx
@@ -6,6 +6,12 @@ import { api } from '@/lib/api';
 
 type Provider = 'anthropic' | 'openai' | 'google';
 
+interface ProviderKeyStatus {
+  hasKey: boolean;
+  keySource: 'env' | 'db' | null;
+  keyMasked: string | null;
+}
+
 interface AdvisorSettingsView {
   provider: Provider;
   model: string;
@@ -16,6 +22,8 @@ interface AdvisorSettingsView {
   canStoreKey: boolean;
   providers: Provider[];
   defaultModels: Record<Provider, string>;
+  providerStatus: Record<Provider, ProviderKeyStatus>;
+  configuredProviders: Provider[];
 }
 
 const PROVIDER_LABELS: Record<Provider, string> = {
@@ -48,6 +56,9 @@ export function AdvisorSettingsSection() {
   }, []);
 
   const isError = message.toLowerCase().includes('fail') || message.includes('✗');
+
+  // Key state for the currently-selected provider (each provider has its own key).
+  const ps = view?.providerStatus?.[provider];
 
   async function save() {
     setBusy(true);
@@ -96,9 +107,10 @@ export function AdvisorSettingsSection() {
         <h2 className="text-lg font-bold">AI Advisor</h2>
       </div>
       <p className="text-sm text-[var(--muted-foreground)]">
-        Choose the model that powers the Advisor chat. Your API key is stored encrypted and
-        never shown again. An <code>ANTHROPIC_API_KEY</code>/<code>OPENAI_API_KEY</code> set in
-        the server environment takes precedence.
+        Choose the model that powers the Advisor chat. Each provider keeps its own API key
+        (stored encrypted, never shown again), so you can switch providers without re-entering
+        keys. A matching <code>ANTHROPIC_API_KEY</code>/<code>OPENAI_API_KEY</code>/
+        <code>GOOGLE_API_KEY</code> in the server environment takes precedence.
       </p>
 
       <div>
@@ -119,6 +131,7 @@ export function AdvisorSettingsSection() {
           {(view?.providers ?? (['anthropic', 'openai', 'google'] as Provider[])).map((p) => (
             <option key={p} value={p}>
               {PROVIDER_LABELS[p]}
+              {view?.providerStatus?.[p]?.hasKey ? ' ✓' : ''}
             </option>
           ))}
         </select>
@@ -143,20 +156,20 @@ export function AdvisorSettingsSection() {
           API key
         </label>
         <p className="mt-0.5 text-xs text-[var(--muted-foreground)]">
-          {view?.keySource === 'env'
-            ? `Using the server environment key (${view.keyMasked}). Entering one here has no effect while the env var is set.`
-            : view?.hasKey
-              ? `A key is saved (${view.keyMasked}). Enter a new one to replace it.`
+          {ps?.keySource === 'env'
+            ? `Using the server environment key (${ps.keyMasked}). Entering one here has no effect while the env var is set.`
+            : ps?.hasKey
+              ? `A key is saved for ${PROVIDER_LABELS[provider]} (${ps.keyMasked}). Enter a new one to replace it.`
               : view?.canStoreKey === false
                 ? 'Set ENCRYPTION_KEY on the server to store a key here, or use the environment variable.'
-                : 'No key saved yet.'}
+                : `No key saved for ${PROVIDER_LABELS[provider]} yet.`}
         </p>
         <input
           id="advisor-key"
           type="password"
           value={apiKey}
           onChange={(e) => setApiKey(e.target.value)}
-          placeholder={view?.hasKey ? '•••••••• (unchanged)' : 'sk-…'}
+          placeholder={ps?.hasKey ? '•••••••• (unchanged)' : 'sk-…'}
           autoComplete="off"
           className="mt-1.5 block w-full rounded-xl border border-[var(--border)] bg-[var(--card)] px-3 py-2.5 text-sm font-mono placeholder:text-[var(--muted-foreground)] focus:border-[var(--primary)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)]/30"
         />

--- a/db/migrations/0010_advisor_per_provider_keys.sql
+++ b/db/migrations/0010_advisor_per_provider_keys.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "advisor_settings" ADD COLUMN IF NOT EXISTS "anthropic_key_ciphertext" text;--> statement-breakpoint
+ALTER TABLE "advisor_settings" ADD COLUMN IF NOT EXISTS "openai_key_ciphertext" text;--> statement-breakpoint
+ALTER TABLE "advisor_settings" ADD COLUMN IF NOT EXISTS "google_key_ciphertext" text;--> statement-breakpoint
+UPDATE "advisor_settings" SET "anthropic_key_ciphertext" = "api_key_ciphertext"
+  WHERE "provider" = 'anthropic' AND "api_key_ciphertext" IS NOT NULL AND "anthropic_key_ciphertext" IS NULL;--> statement-breakpoint
+UPDATE "advisor_settings" SET "openai_key_ciphertext" = "api_key_ciphertext"
+  WHERE "provider" = 'openai' AND "api_key_ciphertext" IS NOT NULL AND "openai_key_ciphertext" IS NULL;--> statement-breakpoint
+UPDATE "advisor_settings" SET "google_key_ciphertext" = "api_key_ciphertext"
+  WHERE "provider" = 'google' AND "api_key_ciphertext" IS NOT NULL AND "google_key_ciphertext" IS NULL;

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1783200200000,
       "tag": "0009_advisor_digest_enabled",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1783200300000,
+      "tag": "0010_advisor_per_provider_keys",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Closes #73. Fixes the API_KEY_INVALID footgun (one global key sent to the wrong provider) and adds the inline switcher.

- **Per-provider keys**: schema + idempotent migration 0010 (anthropic/openai/google key columns; existing key migrated into the active provider's column). resolve() only ever uses the active provider's own key.
- **Settings UI**: enter/replace a key per provider, with ✓ indicators for configured ones.
- **Advisor header switcher**: pick among providers that have a key; switches on the fly (badge when only one).
- Default Gemini model → **gemini-3.5-flash**.

Advisor suite green (42) incl. per-provider isolation tests. Deploy: **db:migrate** then web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)