### PR TITLE
fix(bills): roll overdue next_expected_date forward (#84)

### DIFF
--- a/apps/api/src/bills/__tests__/bills.service.spec.ts
+++ b/apps/api/src/bills/__tests__/bills.service.spec.ts
@@ -332,4 +332,37 @@ describe('BillsService', () => {
       await expect(service.update(billId, 'other-user', {})).rejects.toThrow(NotFoundException);
     });
   });
+
+  describe('rollForwardOverdueBills', () => {
+    function makeSvc(overdue: any[]) {
+      const updates: any[] = [];
+      const db = {
+        select: () => ({ from: () => ({ where: async () => overdue }) }),
+        update: () => ({ set: (v: any) => ({ where: async () => updates.push(v) }) }),
+      };
+      const svc = new BillsService(db as any, mockNotifications as any);
+      return { svc, updates };
+    }
+
+    it('advances an overdue monthly bill to the next future date', async () => {
+      const past = new Date();
+      past.setMonth(past.getMonth() - 3);
+      const { svc, updates } = makeSvc([
+        { ...baseBill, nextExpectedDate: past, frequency: 'monthly' },
+      ]);
+
+      const { rolled } = await svc.rollForwardOverdueBills();
+
+      expect(rolled).toBe(1);
+      expect(updates).toHaveLength(1);
+      expect(updates[0].nextExpectedDate.getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('does nothing when no bills are overdue', async () => {
+      const { svc, updates } = makeSvc([]);
+      const { rolled } = await svc.rollForwardOverdueBills();
+      expect(rolled).toBe(0);
+      expect(updates).toHaveLength(0);
+    });
+  });
 });

--- a/apps/api/src/bills/bills.service.ts
+++ b/apps/api/src/bills/bills.service.ts
@@ -345,6 +345,50 @@ export class BillsService {
     return { missedCount, notified };
   }
 
+  // ── Roll forward overdue bills ───────────────────────────
+
+  /**
+   * Advance every active bill whose next_expected_date is in the past to its next
+   * FUTURE occurrence (by frequency). Without this the date never moves once a period
+   * passes, so "upcoming bills" and the cash-flow forecast go permanently empty (#84).
+   * Global sweep (all users); idempotent — future-dated bills are untouched.
+   */
+  async rollForwardOverdueBills(): Promise<{ rolled: number }> {
+    const now = new Date();
+    const overdue = await this.db
+      .select()
+      .from(schema.recurringBills)
+      .where(
+        and(
+          eq(schema.recurringBills.isActive, true),
+          lt(schema.recurringBills.nextExpectedDate, now),
+        ),
+      );
+
+    let rolled = 0;
+    for (const bill of overdue) {
+      if (!bill.nextExpectedDate) continue;
+      const original = new Date(bill.nextExpectedDate).getTime();
+      let next = new Date(bill.nextExpectedDate);
+      // Advance until future; guard against a no-op/unknown frequency.
+      for (let i = 0; i < 600 && next <= now; i++) {
+        const advanced = addFrequency(next, bill.frequency as BillFrequency);
+        if (advanced.getTime() === next.getTime()) break;
+        next = advanced;
+      }
+      if (next.getTime() !== original && next > now) {
+        await this.db
+          .update(schema.recurringBills)
+          .set({ nextExpectedDate: next, updatedAt: new Date() })
+          .where(eq(schema.recurringBills.id, bill.id));
+        rolled++;
+      }
+    }
+
+    if (rolled > 0) this.logger.log(`Rolled ${rolled} overdue bill(s) forward`);
+    return { rolled };
+  }
+
   // ── CRUD ─────────────────────────────────────────────────
 
   async findAll(userId: string) {

--- a/apps/api/src/jobs/alert-cron.processor.ts
+++ b/apps/api/src/jobs/alert-cron.processor.ts
@@ -6,6 +6,7 @@ import { DigestService } from '../analytics/digest.service';
 import { BalanceSnapshotService } from '../analytics/balance-snapshot.service';
 import { ForecastService } from '../analytics/forecast.service';
 import { AdvisorDigestService } from '../advisor/digest/advisor-digest.service';
+import { BillsService } from '../bills/bills.service';
 
 @Processor('alerts')
 export class AlertCronProcessor extends WorkerHost {
@@ -17,6 +18,7 @@ export class AlertCronProcessor extends WorkerHost {
     private readonly balanceSnapshotService: BalanceSnapshotService,
     private readonly forecastService: ForecastService,
     private readonly advisorDigestService: AdvisorDigestService,
+    private readonly billsService: BillsService,
   ) {
     super();
   }
@@ -62,6 +64,12 @@ export class AlertCronProcessor extends WorkerHost {
       case 'cashflow-sweep':
         await this.forecastService.checkAndAlertAll();
         break;
+
+      case 'bills-roll-forward': {
+        const { rolled } = await this.billsService.rollForwardOverdueBills();
+        this.logger.log(`Bills roll-forward: ${rolled} advanced`);
+        break;
+      }
 
       default:
         this.logger.warn(`Unknown alert job: ${job.name}`);

--- a/apps/api/src/jobs/jobs.module.ts
+++ b/apps/api/src/jobs/jobs.module.ts
@@ -8,6 +8,7 @@ import { SyncModule } from '../sync/sync.module';
 import { SyncDeliveryProcessor } from './sync-delivery.processor';
 import { AnalyticsModule } from '../analytics/analytics.module';
 import { AdvisorModule } from '../advisor/advisor.module';
+import { BillsModule } from '../bills/bills.module';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { AdvisorModule } from '../advisor/advisor.module';
     SyncModule,
     AnalyticsModule,
     AdvisorModule,
+    BillsModule,
   ],
   providers: [AlertCronProcessor, ReminderProcessor, SyncDeliveryProcessor],
 })
@@ -88,6 +90,15 @@ export class JobsModule implements OnModuleInit {
       { pattern: '0 6 * * *' },
       { name: 'cashflow-sweep' },
     );
+
+    // Roll overdue recurring bills to their next occurrence (daily 5 AM UTC) so
+    // "upcoming bills" + forecast stay current. Also run once now to fix stale data.
+    await this.alertsQueue.upsertJobScheduler(
+      'daily-bills-roll-forward',
+      { pattern: '0 5 * * *' },
+      { name: 'bills-roll-forward' },
+    );
+    await this.alertsQueue.add('bills-roll-forward', {}, { removeOnComplete: true });
 
     // Frequent sync delivery sweep for outbox events.
     await this.syncQueue.upsertJobScheduler(

--- a/tasks.md
+++ b/tasks.md
@@ -41,8 +41,8 @@ encrypted key; inline switcher in the advisor header; active-provider badge; def
 | 1b-2 | cash-flow forecast / safe-to-spend | ✅ #82 |
 | 1c | category trend, budget history, unusual-charges feed | ✅ #85 |
 
-**Known data gap (#84):** `recurring_bills.next_expected_date` never rolls forward (all in the past) →
-`get_upcoming_bills` + forecast bill line + digest bills signal show empty until fixed.
+Bills roll-forward (#84, done): daily sweep advances overdue `next_expected_date` to the next
+future occurrence (+ runs once on boot) so `get_upcoming_bills` + forecast + digest bills work.
 
 ### Big features (own phases — need schema/design)
 - **Loan payoff tracker** (mortgage + auto): new `loans` table (principal, rate, term, extra-principal


### PR DESCRIPTION
Closes #84. Bills' next_expected_date never advanced, so all bills sat in the past → upcoming-bills/forecast/digest bills empty. Adds a daily roll-forward sweep (+ one run on boot) that advances overdue bills to the next future occurrence. bills+jobs tests green (62). API-only deploy. 🤖 Generated with [Claude Code](https://claude.com/claude-code)