### PR TITLE
feat(loans): live payoff status on Loans page

### DIFF
--- a/apps/web/src/app/(protected)/loans/page.tsx
+++ b/apps/web/src/app/(protected)/loans/page.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { useState } from 'react';
-import { Landmark, Plus, Pencil, Trash2, X, Sparkles } from 'lucide-react';
+import { Landmark, Plus, Pencil, Trash2, X, Sparkles, AlertTriangle } from 'lucide-react';
 import { formatCents } from '@/lib/format';
 import { MobileCard } from '@/components/MobileCard';
 import type { Loan, LoanType, CreateLoanInput } from '@moneypulse/shared';
+import { computeLoanState, projectPayoff } from '@moneypulse/shared';
 import { useLoans, useCreateLoan, useUpdateLoan, useDeleteLoan } from '@/lib/hooks/useLoans';
 
 // ── Helpers ──────────────────────────────────────────────────
@@ -29,6 +30,89 @@ function formatStartDate(dateStr: string): string {
     year: 'numeric',
     timeZone: 'UTC',
   });
+}
+
+function formatMonths(months: number): string {
+  if (!Number.isFinite(months)) return '—';
+  const y = Math.floor(months / 12);
+  const m = months % 12;
+  if (y === 0) return `${m} mo`;
+  if (m === 0) return `${y} yr`;
+  return `${y} yr ${m} mo`;
+}
+
+// ── Payoff status (client-side amortization) ──────────────────
+
+/**
+ * Live payoff summary computed from the loan's own fields — no server round trip and
+ * nothing sensitive leaves the browser. Extras are folded into the scheduled payment
+ * (the recommended data model), so we replay with no separate extra-principal stream.
+ * Pattern-based extra-principal splitting is a Phase-2, advisor-side feature.
+ */
+function LoanStatusCard({ loan }: { loan: Loan }) {
+  const inputs = {
+    originalBalanceCents: loan.originalBalanceCents,
+    aprBps: loan.aprBps,
+    scheduledPaymentCents: loan.scheduledPaymentCents,
+    startDate: loan.startDate,
+  };
+  const state = computeLoanState(inputs, []);
+  const proj = projectPayoff(state.currentBalanceCents, loan.aprBps, loan.scheduledPaymentCents);
+
+  const paidCents = loan.originalBalanceCents - state.currentBalanceCents;
+  const pctPaid = loan.originalBalanceCents > 0
+    ? Math.min(100, Math.max(0, (paidCents / loan.originalBalanceCents) * 100))
+    : 0;
+  const nonAmortizing = !state.amortizes || !proj.amortizes;
+
+  return (
+    <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4 space-y-3">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <span className="font-semibold">{loan.name}</span>
+          <span className="rounded-full bg-[var(--accent)] px-2 py-0.5 text-[10px] font-medium text-[var(--primary)]">
+            {LOAN_TYPE_LABELS[loan.loanType]}
+          </span>
+        </div>
+        <span className="text-lg font-bold tabular-nums">{formatCents(state.currentBalanceCents)}</span>
+      </div>
+
+      {/* Progress bar */}
+      <div>
+        <div className="h-2 w-full overflow-hidden rounded-full bg-[var(--muted)]">
+          <div className="h-full rounded-full bg-[var(--primary)]" style={{ width: `${pctPaid}%` }} />
+        </div>
+        <p className="mt-1 text-xs text-[var(--muted-foreground)]">
+          {pctPaid.toFixed(1)}% paid off · {formatCents(paidCents)} of {formatCents(loan.originalBalanceCents)}
+        </p>
+      </div>
+
+      {nonAmortizing ? (
+        <div className="flex items-start gap-2 rounded-md bg-[var(--destructive)]/10 px-3 py-2 text-xs text-[var(--destructive)]">
+          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span>
+            The monthly payment doesn&apos;t cover interest at this APR — the balance won&apos;t
+            amortize. Check the payment amount and APR.
+          </span>
+        </div>
+      ) : (
+        <div className="grid grid-cols-3 gap-3 text-center">
+          <div>
+            <p className="text-xs text-[var(--muted-foreground)]">Payoff</p>
+            <p className="text-sm font-semibold">{formatStartDate(proj.payoffDate)}</p>
+          </div>
+          <div>
+            <p className="text-xs text-[var(--muted-foreground)]">Time left</p>
+            <p className="text-sm font-semibold">{formatMonths(proj.monthsRemaining)}</p>
+          </div>
+          <div>
+            <p className="text-xs text-[var(--muted-foreground)]">Interest left</p>
+            <p className="text-sm font-semibold">{formatCents(proj.remainingInterestCents)}</p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }
 
 // ── Form ──────────────────────────────────────────────────────
@@ -325,8 +409,19 @@ export default function LoansPage() {
         </p>
       )}
 
+      {/* Payoff status */}
+      {loans.length > 0 && (
+        <section className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          {loans.map((loan) => (
+            <LoanStatusCard key={loan.id} loan={loan} />
+          ))}
+        </section>
+      )}
+
       {loans.length > 0 && (
         <>
+          {/* Manage / details table */}
+          <h2 className="text-lg font-bold">Details</h2>
           {/* Desktop table */}
           <div className="hidden md:block overflow-x-auto rounded-lg border border-[var(--border)]">
             <table className="w-full text-left text-sm">

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
 export * from './types/index.js';
 export * from './constants/index.js';
 export * from './validation/index.js';
+export * from './loan/amortization.js';

--- a/packages/shared/src/loan/amortization.ts
+++ b/packages/shared/src/loan/amortization.ts
@@ -1,0 +1,128 @@
+/** Pure loan amortization math — no DB, no deps. Cents in, cents out.
+ *
+ * Mirrors apps/mcp-server/src/lib/amortization.ts (the advisor's copy). The MCP server
+ * is a standalone bundle without a @moneypulse/shared dependency, so the two are kept in
+ * sync by hand. Keep any formula change in both places. */
+
+export interface LoanInputs {
+  originalBalanceCents: number;
+  aprBps: number; // APR basis points (3.25% → 325)
+  scheduledPaymentCents: number; // regular P+I payment
+  startDate: string; // YYYY-MM-DD
+}
+
+export interface ExtraPayment {
+  date: string; // YYYY-MM-DD
+  amountCents: number;
+}
+
+export interface LoanState {
+  monthsElapsed: number;
+  currentBalanceCents: number;
+  principalPaidCents: number;
+  interestPaidCents: number;
+  extraPrincipalPaidCents: number;
+  /** False if the scheduled payment never covers interest (negative amortization). */
+  amortizes: boolean;
+}
+
+export interface PayoffProjection {
+  monthsRemaining: number;
+  remainingInterestCents: number;
+  payoffDate: string; // YYYY-MM-DD
+  amortizes: boolean;
+}
+
+const MAX_MONTHS = 1200; // 100-year guard
+
+function monthsBetween(start: Date, end: Date): number {
+  return (
+    (end.getUTCFullYear() - start.getUTCFullYear()) * 12 +
+    (end.getUTCMonth() - start.getUTCMonth())
+  );
+}
+
+/** Replay the loan from start to `asOf`, applying scheduled payments + detected extra principal. */
+export function computeLoanState(
+  loan: LoanInputs,
+  extras: ExtraPayment[],
+  asOf = new Date(),
+): LoanState {
+  const rate = loan.aprBps / 10000 / 12;
+  const start = new Date(loan.startDate + 'T00:00:00Z');
+  const elapsed = Math.max(0, monthsBetween(start, asOf));
+
+  const extrasByMonth = new Map<number, number>();
+  for (const e of extras) {
+    const idx = monthsBetween(start, new Date(e.date + 'T00:00:00Z'));
+    if (idx >= 0) extrasByMonth.set(idx, (extrasByMonth.get(idx) ?? 0) + e.amountCents);
+  }
+
+  let balance = loan.originalBalanceCents;
+  let principalPaid = 0;
+  let interestPaid = 0;
+  let extraPaid = 0;
+  let amortizes = true;
+
+  for (let m = 0; m < elapsed && balance > 0; m++) {
+    const interest = Math.round(balance * rate);
+    let principal = loan.scheduledPaymentCents - interest;
+    if (principal <= 0) {
+      amortizes = false;
+      principal = 0;
+    }
+    principal = Math.min(principal, balance);
+    balance -= principal;
+    principalPaid += principal;
+    interestPaid += interest;
+
+    const extra = Math.min(extrasByMonth.get(m) ?? 0, balance);
+    if (extra > 0) {
+      balance -= extra;
+      extraPaid += extra;
+    }
+  }
+
+  return {
+    monthsElapsed: elapsed,
+    currentBalanceCents: Math.max(0, balance),
+    principalPaidCents: principalPaid,
+    interestPaidCents: interestPaid,
+    extraPrincipalPaidCents: extraPaid,
+    amortizes,
+  };
+}
+
+/** Project remaining months + interest to pay off `balance` at `monthlyPayment`. */
+export function projectPayoff(
+  balanceCents: number,
+  aprBps: number,
+  monthlyPaymentCents: number,
+  asOf = new Date(),
+): PayoffProjection {
+  const rate = aprBps / 10000 / 12;
+  let balance = balanceCents;
+  let interest = 0;
+  let months = 0;
+
+  while (balance > 0 && months < MAX_MONTHS) {
+    const i = Math.round(balance * rate);
+    let p = monthlyPaymentCents - i;
+    if (p <= 0) {
+      return { monthsRemaining: Infinity, remainingInterestCents: 0, payoffDate: '', amortizes: false };
+    }
+    p = Math.min(p, balance);
+    balance -= p;
+    interest += i;
+    months++;
+  }
+
+  const d = new Date(asOf);
+  d.setMonth(d.getMonth() + months);
+  return {
+    monthsRemaining: months,
+    remainingInterestCents: interest,
+    payoffDate: d.toISOString().slice(0, 10),
+    amortizes: true,
+  };
+}

--- a/tasks.md
+++ b/tasks.md
@@ -48,9 +48,13 @@ future occurrence (+ runs once on boot) so `get_upcoming_bills` + forecast + dig
 - **Loan payoff tracker** (mortgage + auto) — Phase 1 backend done (#88): `loans` table (migration 0011),
   amortization engine (`apps/mcp-server/src/lib/amortization.ts`), `get_loan_status` MCP tool (balance,
   principal/interest paid, extra principal, payoff date, "add $X/mo → months+interest saved"), CRUD `/loans`.
-  **Next:** seed the user's loans via `POST /loans` (lender pattern, initial balance, apr_bps, start date,
-  scheduled payment, extra-principal pattern); auto-split scheduled P+I vs extra-principal txns;
-  missing-payment detection; Loans web page; payoff nudges in the digest.
+  **Loans web page** (#92, done): `/loans` CRUD (add/edit/delete) with dollar→cents / percent→bps
+  conversion, drawer nav (HandCoins); `Loan` type in shared. Seed loans here (not direct DB — the
+  classifier blocks `ssh docker exec` prod writes; must go through `POST /loans`).
+  **Next:** auto-split scheduled P+I vs extra-principal txns (Phase 2 — match by amount since both
+  Langley txns share the merchant name); missing-payment detection; payoff status shown on the
+  Loans page (needs amortization moved to shared or a `/loans/:id/status` endpoint); payoff nudges
+  in the digest.
 - **Internet-trends weekly digest**: extend Phase-2 digest with web research (mortgage rates via FRED,
   savings tips) so it proactively makes the user "financially smarter."
 - **Digest → Telegram (#79)**: add Telegram as a delivery channel for the weekly advisor recap +


### PR DESCRIPTION
Builds on #92. Each tracked loan now shows a **payoff summary** right on the Loans page — no need to open the advisor for the headline numbers.

## What changed
- Per-loan status card: current balance, % paid (progress bar), payoff date, time left, remaining interest.
- Non-amortizing guard: warns when the monthly payment doesn't cover interest at the given APR.
- Pure amortization math (`computeLoanState` / `projectPayoff`) moved into `@moneypulse/shared`; computed **client-side** from the loan's own fields (no server round trip, nothing sensitive leaves the browser).
- Mirrors the MCP server's `amortization.ts` (kept in sync by hand — the standalone MCP bundle has no shared dep; noted in code + tasks).

Extras are folded into the scheduled payment (the recommended data model), so replay uses no separate extra-principal stream. Pattern-based extra-principal splitting stays a Phase-2 advisor-side feature.

## Test plan
- `pnpm --filter @moneypulse/shared build` ✅
- `pnpm --filter web build` ✅
- Manual: add the Langley mortgage → card shows balance/payoff; advisor `get_loan_status` matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)