### PR TITLE
feat(loans): detect missed loan payments + notify

### DIFF
--- a/apps/api/src/jobs/alert-cron.processor.ts
+++ b/apps/api/src/jobs/alert-cron.processor.ts
@@ -7,6 +7,7 @@ import { BalanceSnapshotService } from '../analytics/balance-snapshot.service';
 import { ForecastService } from '../analytics/forecast.service';
 import { AdvisorDigestService } from '../advisor/digest/advisor-digest.service';
 import { BillsService } from '../bills/bills.service';
+import { LoansService } from '../loans/loans.service';
 
 @Processor('alerts')
 export class AlertCronProcessor extends WorkerHost {
@@ -19,6 +20,7 @@ export class AlertCronProcessor extends WorkerHost {
     private readonly forecastService: ForecastService,
     private readonly advisorDigestService: AdvisorDigestService,
     private readonly billsService: BillsService,
+    private readonly loansService: LoansService,
   ) {
     super();
   }
@@ -68,6 +70,15 @@ export class AlertCronProcessor extends WorkerHost {
       case 'bills-roll-forward': {
         const { rolled } = await this.billsService.rollForwardOverdueBills();
         this.logger.log(`Bills roll-forward: ${rolled} advanced`);
+        break;
+      }
+
+      case 'loan-missed-check': {
+        const { checked, missed, notified } =
+          await this.loansService.checkMissedLoanPayments();
+        this.logger.log(
+          `Loan missed-check: ${checked} loans, ${missed} missed, ${notified} notified`,
+        );
         break;
       }
 

--- a/apps/api/src/jobs/jobs.module.ts
+++ b/apps/api/src/jobs/jobs.module.ts
@@ -9,6 +9,7 @@ import { SyncDeliveryProcessor } from './sync-delivery.processor';
 import { AnalyticsModule } from '../analytics/analytics.module';
 import { AdvisorModule } from '../advisor/advisor.module';
 import { BillsModule } from '../bills/bills.module';
+import { LoansModule } from '../loans/loans.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { BillsModule } from '../bills/bills.module';
     AnalyticsModule,
     AdvisorModule,
     BillsModule,
+    LoansModule,
   ],
   providers: [AlertCronProcessor, ReminderProcessor, SyncDeliveryProcessor],
 })
@@ -99,6 +101,15 @@ export class JobsModule implements OnModuleInit {
       { name: 'bills-roll-forward' },
     );
     await this.alertsQueue.add('bills-roll-forward', {}, { removeOnComplete: true });
+
+    // Detect missed loan payments (daily 5:30 AM UTC) — flags a loan whose lender
+    // debit didn't show up this cycle. Also run once now.
+    await this.alertsQueue.upsertJobScheduler(
+      'daily-loan-missed-check',
+      { pattern: '30 5 * * *' },
+      { name: 'loan-missed-check' },
+    );
+    await this.alertsQueue.add('loan-missed-check', {}, { removeOnComplete: true });
 
     // Frequent sync delivery sweep for outbox events.
     await this.syncQueue.upsertJobScheduler(

--- a/apps/api/src/loans/__tests__/expected-cycle-date.spec.ts
+++ b/apps/api/src/loans/__tests__/expected-cycle-date.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { expectedCycleDate } from '../loans.service';
+
+const iso = (d: Date | null) => (d ? d.toISOString().slice(0, 10) : null);
+
+describe('expectedCycleDate', () => {
+  it('returns this month once the due date has cleared the grace period', () => {
+    // Due on the 20th; "now" is the 28th → 8 days past, beyond 5-day grace.
+    const now = new Date('2026-07-28T12:00:00Z');
+    expect(iso(expectedCycleDate('2022-07-20', now, 5))).toBe('2026-07-20');
+  });
+
+  it('falls back to last month when this month is still within grace', () => {
+    // Due on the 20th; "now" is the 22nd → only 2 days past, inside 5-day grace.
+    const now = new Date('2026-07-22T12:00:00Z');
+    expect(iso(expectedCycleDate('2022-07-20', now, 5))).toBe('2026-06-20');
+  });
+
+  it('falls back to last month when this month is not yet due', () => {
+    const now = new Date('2026-07-10T12:00:00Z');
+    expect(iso(expectedCycleDate('2022-07-20', now, 5))).toBe('2026-06-20');
+  });
+
+  it('clamps the day-of-month to shorter months', () => {
+    // Payment on the 31st; February has 28 days in 2026.
+    const now = new Date('2026-03-05T12:00:00Z');
+    expect(iso(expectedCycleDate('2020-01-31', now, 5))).toBe('2026-02-28');
+  });
+
+  it('rolls the year boundary back when falling to the previous month', () => {
+    const now = new Date('2026-01-03T12:00:00Z');
+    expect(iso(expectedCycleDate('2022-01-15', now, 5))).toBe('2025-12-15');
+  });
+
+  it('returns null before the loan has reached its first due-plus-grace date', () => {
+    const now = new Date('2026-07-21T12:00:00Z');
+    // Loan starts this month; the first cycle is only 1 day past → grace pushes it to
+    // last month, which is before the start date.
+    expect(expectedCycleDate('2026-07-20', now, 5)).toBeNull();
+  });
+});

--- a/apps/api/src/loans/loans.controller.ts
+++ b/apps/api/src/loans/loans.controller.ts
@@ -37,6 +37,12 @@ export class LoansController {
     return { data: await this.loansService.create(user.sub, body) };
   }
 
+  @Post('check-missed')
+  @ApiOperation({ summary: 'Check for missed loan payments and notify' })
+  async checkMissed(@CurrentUser() user: AuthTokenPayload) {
+    return { data: await this.loansService.checkMissedLoanPayments(user.sub) };
+  }
+
   @Patch(':id')
   @ApiOperation({ summary: 'Update a tracked loan' })
   async update(

--- a/apps/api/src/loans/loans.module.ts
+++ b/apps/api/src/loans/loans.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { LoansService } from './loans.service';
 import { LoansController } from './loans.controller';
+import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
+  imports: [NotificationsModule],
   providers: [LoansService],
   controllers: [LoansController],
   exports: [LoansService],

--- a/apps/api/src/loans/loans.service.ts
+++ b/apps/api/src/loans/loans.service.ts
@@ -1,13 +1,38 @@
 import { Inject, Injectable, NotFoundException } from '@nestjs/common';
-import { and, eq, isNull, asc } from 'drizzle-orm';
+import { and, eq, isNull, asc, gte, lte, or, ilike } from 'drizzle-orm';
 import { DATABASE_CONNECTION } from '../db/db.module';
 import * as schema from '../db/schema';
 import type { CreateLoanInput, UpdateLoanInput } from '@moneypulse/shared';
+import { NotificationsService } from '../notifications/notifications.service';
+
+/**
+ * Most recent monthly payment date that is at least `graceDays` in the past, with the
+ * day-of-month clamped to the month length. Returns null if that date is before the loan
+ * started (loan hasn't reached its first due-date-plus-grace yet). UTC throughout so it
+ * matches how loan start dates are stored (plain calendar dates).
+ */
+export function expectedCycleDate(startDate: string, now: Date, graceDays: number): Date | null {
+  const start = new Date(startDate + 'T00:00:00Z');
+  const dom = start.getUTCDate();
+  const clamp = (y: number, m: number): Date => {
+    const lastDay = new Date(Date.UTC(y, m + 1, 0)).getUTCDate();
+    return new Date(Date.UTC(y, m, Math.min(dom, lastDay)));
+  };
+  let cycle = clamp(now.getUTCFullYear(), now.getUTCMonth());
+  // If this month's due date hasn't cleared the grace period yet, check last month's.
+  if ((now.getTime() - cycle.getTime()) / 86_400_000 < graceDays) {
+    cycle = clamp(now.getUTCFullYear(), now.getUTCMonth() - 1);
+  }
+  return cycle < start ? null : cycle;
+}
 
 /** CRUD for tracked loans. Payoff math lives in the advisor's MCP tool (get_loan_status). */
 @Injectable()
 export class LoansService {
-  constructor(@Inject(DATABASE_CONNECTION) private readonly db: any) {}
+  constructor(
+    @Inject(DATABASE_CONNECTION) private readonly db: any,
+    private readonly notificationsService: NotificationsService,
+  ) {}
 
   async findAll(userId: string) {
     return this.db
@@ -67,5 +92,95 @@ export class LoansService {
       .set({ deletedAt: new Date(), isActive: false })
       .where(eq(schema.loans.id, id));
     return { deleted: true };
+  }
+
+  /**
+   * Detect loan payments that never showed up. For each active loan, find the most recent
+   * monthly due date (past its grace period) and look for ANY matching debit for the lender
+   * within a look-back window — amount is deliberately ignored because a loan may post as two
+   * transactions (P+I and a separate principal), and the tracked payment may fold in extra
+   * principal. If nothing matches, fire a deduped `loan_payment_missed` notification.
+   *
+   * Global sweep when `userId` is omitted (cron); scoped when provided (manual "Check now").
+   */
+  async checkMissedLoanPayments(
+    userId?: string,
+  ): Promise<{ checked: number; missed: number; notified: number }> {
+    const GRACE_DAYS = 5; // mortgages/autos usually allow a few days
+    const WINDOW_DAYS = 25; // look-back for a matching payment before the due date
+    const now = new Date();
+
+    const conditions = [
+      eq(schema.loans.isActive, true),
+      isNull(schema.loans.deletedAt),
+    ];
+    if (userId) conditions.push(eq(schema.loans.userId, userId));
+
+    const loans = await this.db
+      .select()
+      .from(schema.loans)
+      .where(and(...conditions));
+
+    let missed = 0;
+    let notified = 0;
+
+    for (const loan of loans) {
+      const cycle = expectedCycleDate(loan.startDate, now, GRACE_DAYS);
+      if (!cycle) continue;
+
+      const windowStart = new Date(cycle.getTime() - WINDOW_DAYS * 86_400_000);
+      const pattern = `%${loan.lenderPattern}%`;
+
+      const match = await this.db
+        .select({ id: schema.transactions.id })
+        .from(schema.transactions)
+        .where(
+          and(
+            eq(schema.transactions.userId, loan.userId),
+            isNull(schema.transactions.deletedAt),
+            eq(schema.transactions.isCredit, false),
+            gte(schema.transactions.date, windowStart),
+            lte(schema.transactions.date, now),
+            or(
+              ilike(schema.transactions.normalizedMerchantName, pattern),
+              ilike(schema.transactions.merchantName, pattern),
+            ),
+          ),
+        )
+        .limit(1);
+
+      if (match.length > 0) continue;
+
+      missed++;
+
+      const cycleKey = cycle.toISOString().slice(0, 7); // YYYY-MM
+      const dedupeKey = `loan_missed_${loan.id}_${cycleKey}`;
+      if (await this.notificationsService.findByMetadata(loan.userId, dedupeKey)) {
+        continue;
+      }
+
+      const monthLabel = cycle.toLocaleDateString('en-US', {
+        month: 'long',
+        year: 'numeric',
+        timeZone: 'UTC',
+      });
+      const dueStr = cycle.toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        timeZone: 'UTC',
+      });
+
+      await this.notificationsService.createAndDispatch({
+        userId: loan.userId,
+        type: 'loan_payment_missed',
+        title: `Possible missed payment: ${loan.name}`,
+        message: `No "${loan.lenderPattern}" payment found for ${monthLabel} (expected around ${dueStr}). If you already paid, it may just not have imported yet.`,
+        dedupeKey,
+        metadata: { loanId: loan.id },
+      });
+      notified++;
+    }
+
+    return { checked: loans.length, missed, notified };
   }
 }

--- a/apps/web/src/app/(protected)/loans/page.tsx
+++ b/apps/web/src/app/(protected)/loans/page.tsx
@@ -1,12 +1,18 @@
 'use client';
 
 import { useState } from 'react';
-import { Landmark, Plus, Pencil, Trash2, X, Sparkles, AlertTriangle } from 'lucide-react';
+import { Landmark, Plus, Pencil, Trash2, X, Sparkles, AlertTriangle, BellRing } from 'lucide-react';
 import { formatCents } from '@/lib/format';
 import { MobileCard } from '@/components/MobileCard';
 import type { Loan, LoanType, CreateLoanInput } from '@moneypulse/shared';
 import { computeLoanState, projectPayoff } from '@moneypulse/shared';
-import { useLoans, useCreateLoan, useUpdateLoan, useDeleteLoan } from '@/lib/hooks/useLoans';
+import {
+  useLoans,
+  useCreateLoan,
+  useUpdateLoan,
+  useDeleteLoan,
+  useCheckMissedLoans,
+} from '@/lib/hooks/useLoans';
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -358,8 +364,14 @@ function LoanCard({ loan, onEdit }: { loan: Loan; onEdit: () => void }) {
 /** Loan payoff tracker — manage mortgage / auto / other loans. */
 export default function LoansPage() {
   const { data, isLoading } = useLoans();
+  const checkMissed = useCheckMissedLoans();
   const [editing, setEditing] = useState<Loan | null>(null);
   const [adding, setAdding] = useState(false);
+  const [checkResult, setCheckResult] = useState<{
+    checked: number;
+    missed: number;
+    notified: number;
+  } | null>(null);
 
   const loans: Loan[] = data?.data ?? [];
   const showForm = adding || editing !== null;
@@ -382,12 +394,39 @@ export default function LoansPage() {
           </p>
         </div>
         {!showForm && (
-          <button onClick={() => setAdding(true)}
-            className="flex items-center gap-2 rounded-lg bg-[var(--primary)] px-4 py-2 text-sm font-semibold text-[var(--primary-foreground)] hover:opacity-90 transition-opacity">
-            <Plus className="h-4 w-4" /> Add loan
-          </button>
+          <div className="flex flex-wrap items-center gap-3">
+            {loans.length > 0 && (
+              <button
+                onClick={() =>
+                  checkMissed.mutateAsync().then((res) => setCheckResult(res.data))
+                }
+                disabled={checkMissed.isPending}
+                className="flex items-center gap-2 rounded-lg border border-[var(--border)] px-4 py-2 text-sm font-semibold hover:bg-[var(--muted)] disabled:opacity-50 transition-colors">
+                <BellRing className="h-4 w-4" />
+                {checkMissed.isPending ? 'Checking…' : 'Check payments'}
+              </button>
+            )}
+            <button onClick={() => setAdding(true)}
+              className="flex items-center gap-2 rounded-lg bg-[var(--primary)] px-4 py-2 text-sm font-semibold text-[var(--primary-foreground)] hover:opacity-90 transition-opacity">
+              <Plus className="h-4 w-4" /> Add loan
+            </button>
+          </div>
         )}
       </div>
+
+      {checkResult && (
+        <div className="flex items-center justify-between rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800 dark:border-blue-800 dark:bg-blue-900/20 dark:text-blue-300">
+          <span>
+            Checked {checkResult.checked} loan{checkResult.checked !== 1 ? 's' : ''} —{' '}
+            {checkResult.missed === 0
+              ? 'all payments accounted for.'
+              : `${checkResult.missed} possible missed, ${checkResult.notified} alert${checkResult.notified !== 1 ? 's' : ''} sent.`}
+          </span>
+          <button onClick={() => setCheckResult(null)}>
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      )}
 
       {showForm && (
         <LoanForm

--- a/apps/web/src/lib/hooks/useLoans.ts
+++ b/apps/web/src/lib/hooks/useLoans.ts
@@ -35,6 +35,21 @@ export function useUpdateLoan() {
   });
 }
 
+/** Check for missed loan payments (fires notifications). */
+export function useCheckMissedLoans() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () =>
+      api.post<{ data: { checked: number; missed: number; notified: number } }>(
+        '/loans/check-missed',
+        {},
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['notifications'] });
+    },
+  });
+}
+
 /** Delete (soft) a tracked loan. */
 export function useDeleteLoan() {
   const queryClient = useQueryClient();


### PR DESCRIPTION
Flags when a tracked loan's payment doesn't show up.

## How it works
For each active loan, `checkMissedLoanPayments` finds the most recent monthly due date past a **5-day grace period**, then looks for **any** matching lender debit in a **25-day look-back window**. Amount is deliberately ignored — a loan may post as two transactions (P+I + a separate principal payment) and the tracked payment can fold in extra principal, so the *presence* of the lender debit is the reliable signal. No match → a deduped `loan_payment_missed` notification (per loan + cycle month), routed through the same notifications pipeline as bills (web + Home Assistant webhook).

## Surfaces
- **Daily cron** sweep (5:30 AM UTC, global) + run-once on boot.
- **`POST /loans/check-missed`** for a manual per-user run.
- Loans page **"Check payments"** button + result banner.

## Test plan
- `vitest run src/loans` — 6 tests for the due-date cycle math (grace period, month-length clamp, year rollover, before-start) ✅
- `pnpm --filter @moneypulse/api build` ✅ · `pnpm --filter web build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)