### PR TITLE
fix(deploy): don't sync local .env to NAS (clobbered secrets)

### DIFF
--- a/deploy-to-nas.sh
+++ b/deploy-to-nas.sh
@@ -64,6 +64,8 @@ sync_code() {
         --exclude=coverage \
         --exclude=tmp \
         --exclude=.turbo \
+        --exclude=./.env \
+        --exclude=./.env.local \
         . 2>/dev/null || \
     COPYFILE_DISABLE=1 tar czf "$TMP_ARCHIVE" \
         --exclude=node_modules \
@@ -73,6 +75,8 @@ sync_code() {
         --exclude=coverage \
         --exclude=tmp \
         --exclude=.turbo \
+        --exclude=./.env \
+        --exclude=./.env.local \
         .
 
     local size


### PR DESCRIPTION
The deploy tar didn't exclude .env, so every deploy overwrote the NAS-only secrets file with the local Mac .env — wiping anything added on the NAS (e.g. TELEGRAM_BOT_TOKEN). Exclude ./.env + ./.env.local; leaves apps/web/.env.production and .env.example intact. 🤖 Generated with [Claude Code](https://claude.com/claude-code)