### PR TITLE
feat(loans): payoff tracker Phase 1 — backend + advisor tool (#88)

### DIFF
--- a/apps/api/src/advisor/__tests__/mcp-client.service.spec.ts
+++ b/apps/api/src/advisor/__tests__/mcp-client.service.spec.ts
@@ -21,6 +21,7 @@ const ALL_TOOLS = [
   { name: 'get_category_trend', description: 'n', inputSchema: { type: 'object' } },
   { name: 'get_budget_history', description: 'o', inputSchema: { type: 'object' } },
   { name: 'get_recent_anomalies', description: 'p', inputSchema: { type: 'object' } },
+  { name: 'get_loan_status', description: 'q', inputSchema: { type: 'object' } },
   { name: 'compare_periods', description: 'f', inputSchema: { type: 'object' } },
   { name: 'get_transactions', description: 'ROW-LEVEL', inputSchema: { type: 'object' } },
   { name: 'search_transactions', description: 'ROW-LEVEL', inputSchema: { type: 'object' } },

--- a/apps/api/src/advisor/mcp-client.service.ts
+++ b/apps/api/src/advisor/mcp-client.service.ts
@@ -26,6 +26,7 @@ export const AGGREGATE_TOOL_ALLOWLIST = new Set([
   'get_category_trend',
   'get_budget_history',
   'get_recent_anomalies',
+  'get_loan_status',
   'compare_periods',
 ]);
 

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -21,6 +21,7 @@ import { JobsModule } from './jobs/jobs.module';
 import { AiLogsModule } from './ai-logs/ai-logs.module';
 import { SyncModule } from './sync/sync.module';
 import { BillsModule } from './bills/bills.module';
+import { LoansModule } from './loans/loans.module';
 import { InvestmentsModule } from './investments/investments.module';
 import { AdvisorModule } from './advisor/advisor.module';
 
@@ -65,6 +66,7 @@ import { AdvisorModule } from './advisor/advisor.module';
     JobsModule,
     AiLogsModule,
     BillsModule,
+    LoansModule,
     InvestmentsModule,
     AdvisorModule,
     HealthModule,

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -459,6 +459,33 @@ export const investmentSnapshots = pgTable('investment_snapshots', {
     .defaultNow(),
 });
 
+// ── Loans (mortgage / auto payoff tracker) ──────────────────
+
+export const loans = pgTable('loans', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  userId: uuid('user_id')
+    .notNull()
+    .references(() => users.id),
+  name: varchar('name', { length: 100 }).notNull(),
+  /** Merchant substring identifying this loan's payment transactions (e.g. "Langley Federal"). */
+  lenderPattern: varchar('lender_pattern', { length: 200 }).notNull(),
+  loanType: varchar('loan_type', { length: 30 }).notNull().default('mortgage'),
+  /** Balance at start_date (user-entered). */
+  originalBalanceCents: integer('original_balance_cents').notNull(),
+  /** APR in basis points (3.25% → 325). */
+  aprBps: integer('apr_bps').notNull(),
+  termMonths: integer('term_months'),
+  startDate: date('start_date').notNull(),
+  /** Regular scheduled principal+interest payment. */
+  scheduledPaymentCents: integer('scheduled_payment_cents').notNull(),
+  /** Optional merchant substring for separate extra-principal payments. */
+  extraPrincipalPattern: varchar('extra_principal_pattern', { length: 200 }),
+  isActive: boolean('is_active').notNull().default(true),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  deletedAt: timestamp('deleted_at', { withTimezone: true }),
+});
+
 // ── AI Prompt Logs ──────────────────────────────────────────
 
 export const aiPromptTypeEnum = pgEnum('ai_prompt_type', [

--- a/apps/api/src/loans/loans.controller.ts
+++ b/apps/api/src/loans/loans.controller.ts
@@ -1,0 +1,55 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Param,
+  Body,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { LoansService } from './loans.service';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
+import { createLoanSchema, updateLoanSchema } from '@moneypulse/shared';
+import type { AuthTokenPayload, CreateLoanInput, UpdateLoanInput } from '@moneypulse/shared';
+
+@ApiTags('Loans')
+@Controller('loans')
+@UseGuards(JwtAuthGuard)
+export class LoansController {
+  constructor(private readonly loansService: LoansService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List tracked loans for the current user' })
+  async findAll(@CurrentUser() user: AuthTokenPayload) {
+    return { data: await this.loansService.findAll(user.sub) };
+  }
+
+  @Post()
+  @ApiOperation({ summary: 'Create a tracked loan' })
+  async create(
+    @CurrentUser() user: AuthTokenPayload,
+    @Body(new ZodValidationPipe(createLoanSchema)) body: CreateLoanInput,
+  ) {
+    return { data: await this.loansService.create(user.sub, body) };
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update a tracked loan' })
+  async update(
+    @Param('id') id: string,
+    @CurrentUser() user: AuthTokenPayload,
+    @Body(new ZodValidationPipe(updateLoanSchema)) body: UpdateLoanInput,
+  ) {
+    return { data: await this.loansService.update(id, user.sub, body) };
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete (soft) a tracked loan' })
+  async remove(@Param('id') id: string, @CurrentUser() user: AuthTokenPayload) {
+    return { data: await this.loansService.remove(id, user.sub) };
+  }
+}

--- a/apps/api/src/loans/loans.module.ts
+++ b/apps/api/src/loans/loans.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { LoansService } from './loans.service';
+import { LoansController } from './loans.controller';
+
+@Module({
+  providers: [LoansService],
+  controllers: [LoansController],
+  exports: [LoansService],
+})
+export class LoansModule {}

--- a/apps/api/src/loans/loans.service.ts
+++ b/apps/api/src/loans/loans.service.ts
@@ -1,0 +1,71 @@
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { and, eq, isNull, asc } from 'drizzle-orm';
+import { DATABASE_CONNECTION } from '../db/db.module';
+import * as schema from '../db/schema';
+import type { CreateLoanInput, UpdateLoanInput } from '@moneypulse/shared';
+
+/** CRUD for tracked loans. Payoff math lives in the advisor's MCP tool (get_loan_status). */
+@Injectable()
+export class LoansService {
+  constructor(@Inject(DATABASE_CONNECTION) private readonly db: any) {}
+
+  async findAll(userId: string) {
+    return this.db
+      .select()
+      .from(schema.loans)
+      .where(and(eq(schema.loans.userId, userId), isNull(schema.loans.deletedAt)))
+      .orderBy(asc(schema.loans.name));
+  }
+
+  async create(userId: string, input: CreateLoanInput) {
+    const rows = await this.db
+      .insert(schema.loans)
+      .values({
+        userId,
+        name: input.name,
+        lenderPattern: input.lenderPattern,
+        loanType: input.loanType,
+        originalBalanceCents: input.originalBalanceCents,
+        aprBps: input.aprBps,
+        termMonths: input.termMonths ?? null,
+        startDate: input.startDate,
+        scheduledPaymentCents: input.scheduledPaymentCents,
+        extraPrincipalPattern: input.extraPrincipalPattern ?? null,
+      })
+      .returning();
+    return rows[0];
+  }
+
+  async update(id: string, userId: string, input: UpdateLoanInput) {
+    const existing = await this.db
+      .select()
+      .from(schema.loans)
+      .where(and(eq(schema.loans.id, id), eq(schema.loans.userId, userId)))
+      .limit(1);
+    if (!existing[0] || existing[0].deletedAt) {
+      throw new NotFoundException('Loan not found');
+    }
+    const rows = await this.db
+      .update(schema.loans)
+      .set({ ...input, updatedAt: new Date() })
+      .where(eq(schema.loans.id, id))
+      .returning();
+    return rows[0];
+  }
+
+  async remove(id: string, userId: string) {
+    const existing = await this.db
+      .select()
+      .from(schema.loans)
+      .where(and(eq(schema.loans.id, id), eq(schema.loans.userId, userId)))
+      .limit(1);
+    if (!existing[0] || existing[0].deletedAt) {
+      throw new NotFoundException('Loan not found');
+    }
+    await this.db
+      .update(schema.loans)
+      .set({ deletedAt: new Date(), isActive: false })
+      .where(eq(schema.loans.id, id));
+    return { deleted: true };
+  }
+}

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -19,6 +19,7 @@ import { registerGetCashflowForecast } from './tools/get-cashflow-forecast.js';
 import { registerGetCategoryTrend } from './tools/get-category-trend.js';
 import { registerGetBudgetHistory } from './tools/get-budget-history.js';
 import { registerGetRecentAnomalies } from './tools/get-recent-anomalies.js';
+import { registerGetLoanStatus } from './tools/get-loan-status.js';
 import { close } from './db.js';
 import http from 'node:http';
 
@@ -45,6 +46,7 @@ registerGetCashflowForecast(server);
 registerGetCategoryTrend(server);
 registerGetBudgetHistory(server);
 registerGetRecentAnomalies(server);
+registerGetLoanStatus(server);
 
 const mode = process.argv.includes('--sse') ? 'sse' : 'stdio';
 

--- a/apps/mcp-server/src/lib/__tests__/amortization.spec.ts
+++ b/apps/mcp-server/src/lib/__tests__/amortization.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { computeLoanState, projectPayoff } from '../amortization.js';
+
+// $100,000 loan, 6% APR (600 bps), $600/mo. Monthly rate 0.005.
+const LOAN = {
+  originalBalanceCents: 10_000_000,
+  aprBps: 600,
+  scheduledPaymentCents: 60_000,
+  startDate: '2026-06-01',
+};
+
+describe('computeLoanState', () => {
+  it('splits the first payment into interest + principal', () => {
+    const s = computeLoanState(LOAN, [], new Date('2026-07-01T00:00:00Z'));
+    expect(s.monthsElapsed).toBe(1);
+    expect(s.interestPaidCents).toBe(50_000); // 10,000,000 * 0.005
+    expect(s.principalPaidCents).toBe(10_000); // 60,000 - 50,000
+    expect(s.currentBalanceCents).toBe(9_990_000);
+    expect(s.amortizes).toBe(true);
+  });
+
+  it('applies detected extra-principal payments', () => {
+    const s = computeLoanState(
+      LOAN,
+      [{ date: '2026-06-15', amountCents: 1_000_000 }],
+      new Date('2026-07-01T00:00:00Z'),
+    );
+    expect(s.extraPrincipalPaidCents).toBe(1_000_000);
+    expect(s.currentBalanceCents).toBe(8_990_000); // 9,990,000 - 1,000,000
+  });
+
+  it('flags a payment that does not cover interest (negative amortization)', () => {
+    const s = computeLoanState(
+      { ...LOAN, scheduledPaymentCents: 40_000 }, // < 50,000 interest
+      [],
+      new Date('2026-07-01T00:00:00Z'),
+    );
+    expect(s.amortizes).toBe(false);
+    expect(s.currentBalanceCents).toBe(10_000_000); // never decreases
+  });
+
+  it('is zero-progress for a brand-new loan', () => {
+    const s = computeLoanState(LOAN, [], new Date('2026-06-01T00:00:00Z'));
+    expect(s.monthsElapsed).toBe(0);
+    expect(s.currentBalanceCents).toBe(10_000_000);
+    expect(s.principalPaidCents).toBe(0);
+  });
+});
+
+describe('projectPayoff', () => {
+  it('projects a finite payoff and extra payments shorten it', () => {
+    const base = projectPayoff(9_990_000, 600, 60_000, new Date('2026-07-01T00:00:00Z'));
+    expect(base.amortizes).toBe(true);
+    expect(base.monthsRemaining).toBeGreaterThan(0);
+    expect(base.remainingInterestCents).toBeGreaterThan(0);
+
+    const accel = projectPayoff(9_990_000, 600, 120_000, new Date('2026-07-01T00:00:00Z'));
+    expect(accel.monthsRemaining).toBeLessThan(base.monthsRemaining);
+    expect(accel.remainingInterestCents).toBeLessThan(base.remainingInterestCents);
+  });
+
+  it('reports non-amortizing when the payment never covers interest', () => {
+    const p = projectPayoff(10_000_000, 600, 40_000);
+    expect(p.amortizes).toBe(false);
+    expect(p.monthsRemaining).toBe(Infinity);
+  });
+});

--- a/apps/mcp-server/src/lib/amortization.ts
+++ b/apps/mcp-server/src/lib/amortization.ts
@@ -1,0 +1,124 @@
+/** Pure loan amortization math — no DB. Cents in, cents out. */
+
+export interface LoanInputs {
+  originalBalanceCents: number;
+  aprBps: number; // APR basis points (3.25% → 325)
+  scheduledPaymentCents: number; // regular P+I payment
+  startDate: string; // YYYY-MM-DD
+}
+
+export interface ExtraPayment {
+  date: string; // YYYY-MM-DD
+  amountCents: number;
+}
+
+export interface LoanState {
+  monthsElapsed: number;
+  currentBalanceCents: number;
+  principalPaidCents: number;
+  interestPaidCents: number;
+  extraPrincipalPaidCents: number;
+  /** False if the scheduled payment never covers interest (negative amortization). */
+  amortizes: boolean;
+}
+
+export interface PayoffProjection {
+  monthsRemaining: number;
+  remainingInterestCents: number;
+  payoffDate: string; // YYYY-MM-DD
+  amortizes: boolean;
+}
+
+const MAX_MONTHS = 1200; // 100-year guard
+
+function monthsBetween(start: Date, end: Date): number {
+  return (
+    (end.getUTCFullYear() - start.getUTCFullYear()) * 12 +
+    (end.getUTCMonth() - start.getUTCMonth())
+  );
+}
+
+/** Replay the loan from start to `asOf`, applying scheduled payments + detected extra principal. */
+export function computeLoanState(
+  loan: LoanInputs,
+  extras: ExtraPayment[],
+  asOf = new Date(),
+): LoanState {
+  const rate = loan.aprBps / 10000 / 12;
+  const start = new Date(loan.startDate + 'T00:00:00Z');
+  const elapsed = Math.max(0, monthsBetween(start, asOf));
+
+  const extrasByMonth = new Map<number, number>();
+  for (const e of extras) {
+    const idx = monthsBetween(start, new Date(e.date + 'T00:00:00Z'));
+    if (idx >= 0) extrasByMonth.set(idx, (extrasByMonth.get(idx) ?? 0) + e.amountCents);
+  }
+
+  let balance = loan.originalBalanceCents;
+  let principalPaid = 0;
+  let interestPaid = 0;
+  let extraPaid = 0;
+  let amortizes = true;
+
+  for (let m = 0; m < elapsed && balance > 0; m++) {
+    const interest = Math.round(balance * rate);
+    let principal = loan.scheduledPaymentCents - interest;
+    if (principal <= 0) {
+      amortizes = false;
+      principal = 0;
+    }
+    principal = Math.min(principal, balance);
+    balance -= principal;
+    principalPaid += principal;
+    interestPaid += interest;
+
+    const extra = Math.min(extrasByMonth.get(m) ?? 0, balance);
+    if (extra > 0) {
+      balance -= extra;
+      extraPaid += extra;
+    }
+  }
+
+  return {
+    monthsElapsed: elapsed,
+    currentBalanceCents: Math.max(0, balance),
+    principalPaidCents: principalPaid,
+    interestPaidCents: interestPaid,
+    extraPrincipalPaidCents: extraPaid,
+    amortizes,
+  };
+}
+
+/** Project remaining months + interest to pay off `balance` at `monthlyPayment`. */
+export function projectPayoff(
+  balanceCents: number,
+  aprBps: number,
+  monthlyPaymentCents: number,
+  asOf = new Date(),
+): PayoffProjection {
+  const rate = aprBps / 10000 / 12;
+  let balance = balanceCents;
+  let interest = 0;
+  let months = 0;
+
+  while (balance > 0 && months < MAX_MONTHS) {
+    const i = Math.round(balance * rate);
+    let p = monthlyPaymentCents - i;
+    if (p <= 0) {
+      return { monthsRemaining: Infinity, remainingInterestCents: 0, payoffDate: '', amortizes: false };
+    }
+    p = Math.min(p, balance);
+    balance -= p;
+    interest += i;
+    months++;
+  }
+
+  const d = new Date(asOf);
+  d.setMonth(d.getMonth() + months);
+  return {
+    monthsRemaining: months,
+    remainingInterestCents: interest,
+    payoffDate: d.toISOString().slice(0, 10),
+    amortizes: true,
+  };
+}

--- a/apps/mcp-server/src/tools/get-loan-status.ts
+++ b/apps/mcp-server/src/tools/get-loan-status.ts
@@ -1,0 +1,104 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { query, getUserId } from '../db.js';
+import { computeLoanState, projectPayoff, type ExtraPayment } from '../lib/amortization.js';
+
+export function registerGetLoanStatus(server: McpServer) {
+  server.tool(
+    'get_loan_status',
+    'Status of tracked loans (mortgage/auto): current balance, principal & interest paid, extra principal applied, and payoff date at the current pace. Optionally model adding extra $/month to see months and interest saved. Answers "how much do I owe", "when is it paid off", "what if I pay $X more".',
+    {
+      extra_monthly: z
+        .number()
+        .min(0)
+        .optional()
+        .describe('Extra dollars per month to model an accelerated payoff'),
+    },
+    async (params) => {
+      const userId = await getUserId();
+      const loans = await query(
+        `SELECT name, loan_type, lender_pattern, extra_principal_pattern,
+                original_balance_cents, apr_bps, scheduled_payment_cents,
+                to_char(start_date, 'YYYY-MM-DD') AS start_date
+         FROM loans
+         WHERE user_id = $1 AND is_active = true AND deleted_at IS NULL
+         ORDER BY original_balance_cents DESC`,
+        [userId],
+      );
+
+      if (loans.length === 0) {
+        return {
+          content: [{ type: 'text' as const, text: 'No loans are being tracked yet.' }],
+        };
+      }
+
+      const dollars = (c: number) => `$${(c / 100).toFixed(2)}`;
+      const extraMonthlyCents =
+        params.extra_monthly != null ? Math.round(params.extra_monthly * 100) : 0;
+
+      const blocks: string[] = [];
+      for (const loan of loans) {
+        const inputs = {
+          originalBalanceCents: Number(loan.original_balance_cents),
+          aprBps: Number(loan.apr_bps),
+          scheduledPaymentCents: Number(loan.scheduled_payment_cents),
+          startDate: loan.start_date as string,
+        };
+
+        // Extra-principal payments detected from transactions (if a pattern is configured).
+        let extras: ExtraPayment[] = [];
+        if (loan.extra_principal_pattern) {
+          const rows = await query(
+            `SELECT to_char(t.date, 'YYYY-MM-DD') AS d, t.amount_cents
+             FROM transactions t
+             WHERE t.user_id = $3 AND t.is_credit = false AND t.is_split_parent = false
+               AND t.deleted_at IS NULL
+               AND (t.normalized_merchant_name ILIKE $1 OR t.merchant_name ILIKE $1)
+               AND t.date >= $2::date`,
+            [`%${loan.extra_principal_pattern}%`, inputs.startDate, userId],
+          );
+          extras = rows.map((r) => ({ date: r.d as string, amountCents: Number(r.amount_cents) }));
+        }
+
+        const state = computeLoanState(inputs, extras);
+        const apr = (inputs.aprBps / 100).toFixed(3).replace(/\.?0+$/, '');
+        const lines = [
+          `${loan.name} (${loan.loan_type}, ${apr}% APR):`,
+          `  Original balance: ${dollars(inputs.originalBalanceCents)} (from ${inputs.startDate})`,
+          `  Current balance: ${dollars(state.currentBalanceCents)}`,
+          `  Principal paid: ${dollars(state.principalPaidCents)}${state.extraPrincipalPaidCents > 0 ? ` (incl. ${dollars(state.extraPrincipalPaidCents)} extra principal)` : ''}`,
+          `  Interest paid so far: ${dollars(state.interestPaidCents)}`,
+        ];
+
+        if (state.currentBalanceCents <= 0) {
+          lines.push('  Status: paid off 🎉');
+        } else if (!state.amortizes) {
+          lines.push('  ⚠ The scheduled payment does not cover the monthly interest — balance is not decreasing.');
+        } else {
+          const base = projectPayoff(state.currentBalanceCents, inputs.aprBps, inputs.scheduledPaymentCents);
+          lines.push(
+            `  At ${dollars(inputs.scheduledPaymentCents)}/mo: paid off ~${base.payoffDate} (${base.monthsRemaining} months), ${dollars(base.remainingInterestCents)} interest remaining.`,
+          );
+          if (extraMonthlyCents > 0) {
+            const accel = projectPayoff(
+              state.currentBalanceCents,
+              inputs.aprBps,
+              inputs.scheduledPaymentCents + extraMonthlyCents,
+            );
+            if (accel.amortizes) {
+              const monthsSaved = base.monthsRemaining - accel.monthsRemaining;
+              const interestSaved = base.remainingInterestCents - accel.remainingInterestCents;
+              lines.push(
+                `  Adding ${dollars(extraMonthlyCents)}/mo → paid off ~${accel.payoffDate} (${monthsSaved} months sooner), saving ${dollars(interestSaved)} in interest.`,
+              );
+            }
+          }
+        }
+
+        blocks.push(lines.join('\n'));
+      }
+
+      return { content: [{ type: 'text' as const, text: blocks.join('\n\n') }] };
+    },
+  );
+}

--- a/db/migrations/0011_loans.sql
+++ b/db/migrations/0011_loans.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS "loans" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "user_id" uuid NOT NULL,
+  "name" varchar(100) NOT NULL,
+  "lender_pattern" varchar(200) NOT NULL,
+  "loan_type" varchar(30) DEFAULT 'mortgage' NOT NULL,
+  "original_balance_cents" integer NOT NULL,
+  "apr_bps" integer NOT NULL,
+  "term_months" integer,
+  "start_date" date NOT NULL,
+  "scheduled_payment_cents" integer NOT NULL,
+  "extra_principal_pattern" varchar(200),
+  "is_active" boolean DEFAULT true NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "deleted_at" timestamp with time zone
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "loans" ADD CONSTRAINT "loans_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_loans_user" ON "loans" USING btree ("user_id");

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1783200300000,
       "tag": "0010_advisor_per_provider_keys",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1783200400000,
+      "tag": "0011_loans",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/src/validation/index.ts
+++ b/packages/shared/src/validation/index.ts
@@ -316,3 +316,22 @@ export const addSnapshotSchema = z.object({
 export type CreateInvestmentAccountInput = z.infer<typeof createInvestmentAccountSchema>;
 export type UpdateInvestmentAccountInput = z.infer<typeof updateInvestmentAccountSchema>;
 export type AddSnapshotInput = z.infer<typeof addSnapshotSchema>;
+
+// ── Loans (mortgage / auto payoff tracker) ───────────────────
+
+export const createLoanSchema = z.object({
+  name: z.string().min(1).max(100),
+  lenderPattern: z.string().min(1).max(200),
+  loanType: z.enum(['mortgage', 'auto', 'personal', 'student', 'other']).default('mortgage'),
+  originalBalanceCents: z.int().positive(),
+  aprBps: z.int().min(0).max(100000),
+  termMonths: z.int().positive().max(600).optional(),
+  startDate: z.iso.date(),
+  scheduledPaymentCents: z.int().positive(),
+  extraPrincipalPattern: z.string().max(200).nullable().optional(),
+});
+
+export const updateLoanSchema = createLoanSchema.partial();
+
+export type CreateLoanInput = z.infer<typeof createLoanSchema>;
+export type UpdateLoanInput = z.infer<typeof updateLoanSchema>;

--- a/tasks.md
+++ b/tasks.md
@@ -45,9 +45,12 @@ Bills roll-forward (#84, done): daily sweep advances overdue `next_expected_date
 future occurrence (+ runs once on boot) so `get_upcoming_bills` + forecast + digest bills work.
 
 ### Big features (own phases — need schema/design)
-- **Loan payoff tracker** (mortgage + auto): new `loans` table (principal, rate, term, extra-principal
-  payments), amortization + payoff projection, periodic "pay it down faster" nudges. User wants:
-  mortgage pending vs paid (loan + extra principal), auto loan same, AI nudges.
+- **Loan payoff tracker** (mortgage + auto) — Phase 1 backend done (#88): `loans` table (migration 0011),
+  amortization engine (`apps/mcp-server/src/lib/amortization.ts`), `get_loan_status` MCP tool (balance,
+  principal/interest paid, extra principal, payoff date, "add $X/mo → months+interest saved"), CRUD `/loans`.
+  **Next:** seed the user's loans via `POST /loans` (lender pattern, initial balance, apr_bps, start date,
+  scheduled payment, extra-principal pattern); auto-split scheduled P+I vs extra-principal txns;
+  missing-payment detection; Loans web page; payoff nudges in the digest.
 - **Internet-trends weekly digest**: extend Phase-2 digest with web research (mortgage rates via FRED,
   savings tips) so it proactively makes the user "financially smarter."
 - **Digest → Telegram (#79)**: add Telegram as a delivery channel for the weekly advisor recap +


### PR DESCRIPTION
Part of #88. Loan payoff tracker backend: loans table (migration 0011), amortization engine, get_loan_status MCP tool (balance, principal/interest paid, payoff date, add-$X/mo scenario), CRUD /loans. mcp 90 (incl. amortization tests), advisor 42. Deploy: db:migrate then api; then seed loans via POST /loans. Follow-ups: auto-split P+I vs extra, missing-payment detection, Loans page, digest nudges. 🤖 Generated with [Claude Code](https://claude.com/claude-code)