### PR TITLE
fix(transactions): treat transaction dates as calendar dates end-to-end (#55)

### DIFF
--- a/apps/api/src/transactions/__tests__/business-date.spec.ts
+++ b/apps/api/src/transactions/__tests__/business-date.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { toBusinessDate, utcDayStart } from '../transactions.service';
+
+describe('toBusinessDate (#55)', () => {
+  it('reduces a UTC-midnight Date to its calendar day', () => {
+    // A Jul-1 business date stored at UTC midnight must serialize as 2026-07-01,
+    // never leaking a time component that a client could shift to Jun 30.
+    expect(toBusinessDate(new Date('2026-07-01T00:00:00.000Z'))).toBe('2026-07-01');
+  });
+
+  it('keeps the UTC calendar day even when the instant has a time-of-day', () => {
+    expect(toBusinessDate(new Date('2026-07-01T23:30:00.000Z'))).toBe('2026-07-01');
+  });
+
+  it('truncates an ISO string to its date part', () => {
+    expect(toBusinessDate('2026-07-01T00:00:00.000Z')).toBe('2026-07-01');
+  });
+
+  it('passes a date-only string through unchanged', () => {
+    expect(toBusinessDate('2026-07-01')).toBe('2026-07-01');
+  });
+
+  it('passes null/undefined through unchanged', () => {
+    expect(toBusinessDate(null)).toBeNull();
+    expect(toBusinessDate(undefined)).toBeUndefined();
+  });
+});
+
+describe('utcDayStart (#55)', () => {
+  it('parses a date-only bound to UTC midnight', () => {
+    expect(utcDayStart('2026-07-01').toISOString()).toBe('2026-07-01T00:00:00.000Z');
+  });
+
+  it('normalizes a full ISO bound to the calendar day at UTC midnight', () => {
+    expect(utcDayStart('2026-07-05T18:00:00.000Z').toISOString()).toBe(
+      '2026-07-05T00:00:00.000Z',
+    );
+  });
+
+  it('yields a [from, to+1day) window that includes the whole `to` day', () => {
+    // Range filter uses gte(from) + lt(to+1day); a transaction anywhere on the
+    // last day (Jul 5) must fall inside the window.
+    const from = utcDayStart('2026-07-01');
+    const toExclusive = utcDayStart('2026-07-05');
+    toExclusive.setUTCDate(toExclusive.getUTCDate() + 1);
+
+    const lastDayTxn = new Date('2026-07-05T23:59:59.000Z');
+    expect(lastDayTxn >= from).toBe(true);
+    expect(lastDayTxn < toExclusive).toBe(true);
+
+    const nextDayTxn = new Date('2026-07-06T00:00:00.000Z');
+    expect(nextDayTxn < toExclusive).toBe(false);
+  });
+});

--- a/apps/api/src/transactions/transactions.service.ts
+++ b/apps/api/src/transactions/transactions.service.ts
@@ -17,7 +17,8 @@ import {
   asc,
   ilike,
   sql,
-  between,
+  gte,
+  lt,
   count,
   inArray,
 } from 'drizzle-orm';
@@ -30,6 +31,29 @@ import type {
 } from '@moneypulse/shared';
 import { createHash } from 'crypto';
 import { encryptField, decryptField } from '../common/crypto';
+
+/**
+ * Normalize a transaction business date to a stable, timezone-free `YYYY-MM-DD`
+ * string. Transaction dates are calendar dates, not instants — emitting a full
+ * `...T00:00:00.000Z` timestamp lets clients in negative-UTC-offset timezones
+ * render `Jul 1` as `Jun 30`. Accepts a Date or an ISO/date-only string; passes
+ * null/undefined through unchanged. See issue #55.
+ */
+export function toBusinessDate(value: unknown): unknown {
+  if (value == null) return value;
+  if (value instanceof Date) return value.toISOString().slice(0, 10);
+  if (typeof value === 'string') return value.slice(0, 10);
+  return value;
+}
+
+/**
+ * Parse a `YYYY-MM-DD` (or ISO) date query bound to the UTC-midnight instant of
+ * that calendar day, so range filtering matches the UTC-midnight semantics used
+ * when transaction dates are stored. See issue #55.
+ */
+export function utcDayStart(dateStr: string): Date {
+  return new Date(`${dateStr.slice(0, 10)}T00:00:00.000Z`);
+}
 
 @Injectable()
 export class TransactionsService {
@@ -138,13 +162,12 @@ export class TransactionsService {
       conditions.push(eq(schema.transactions.categoryId, query.categoryId));
     }
     if (query.from && query.to) {
-      conditions.push(
-        between(
-          schema.transactions.date,
-          new Date(query.from),
-          new Date(query.to),
-        ),
-      );
+      // Filter on UTC calendar-day bounds: [from 00:00Z, to+1day 00:00Z) so the
+      // whole `to` day is included regardless of the stored time-of-day. #55
+      const toExclusive = utcDayStart(query.to);
+      toExclusive.setUTCDate(toExclusive.getUTCDate() + 1);
+      conditions.push(gte(schema.transactions.date, utcDayStart(query.from)));
+      conditions.push(lt(schema.transactions.date, toExclusive));
     }
     if (query.search) {
       conditions.push(
@@ -433,6 +456,9 @@ export class TransactionsService {
     if (!txn) return txn;
     return {
       ...txn,
+      // Emit the business date as a stable `YYYY-MM-DD` calendar date so clients
+      // never shift it a day across timezones. #55
+      date: toBusinessDate(txn.date),
       originalDescription: decryptField(txn.originalDescription),
     };
   }

--- a/apps/web/src/__tests__/format.spec.ts
+++ b/apps/web/src/__tests__/format.spec.ts
@@ -39,6 +39,16 @@ describe('formatDate', () => {
   it('should format ISO date string for display', () => {
     expect(formatDate('2026-03-15')).toBe('Mar 15, 2026');
   });
+
+  // Regression for #55: a Jul-1 business date must never render as Jun 30 in a
+  // behind-UTC timezone, whether the API sends a date-only or a full-ISO value.
+  it('renders a date-only Jul 1 as Jul 1 (not Jun 30)', () => {
+    expect(formatDate('2026-07-01')).toBe('Jul 1, 2026');
+  });
+
+  it('renders a UTC-midnight ISO Jul 1 as Jul 1 (not Jun 30)', () => {
+    expect(formatDate('2026-07-01T00:00:00.000Z')).toBe('Jul 1, 2026');
+  });
 });
 
 describe('formatDateShort', () => {

--- a/apps/web/src/components/charts/TopTransactionsCard.tsx
+++ b/apps/web/src/components/charts/TopTransactionsCard.tsx
@@ -1,6 +1,5 @@
-import { formatCents } from '@/lib/format';
+import { formatCents, formatDate } from '@/lib/format';
 import type { Transaction } from '@moneypulse/shared';
-import { format } from 'date-fns';
 import { Flame } from 'lucide-react';
 
 interface TopTransactionsCardProps {
@@ -41,7 +40,7 @@ export function TopTransactionsCard({ transactions }: TopTransactionsCardProps) 
                   {tx.merchantName || tx.description}
                 </p>
                 <p className="text-xs text-[var(--muted-foreground)]">
-                  {format(new Date(tx.date), 'MMM d, yyyy')}
+                  {formatDate(tx.date)}
                 </p>
               </div>
               <span className="shrink-0 text-sm font-bold tabular-nums text-[var(--destructive)]">


### PR DESCRIPTION
Closes #55

## Problem
Transaction business dates were serialized to clients as full UTC-midnight timestamps (`2026-07-01T00:00:00.000Z`). Any render path that parsed them in **local** time showed a Jul-1 date as **"Jun 30"** for negative-UTC-offset viewers (e.g. `America/New_York`) — so a drill-down banner reading `Total Expenses (2026-07-01 – 2026-07-05)` could list rows labeled `Jun 30, 2026`.

#67 fixed the main transactions list (UTC-safe `formatDate`), but this issue was filed before that and covers the remaining paths.

## Changes
- **API — unambiguous responses:** normalize the transaction `date` field to a stable `YYYY-MM-DD` calendar string in `decryptTxn` (the single choke point for all transaction reads) via a new exported `toBusinessDate` helper. Clients can no longer misinterpret the time component.
- **API — robust filtering:** replace the inclusive-both-ends `between(date, new Date(from), new Date(to))` with UTC calendar-day bounds `[from 00:00Z, to+1day 00:00Z)` via a new `utcDayStart` helper, so the entire `to` day is included regardless of stored time-of-day.
- **web — last local-format path:** `TopTransactionsCard` rendered `tx.date` with date-fns local `format(new Date(...))`; now uses the UTC-safe `formatDate`.

Storage was already correct (dates parsed via ISO = UTC midnight); export CSV already slices UTC ISO. No schema/migration change.

## Test plan
- API: new `business-date.spec.ts` — `toBusinessDate` (Date/ISO/date-only/null) and `utcDayStart` (calendar-day parse + `[from, to+1day)` window includes the whole last day). Full API suite: **477 pass**.
- web: `format.spec.ts` regressions — date-only and full-ISO `2026-07-01` both render `Jul 1, 2026` (13 pass).
- `pnpm build` green for api + web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)