### PR TITLE
feat(notifications): deliver notifications to Telegram (#79)

### DIFF
--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -107,6 +107,9 @@ export const userSettings = pgTable('user_settings', {
   advisorDigestEnabled: boolean('advisor_digest_enabled')
     .notNull()
     .default(false),
+  telegramNotificationsEnabled: boolean('telegram_notifications_enabled')
+    .notNull()
+    .default(false),
   notificationEmail: varchar('notification_email', { length: 255 }),
   firebaseUid: varchar('firebase_uid', { length: 128 }),
   createdAt: timestamp('created_at', { withTimezone: true })

--- a/apps/api/src/notifications/__tests__/telegram-push.service.spec.ts
+++ b/apps/api/src/notifications/__tests__/telegram-push.service.spec.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { ConfigService } from '@nestjs/config';
+import { TelegramPushService } from '../telegram-push.service';
+
+/** Build a service with a fake ConfigService backed by a plain map. */
+function make(env: Record<string, string | undefined>): TelegramPushService {
+  const config = { get: (k: string) => env[k] } as unknown as ConfigService;
+  return new TelegramPushService(config);
+}
+
+describe('TelegramPushService', () => {
+  it('is disabled without a bot token', () => {
+    const svc = make({});
+    expect(svc.enabled).toBe(false);
+  });
+
+  it('is enabled once a token is present', () => {
+    const svc = make({ TELEGRAM_BOT_TOKEN: 't' });
+    expect(svc.enabled).toBe(true);
+  });
+
+  it('returns false (no chats) for an unmapped user', async () => {
+    const svc = make({ TELEGRAM_BOT_TOKEN: 't', TELEGRAM_CHAT_MAP: '111:user-a' });
+    // user-b has no chat → nothing sent, no fetch attempted.
+    await expect(svc.sendToUser('user-b', 'hi')).resolves.toBe(false);
+  });
+
+  it('returns false when disabled even if the user is mapped', async () => {
+    const svc = make({ TELEGRAM_CHAT_MAP: '111:user-a' });
+    await expect(svc.sendToUser('user-a', 'hi')).resolves.toBe(false);
+  });
+
+  it('maps multiple chats to the same user (inverted allowlist)', () => {
+    const svc = make({
+      TELEGRAM_BOT_TOKEN: 't',
+      TELEGRAM_CHAT_MAP: '111:user-a, 222:user-a, 333:user-b',
+    });
+    // @ts-expect-error private access for the inversion assertion
+    expect(svc.chatsForUser('user-a')).toEqual(['111', '222']);
+    // @ts-expect-error private access for the inversion assertion
+    expect(svc.chatsForUser('user-b')).toEqual(['333']);
+  });
+
+  it('falls back to the default chat for the single configured default user', () => {
+    const svc = make({
+      TELEGRAM_BOT_TOKEN: 't',
+      TELEGRAM_DEFAULT_USER_ID: 'user-solo',
+      TELEGRAM_DEFAULT_CHAT_ID: '999',
+    });
+    // @ts-expect-error private access
+    expect(svc.chatsForUser('user-solo')).toEqual(['999']);
+    // @ts-expect-error private access
+    expect(svc.chatsForUser('someone-else')).toEqual([]);
+  });
+});

--- a/apps/api/src/notifications/notifications.module.ts
+++ b/apps/api/src/notifications/notifications.module.ts
@@ -4,6 +4,7 @@ import { NotificationsController } from './notifications.controller';
 import { AlertEngineService } from './alert-engine.service';
 import { WebhookService } from './webhook.service';
 import { EmailService } from './email.service';
+import { TelegramPushService } from './telegram-push.service';
 import { SyncModule } from '../sync/sync.module';
 
 @Module({
@@ -13,6 +14,7 @@ import { SyncModule } from '../sync/sync.module';
     AlertEngineService,
     WebhookService,
     EmailService,
+    TelegramPushService,
   ],
   controllers: [NotificationsController],
   exports: [NotificationsService, AlertEngineService],

--- a/apps/api/src/notifications/notifications.service.spec.ts
+++ b/apps/api/src/notifications/notifications.service.spec.ts
@@ -4,6 +4,7 @@ describe('NotificationsService', () => {
   let service: NotificationsService;
   let mockDb: any;
   let mockWebhookService: any;
+  let mockTelegramPush: any;
   let mockOutbox: any;
   let mockAliasMapper: any;
 
@@ -42,6 +43,12 @@ describe('NotificationsService', () => {
       sendWebhook: vi.fn().mockResolvedValue(false),
     };
 
+    // Disabled by default so createAndDispatch skips the Telegram path (no user-settings read).
+    mockTelegramPush = {
+      enabled: false,
+      sendToUser: vi.fn().mockResolvedValue(false),
+    };
+
     mockOutbox = {
       enqueue: vi.fn().mockResolvedValue(undefined),
     };
@@ -53,6 +60,7 @@ describe('NotificationsService', () => {
     service = new NotificationsService(
       mockDb,
       mockWebhookService,
+      mockTelegramPush,
       mockOutbox,
       mockAliasMapper,
     );

--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -3,6 +3,7 @@ import { DATABASE_CONNECTION } from '../db/db.module';
 import * as schema from '../db/schema';
 import { eq, and, desc, sql } from 'drizzle-orm';
 import { WebhookService } from './webhook.service';
+import { TelegramPushService } from './telegram-push.service';
 import { OutboxService } from '../sync/outbox.service';
 import { AliasMapperService } from '../sync/alias-mapper.service';
 
@@ -23,6 +24,7 @@ export class NotificationsService {
   constructor(
     @Inject(DATABASE_CONNECTION) private readonly db: any,
     private readonly webhookService: WebhookService,
+    private readonly telegramPush: TelegramPushService,
     private readonly outbox: OutboxService,
     private readonly aliasMapper: AliasMapperService,
   ) {}
@@ -147,6 +149,31 @@ export class NotificationsService {
         this.logger.warn(`HA webhook dispatch error: ${err.message}`);
       });
 
+    // Best-effort Telegram push — fire-and-forget, gated by the user's opt-in.
+    void this.pushToTelegram(input);
+
     return notification;
+  }
+
+  /**
+   * Push a notification to the user's Telegram chat when they've opted in
+   * (user_settings.telegram_notifications_enabled) and a bot token is configured.
+   * Never throws — notification delivery must not block the domain write. #79
+   */
+  private async pushToTelegram(input: CreateNotificationInput): Promise<void> {
+    if (!this.telegramPush.enabled) return;
+    try {
+      const rows = await this.db
+        .select({ enabled: schema.userSettings.telegramNotificationsEnabled })
+        .from(schema.userSettings)
+        .where(eq(schema.userSettings.userId, input.userId))
+        .limit(1);
+      if (!rows[0]?.enabled) return;
+
+      const text = `${input.title}\n\n${input.message}`;
+      await this.telegramPush.sendToUser(input.userId, text);
+    } catch (err) {
+      this.logger.warn(`Telegram push dispatch error: ${(err as Error).message}`);
+    }
   }
 }

--- a/apps/api/src/notifications/telegram-push.service.ts
+++ b/apps/api/src/notifications/telegram-push.service.ts
@@ -1,0 +1,95 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+/**
+ * Outbound-only Telegram push, used to deliver notifications (digests, missed-payment
+ * nudges, alerts) to a user's chat. Deliberately depends on nothing but ConfigService so
+ * it can live in NotificationsModule without the circular dependency that injecting the
+ * inbound advisor {@link TelegramService} (in AdvisorModule → NotificationsModule) would
+ * create. Reuses the same TELEGRAM_BOT_TOKEN + TELEGRAM_CHAT_MAP as the advisor bot, but
+ * resolves the mapping in reverse (userId → chatIds). LAN-safe: dials OUT only.
+ */
+@Injectable()
+export class TelegramPushService {
+  private readonly logger = new Logger(TelegramPushService.name);
+  private readonly token: string | undefined;
+  /** userId → chatIds (a user may have more than one linked chat). */
+  private readonly userToChats: Map<string, string[]>;
+  private readonly defaultUserId: string | undefined;
+  private readonly defaultChatId: string | undefined;
+
+  constructor(private readonly config: ConfigService) {
+    this.token = this.config.get<string>('TELEGRAM_BOT_TOKEN');
+    this.defaultUserId = this.config.get<string>('TELEGRAM_DEFAULT_USER_ID');
+    this.defaultChatId = this.config.get<string>('TELEGRAM_DEFAULT_CHAT_ID');
+    this.userToChats = this.parseChatMap(this.config.get<string>('TELEGRAM_CHAT_MAP'));
+  }
+
+  get enabled(): boolean {
+    return !!this.token;
+  }
+
+  /** Invert the `chatId:userId,...` allowlist into userId → [chatId, ...]. */
+  private parseChatMap(raw?: string): Map<string, string[]> {
+    const map = new Map<string, string[]>();
+    if (!raw) return map;
+    for (const pair of raw.split(',')) {
+      const [chatId, userId] = pair.split(':').map((s) => s.trim());
+      if (chatId && userId) {
+        map.set(userId, [...(map.get(userId) ?? []), chatId]);
+      }
+    }
+    return map;
+  }
+
+  /** Resolve the chat ids to push to for a given MoneyPulse user. */
+  private chatsForUser(userId: string): string[] {
+    const mapped = this.userToChats.get(userId);
+    if (mapped && mapped.length > 0) return mapped;
+    // Single-user fallback: if this user is the configured default, use the default chat.
+    if (this.defaultUserId && userId === this.defaultUserId && this.defaultChatId) {
+      return [this.defaultChatId];
+    }
+    return [];
+  }
+
+  /**
+   * Best-effort push of a message to every chat linked to `userId`. Returns true if at
+   * least one chat was delivered to. Never throws — notification delivery must not block
+   * the domain write.
+   */
+  async sendToUser(userId: string, text: string): Promise<boolean> {
+    if (!this.token) return false;
+    const chats = this.chatsForUser(userId);
+    if (chats.length === 0) return false;
+
+    let delivered = false;
+    for (const chatId of chats) {
+      const ok = await this.send(chatId, text);
+      delivered = delivered || ok;
+    }
+    return delivered;
+  }
+
+  private async send(chatId: string, text: string): Promise<boolean> {
+    try {
+      const res = await fetch(
+        `https://api.telegram.org/bot${this.token}/sendMessage`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ chat_id: chatId, text }),
+          signal: AbortSignal.timeout(10000),
+        },
+      );
+      if (!res.ok) {
+        this.logger.warn(`Telegram push failed for chat ${chatId}: ${res.status}`);
+        return false;
+      }
+      return true;
+    } catch (err) {
+      this.logger.warn(`Telegram push error for chat ${chatId}: ${(err as Error).message}`);
+      return false;
+    }
+  }
+}

--- a/apps/web/src/app/(protected)/settings/page.tsx
+++ b/apps/web/src/app/(protected)/settings/page.tsx
@@ -24,6 +24,9 @@ export default function SettingsPage() {
   const [advisorDigest, setAdvisorDigest] = useState(
     settings?.advisorDigestEnabled ?? false,
   );
+  const [telegramNotifications, setTelegramNotifications] = useState(
+    settings?.telegramNotificationsEnabled ?? false,
+  );
   const [haWebhookUrl, setHaWebhookUrl] = useState(
     settings?.haWebhookUrl ?? '',
   );
@@ -48,6 +51,7 @@ export default function SettingsPage() {
         dailyDigestEnabled: dailyDigest,
         monthlyDigestEnabled: monthlyDigest,
         advisorDigestEnabled: advisorDigest,
+        telegramNotificationsEnabled: telegramNotifications,
         haWebhookUrl: haWebhookUrl || null,
         firebaseUid: firebaseUid || null,
       });
@@ -189,6 +193,23 @@ export default function SettingsPage() {
 
         <section className="space-y-4 rounded-2xl bg-[var(--surface-container-low)] p-6">
           <h2 className="text-lg font-bold">Integrations</h2>
+          <div className="flex items-start gap-3">
+            <input
+              id="telegramNotifications"
+              type="checkbox"
+              checked={telegramNotifications}
+              onChange={(e) => setTelegramNotifications(e.target.checked)}
+              className="mt-1 h-4 w-4 rounded border-[var(--border)]"
+            />
+            <label htmlFor="telegramNotifications" className="text-sm font-medium">
+              Send notifications to Telegram
+              <span className="block text-xs font-normal text-[var(--on-surface-variant)]">
+                Push digests, the weekly advisor recap, and alerts (missed bills &amp; loan
+                payments) to your linked Telegram chat. Requires the bot token and your
+                chat link configured on the server.
+              </span>
+            </label>
+          </div>
           <div>
             <label htmlFor="haWebhookUrl" className="block text-sm font-semibold">
               Home Assistant Webhook URL

--- a/db/migrations/0012_telegram_notifications.sql
+++ b/db/migrations/0012_telegram_notifications.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user_settings" ADD COLUMN IF NOT EXISTS "telegram_notifications_enabled" boolean DEFAULT false NOT NULL;

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1783200400000,
       "tag": "0011_loans",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1783200500000,
+      "tag": "0012_telegram_notifications",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -54,6 +54,7 @@ export interface UserSettings {
   dailyDigestEnabled: boolean;
   monthlyDigestEnabled: boolean;
   advisorDigestEnabled: boolean;
+  telegramNotificationsEnabled: boolean;
   notificationEmail: string | null;
   firebaseUid: string | null;
 }

--- a/packages/shared/src/validation/index.ts
+++ b/packages/shared/src/validation/index.ts
@@ -211,6 +211,7 @@ export const updateUserSettingsSchema = z.object({
   dailyDigestEnabled: z.boolean().optional(),
   monthlyDigestEnabled: z.boolean().optional(),
   advisorDigestEnabled: z.boolean().optional(),
+  telegramNotificationsEnabled: z.boolean().optional(),
   notificationEmail: z.email().nullable().optional(),
   firebaseUid: z.string().max(128).nullable().optional(),
 });


### PR DESCRIPTION
Closes #79. Adds Telegram as a delivery channel for notifications — digests, the weekly advisor recap, and proactive alerts (missed bills & loan payments) — gated by a per-user opt-in.

## Design
- **`TelegramPushService`** — outbound-only push depending on `ConfigService` alone, so it lives in `NotificationsModule` without the circular dependency that injecting the inbound advisor `TelegramService` (AdvisorModule → NotificationsModule) would create. Inverts `TELEGRAM_CHAT_MAP` (`userId → chatIds`); reuses the same bot token. LAN-safe (dials out only).
- **`NotificationsService.createAndDispatch`** pushes best-effort after the HA webhook, reading `user_settings.telegram_notifications_enabled`; never throws / never blocks the domain write. Because digests and the advisor recap already dispatch through this path, they're covered automatically.
- **Per-user opt-in** (default **off**): Settings → Integrations → "Send notifications to Telegram".

## Changes
- schema + **migration 0012** (`telegram_notifications_enabled`); shared type + validation.
- Reuses existing `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_MAP` (no new required env; optional single-user `TELEGRAM_DEFAULT_CHAT_ID` fallback).

## Test plan
- `vitest run` — full API suite **469 passing**, incl. 6 new `TelegramPushService` tests (token gating, reverse map, multi-chat, default fallback) and updated `NotificationsService` spec.
- `pnpm --filter @moneypulse/api build` ✅ · shared ✅ · web ✅
- Post-deploy: enable the toggle, trigger a digest → arrives in Telegram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)