### PR TITLE
feat(advisor): cash-flow forecast / safe-to-spend (Batch 1b-2) (#82)

### DIFF
--- a/apps/api/src/advisor/__tests__/mcp-client.service.spec.ts
+++ b/apps/api/src/advisor/__tests__/mcp-client.service.spec.ts
@@ -17,6 +17,7 @@ const ALL_TOOLS = [
   { name: 'get_net_worth', description: 'j', inputSchema: { type: 'object' } },
   { name: 'get_upcoming_bills', description: 'k', inputSchema: { type: 'object' } },
   { name: 'get_subscriptions', description: 'l', inputSchema: { type: 'object' } },
+  { name: 'get_cashflow_forecast', description: 'm', inputSchema: { type: 'object' } },
   { name: 'compare_periods', description: 'f', inputSchema: { type: 'object' } },
   { name: 'get_transactions', description: 'ROW-LEVEL', inputSchema: { type: 'object' } },
   { name: 'search_transactions', description: 'ROW-LEVEL', inputSchema: { type: 'object' } },

--- a/apps/api/src/advisor/mcp-client.service.ts
+++ b/apps/api/src/advisor/mcp-client.service.ts
@@ -22,6 +22,7 @@ export const AGGREGATE_TOOL_ALLOWLIST = new Set([
   'get_net_worth',
   'get_upcoming_bills',
   'get_subscriptions',
+  'get_cashflow_forecast',
   'compare_periods',
 ]);
 

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -15,6 +15,7 @@ import { registerGetIncomeBreakdown } from './tools/get-income-breakdown.js';
 import { registerGetNetWorth } from './tools/get-net-worth.js';
 import { registerGetUpcomingBills } from './tools/get-upcoming-bills.js';
 import { registerGetSubscriptions } from './tools/get-subscriptions.js';
+import { registerGetCashflowForecast } from './tools/get-cashflow-forecast.js';
 import { close } from './db.js';
 import http from 'node:http';
 
@@ -37,6 +38,7 @@ registerGetIncomeBreakdown(server);
 registerGetNetWorth(server);
 registerGetUpcomingBills(server);
 registerGetSubscriptions(server);
+registerGetCashflowForecast(server);
 
 const mode = process.argv.includes('--sse') ? 'sse' : 'stdio';
 

--- a/apps/mcp-server/src/tools/get-cashflow-forecast.ts
+++ b/apps/mcp-server/src/tools/get-cashflow-forecast.ts
@@ -1,0 +1,84 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { query, getUserId } from '../db.js';
+
+export function registerGetCashflowForecast(server: McpServer) {
+  server.tool(
+    'get_cashflow_forecast',
+    'Short-term cash-flow outlook: current liquid balance (checking/savings), bills due in the window, a conservative "safe to spend", and a projected balance based on recent trend (flags a low-balance date). Answers "will I make it to payday" / "how much is safe to spend".',
+    {
+      days: z.number().min(7).max(120).default(30).describe('Forecast horizon in days'),
+    },
+    async (params) => {
+      const userId = await getUserId();
+      const dollars = (c: number) => `$${(Math.abs(c) / 100).toFixed(2)}`;
+      const signed = (c: number) => `${c < 0 ? '-' : '+'}${dollars(c)}`;
+
+      // 1) Liquid balance across checking/savings accounts.
+      const liquidRows = await query(
+        `SELECT COALESCE(SUM(a.starting_balance_cents + COALESCE(tx.net, 0)), 0) AS liquid_cents
+         FROM accounts a
+         LEFT JOIN (
+           SELECT account_id,
+                  SUM(CASE WHEN is_credit THEN amount_cents ELSE -amount_cents END) AS net
+           FROM transactions
+           WHERE deleted_at IS NULL AND is_split_parent = false
+           GROUP BY account_id
+         ) tx ON tx.account_id = a.id
+         WHERE a.user_id = $1 AND a.deleted_at IS NULL
+           AND a.account_type IN ('checking', 'savings')`,
+        [userId],
+      );
+      const liquid = Number(liquidRows[0]?.liquid_cents ?? 0);
+
+      // 2) Bills due within the window.
+      const billRows = await query(
+        `SELECT COALESCE(SUM(expected_amount_cents), 0) AS bills_cents, COUNT(*) AS bill_count
+         FROM recurring_bills
+         WHERE user_id = $2 AND is_active = true AND next_expected_date IS NOT NULL
+           AND next_expected_date >= NOW()
+           AND next_expected_date < NOW() + make_interval(days => $1)`,
+        [params.days, userId],
+      );
+      const bills = Number(billRows[0]?.bills_cents ?? 0);
+      const billCount = Number(billRows[0]?.bill_count ?? 0);
+
+      // 3) Average daily net cash flow over the last 90 days (excludes transfers).
+      const netRows = await query(
+        `SELECT COALESCE(SUM(CASE WHEN t.is_credit THEN t.amount_cents ELSE -t.amount_cents END), 0) AS net_90d
+         FROM transactions t
+         LEFT JOIN categories c ON t.category_id = c.id
+         WHERE t.user_id = $1 AND t.deleted_at IS NULL AND t.is_split_parent = false
+           AND COALESCE(c.is_transfer, false) = false
+           AND t.date >= CURRENT_DATE - interval '90 days'`,
+        [userId],
+      );
+      const avgDailyNet = Math.round(Number(netRows[0]?.net_90d ?? 0) / 90);
+
+      const projected = liquid + avgDailyNet * params.days;
+      const safeToSpend = liquid - bills;
+
+      const lines = [
+        `Liquid balance (checking/savings): ${dollars(liquid)}`,
+        `Bills due in next ${params.days}d: ${dollars(bills)} across ${billCount} bill${billCount === 1 ? '' : 's'}`,
+        `Safe to spend now (after those bills): ${signed(safeToSpend)}`,
+        `Avg daily net cash flow (last 90d): ${signed(avgDailyNet)}/day`,
+        `Projected liquid balance in ${params.days}d: ${dollars(projected)}`,
+      ];
+
+      // Low-balance warning if the trend runs the liquid balance negative.
+      if (avgDailyNet < 0) {
+        const daysToZero = Math.floor(liquid / -avgDailyNet);
+        if (daysToZero <= params.days) {
+          const d = new Date();
+          d.setDate(d.getDate() + daysToZero);
+          lines.push(
+            `⚠ On the current trend, liquid balance dips below $0 around ${d.toISOString().slice(0, 10)} (~${daysToZero} days).`,
+          );
+        }
+      }
+
+      return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
+    },
+  );
+}

--- a/tasks.md
+++ b/tasks.md
@@ -38,8 +38,8 @@ encrypted key; inline switcher in the advisor header; active-provider badge; def
 |---|---|---|
 | 1a | cash flow + savings rate, income breakdown, net worth (current + trend) | ✅ #65 deployed |
 | 1b-1 | net worth incl. investments, upcoming bills, subscriptions | ✅ #75 |
-| 1b-2 | forecast / safe-to-spend | ⏳ next |
-| 1c | category trend over time, budget on-track history, unusual-charges feed | ⏳ |
+| 1b-2 | cash-flow forecast / safe-to-spend | ✅ #82 |
+| 1c | category trend over time, budget on-track history, unusual-charges feed | ⏳ next |
 
 ### Big features (own phases — need schema/design)
 - **Loan payoff tracker** (mortgage + auto): new `loans` table (principal, rate, term, extra-principal


### PR DESCRIPTION
Closes #82. get_cashflow_forecast(days): liquid balance, upcoming bills, safe-to-spend, avg daily net (90d), projected balance + low-balance flag. Aggregate, on the allowlist. mcp 62, advisor 42. API-only deploy. 🤖 Generated with [Claude Code](https://claude.com/claude-code)