### PR TITLE
feat(advisor): net worth incl. investments + bills + subscriptions (Batch 1b-1) (#75)

### DIFF
--- a/apps/api/src/advisor/__tests__/mcp-client.service.spec.ts
+++ b/apps/api/src/advisor/__tests__/mcp-client.service.spec.ts
@@ -15,6 +15,8 @@ const ALL_TOOLS = [
   { name: 'get_cashflow_summary', description: 'h', inputSchema: { type: 'object' } },
   { name: 'get_income_breakdown', description: 'i', inputSchema: { type: 'object' } },
   { name: 'get_net_worth', description: 'j', inputSchema: { type: 'object' } },
+  { name: 'get_upcoming_bills', description: 'k', inputSchema: { type: 'object' } },
+  { name: 'get_subscriptions', description: 'l', inputSchema: { type: 'object' } },
   { name: 'compare_periods', description: 'f', inputSchema: { type: 'object' } },
   { name: 'get_transactions', description: 'ROW-LEVEL', inputSchema: { type: 'object' } },
   { name: 'search_transactions', description: 'ROW-LEVEL', inputSchema: { type: 'object' } },

--- a/apps/api/src/advisor/mcp-client.service.ts
+++ b/apps/api/src/advisor/mcp-client.service.ts
@@ -20,6 +20,8 @@ export const AGGREGATE_TOOL_ALLOWLIST = new Set([
   'get_cashflow_summary',
   'get_income_breakdown',
   'get_net_worth',
+  'get_upcoming_bills',
+  'get_subscriptions',
   'compare_periods',
 ]);
 

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -13,6 +13,8 @@ import { registerGetMerchantBreakdown } from './tools/get-merchant-breakdown.js'
 import { registerGetCashflowSummary } from './tools/get-cashflow-summary.js';
 import { registerGetIncomeBreakdown } from './tools/get-income-breakdown.js';
 import { registerGetNetWorth } from './tools/get-net-worth.js';
+import { registerGetUpcomingBills } from './tools/get-upcoming-bills.js';
+import { registerGetSubscriptions } from './tools/get-subscriptions.js';
 import { close } from './db.js';
 import http from 'node:http';
 
@@ -33,6 +35,8 @@ registerGetMerchantBreakdown(server);
 registerGetCashflowSummary(server);
 registerGetIncomeBreakdown(server);
 registerGetNetWorth(server);
+registerGetUpcomingBills(server);
+registerGetSubscriptions(server);
 
 const mode = process.argv.includes('--sse') ? 'sse' : 'stdio';
 

--- a/apps/mcp-server/src/tools/get-net-worth.ts
+++ b/apps/mcp-server/src/tools/get-net-worth.ts
@@ -31,14 +31,50 @@ export function registerGetNetWorth(server: McpServer) {
          GROUP BY a.id, a.starting_balance_cents`,
         [userId],
       );
-      let assets = 0;
+      let cashAssets = 0;
       let liabilities = 0;
       for (const r of balRows) {
         const bal = Number(r.bal);
-        if (bal >= 0) assets += bal;
+        if (bal >= 0) cashAssets += bal;
         else liabilities += bal; // negative
       }
+
+      // Current investment/brokerage value = latest snapshot balance per active account.
+      const investRows = await query(
+        `SELECT COALESCE(SUM(latest.balance_cents), 0) AS invest_cents
+         FROM investment_accounts ia
+         JOIN LATERAL (
+           SELECT balance_cents FROM investment_snapshots s
+           WHERE s.investment_account_id = ia.id
+           ORDER BY s.date DESC LIMIT 1
+         ) latest ON true
+         WHERE ia.user_id = $1 AND ia.deleted_at IS NULL`,
+        [userId],
+      );
+      const investments = Number(investRows[0]?.invest_cents ?? 0);
+      const assets = cashAssets + investments;
       const netWorth = assets + liabilities;
+
+      // Investment value at each month-end (latest snapshot on/before month end).
+      const investTrend = await query(
+        `SELECT to_char(m, 'YYYY-MM') AS ym, COALESCE(SUM(sv.balance_cents), 0) AS invest_cents
+         FROM generate_series(
+                date_trunc('month', CURRENT_DATE) - make_interval(months => $2 - 1),
+                date_trunc('month', CURRENT_DATE),
+                interval '1 month'
+              ) AS m
+         LEFT JOIN investment_accounts ia ON ia.user_id = $1 AND ia.deleted_at IS NULL
+         LEFT JOIN LATERAL (
+           SELECT balance_cents FROM investment_snapshots s
+           WHERE s.investment_account_id = ia.id AND s.date < (m + interval '1 month')
+           ORDER BY s.date DESC LIMIT 1
+         ) sv ON true
+         GROUP BY m ORDER BY m`,
+        [userId, params.months],
+      );
+      const investByMonth = new Map<string, number>(
+        investTrend.map((r) => [r.ym as string, Number(r.invest_cents)]),
+      );
 
       // Month-end net worth = starting balances + cumulative signed transactions by month.
       const trendRows = await query(
@@ -65,15 +101,22 @@ export function registerGetNetWorth(server: McpServer) {
       const recent = trendRows.slice(-params.months);
       const trendLines = recent.map((r) => {
         const label = new Date(r.m).toISOString().slice(0, 7); // YYYY-MM
-        return `${label}: ${signed(Number(r.net_worth_cents))}`;
+        const cash = Number(r.net_worth_cents);
+        const invest = investByMonth.get(label) ?? 0;
+        return `${label}: ${signed(cash + invest)}`;
       });
+
+      const assetLine =
+        investments > 0
+          ? `  Assets: ${dollars(assets)} (cash ${dollars(cashAssets)} + investments ${dollars(investments)})`
+          : `  Assets: ${dollars(assets)}`;
 
       const text = [
         `Net worth: ${signed(netWorth)}`,
-        `  Assets: ${dollars(assets)}`,
+        assetLine,
         `  Liabilities: ${signed(liabilities)}`,
         '',
-        `Month-end net worth (last ${recent.length} month${recent.length === 1 ? '' : 's'}):`,
+        `Month-end net worth (last ${recent.length} month${recent.length === 1 ? '' : 's'}, incl. investments):`,
         trendLines.length ? trendLines.join('\n') : '(not enough history)',
       ].join('\n');
 

--- a/apps/mcp-server/src/tools/get-subscriptions.ts
+++ b/apps/mcp-server/src/tools/get-subscriptions.ts
@@ -1,0 +1,60 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { query, getUserId } from '../db.js';
+
+/** Rough monthly-equivalent multiplier by frequency. */
+const MONTHLY: Record<string, number> = {
+  weekly: 4.345,
+  biweekly: 2.173,
+  monthly: 1,
+  quarterly: 1 / 3,
+  yearly: 1 / 12,
+  annual: 1 / 12,
+};
+
+export function registerGetSubscriptions(server: McpServer) {
+  server.tool(
+    'get_subscriptions',
+    'Active recurring subscriptions/bills with their amount, cadence, and any price change vs the usual amount. Answers "what am I subscribed to" and "did any subscription change price".',
+    {},
+    async () => {
+      const userId = await getUserId();
+      const rows = await query(
+        `SELECT normalized_name, expected_amount_cents, last_amount_cents,
+                amount_tolerance_percent, frequency
+         FROM recurring_bills
+         WHERE user_id = $1 AND is_active = true
+         ORDER BY expected_amount_cents DESC`,
+        [userId],
+      );
+
+      if (rows.length === 0) {
+        return { content: [{ type: 'text' as const, text: 'No active subscriptions tracked.' }] };
+      }
+
+      const dollars = (c: number) => `$${(Math.abs(c) / 100).toFixed(2)}`;
+      let monthlyTotal = 0;
+      const lines = rows.map((r) => {
+        const expected = Number(r.expected_amount_cents);
+        const freq = String(r.frequency || 'monthly');
+        monthlyTotal += expected * (MONTHLY[freq] ?? 1);
+
+        let change = '';
+        const last = r.last_amount_cents == null ? null : Number(r.last_amount_cents);
+        const tol = Number(r.amount_tolerance_percent ?? 0);
+        if (last != null && Math.abs(last - expected) > (expected * tol) / 100) {
+          const diff = last - expected;
+          change = ` — ${diff > 0 ? 'up' : 'down'} ${dollars(diff)} (last charge ${dollars(last)})`;
+        }
+        return `${r.normalized_name} (${freq}): ${dollars(expected)}${change}`;
+      });
+
+      const text = [
+        lines.join('\n'),
+        '',
+        `~${dollars(Math.round(monthlyTotal))}/month across ${rows.length} subscription${rows.length === 1 ? '' : 's'}.`,
+      ].join('\n');
+      return { content: [{ type: 'text' as const, text }] };
+    },
+  );
+}

--- a/apps/mcp-server/src/tools/get-upcoming-bills.ts
+++ b/apps/mcp-server/src/tools/get-upcoming-bills.ts
@@ -1,0 +1,49 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { query, getUserId } from '../db.js';
+
+export function registerGetUpcomingBills(server: McpServer) {
+  server.tool(
+    'get_upcoming_bills',
+    'Recurring bills due within the next N days. Answers "what bills are coming up" / "what\'s due soon".',
+    {
+      days: z.number().min(1).max(90).default(14).describe('Look-ahead window in days'),
+    },
+    async (params) => {
+      const userId = await getUserId();
+      const rows = await query(
+        `SELECT normalized_name, expected_amount_cents, next_expected_date, frequency
+         FROM recurring_bills
+         WHERE user_id = $2
+           AND is_active = true
+           AND next_expected_date IS NOT NULL
+           AND next_expected_date >= NOW()
+           AND next_expected_date < NOW() + make_interval(days => $1)
+         ORDER BY next_expected_date ASC`,
+        [params.days, userId],
+      );
+
+      if (rows.length === 0) {
+        return {
+          content: [
+            { type: 'text' as const, text: `No bills due in the next ${params.days} days.` },
+          ],
+        };
+      }
+
+      const dollars = (c: number) => `$${(c / 100).toFixed(2)}`;
+      const total = rows.reduce((s, r) => s + Number(r.expected_amount_cents), 0);
+      const lines = rows.map((r) => {
+        const due = new Date(r.next_expected_date).toISOString().slice(0, 10);
+        return `${r.normalized_name} (${r.frequency}): ${dollars(Number(r.expected_amount_cents))} due ${due}`;
+      });
+
+      const text = [
+        lines.join('\n'),
+        '',
+        `Total due in next ${params.days} days: ${dollars(total)}`,
+      ].join('\n');
+      return { content: [{ type: 'text' as const, text }] };
+    },
+  );
+}

--- a/tasks.md
+++ b/tasks.md
@@ -26,14 +26,19 @@ Key precedence: env (`ANTHROPIC_API_KEY`/`OPENAI_API_KEY`/`GOOGLE_API_KEY`) → 
 MCP tools the advisor can call (aggregates-only allowlist in `mcp-client.service.ts`):
 `get_account_balances`, `get_spending_summary`, `get_category_breakdown` (+parent subtotals #61),
 `get_budget_status`, `compare_periods`, `get_recurring_expenses`, `get_merchant_breakdown` (#63),
-`get_cashflow_summary` · `get_income_breakdown` · `get_net_worth` (#65). Row-level
+`get_cashflow_summary` · `get_income_breakdown` · `get_net_worth` (#65, +investments #75),
+`get_upcoming_bills` · `get_subscriptions` (#75). Row-level
 `get_transactions`/`search_transactions` are **excluded** from the cloud allowlist.
+
+Providers use **per-provider keys** (#73/#74): each of Claude/OpenAI/Gemini stores its own
+encrypted key; inline switcher in the advisor header; active-provider badge; default
+`gemini-3.5-flash`. Migration 0010 added the key columns.
 
 | Batch | Tools | Status |
 |---|---|---|
 | 1a | cash flow + savings rate, income breakdown, net worth (current + trend) | ✅ #65 deployed |
-| — | **net worth: include investments/brokerage** (currently accounts-only, understates) | ⏳ next |
-| 1b | forecast / safe-to-spend, upcoming bills, subscriptions + price changes | ⏳ |
+| 1b-1 | net worth incl. investments, upcoming bills, subscriptions | ✅ #75 |
+| 1b-2 | forecast / safe-to-spend | ⏳ next |
 | 1c | category trend over time, budget on-track history, unusual-charges feed | ⏳ |
 
 ### Big features (own phases — need schema/design)


### PR DESCRIPTION
Closes #75. net_worth now includes investment/brokerage holdings (current + month-end trend). Adds get_upcoming_bills and get_subscriptions (with price-change flags). All aggregate, on the allowlist. mcp guardrail 58, advisor 42. API-only deploy. 🤖 Generated with [Claude Code](https://claude.com/claude-code)