### PR TITLE
fix(sync): reproject transactions on mutation + canonical aliased category contract (#89 #90)

### DIFF
--- a/apps/api/src/categories/categories.service.ts
+++ b/apps/api/src/categories/categories.service.ts
@@ -15,6 +15,7 @@ import type {
   UpdateCategoryInput,
 } from '@moneypulse/shared';
 import { OutboxService } from '../sync/outbox.service';
+import { AliasMapperService } from '../sync/alias-mapper.service';
 
 /**
  * Service for managing the category tree.
@@ -28,6 +29,7 @@ export class CategoriesService {
   constructor(
     @Inject(DATABASE_CONNECTION) private readonly db: any,
     @Optional() private readonly outbox?: OutboxService,
+    @Optional() private readonly aliasMapper?: AliasMapperService,
   ) {}
 
   /**
@@ -223,7 +225,7 @@ export class CategoriesService {
   }
 
   private async enqueueCategoryEvent(category: any, userId?: string): Promise<void> {
-    if (!this.outbox || !userId) return;
+    if (!this.outbox || !this.aliasMapper || !userId) return;
     try {
       await this.outbox.enqueue({
         eventType: 'category.projected.v1',
@@ -231,10 +233,16 @@ export class CategoriesService {
         aggregateId: category.id,
         userId,
         payload: {
+          // Web ingest keys category docs on `categoryId` and reads
+          // `parentCategoryId`; both are obfuscated aliases so raw local UUIDs
+          // never leave the NAS and match the aliased categoryId on transactions. #90
+          categoryId: this.aliasMapper.toAliasId('category', category.id),
           name: category.name,
           icon: category.icon ?? null,
           color: category.color ?? null,
-          parentId: category.parentId ?? null,
+          parentCategoryId: category.parentId
+            ? this.aliasMapper.toAliasId('category', category.parentId)
+            : null,
           sortOrder: category.sortOrder ?? 0,
           isTransfer: category.isTransfer ?? false,
         },

--- a/apps/api/src/categorization/__tests__/categorization.service.spec.ts
+++ b/apps/api/src/categorization/__tests__/categorization.service.spec.ts
@@ -2,6 +2,7 @@ import { CategorizationService } from '../categorization.service';
 import { RuleEngineService } from '../rule-engine.service';
 import { AiCategorizerService } from '../ai-categorizer.service';
 import { LearningService } from '../learning.service';
+import { TransactionProjectionService } from '../../sync/transaction-projection.service';
 
 describe('CategorizationService', () => {
   let service: CategorizationService;
@@ -82,11 +83,16 @@ describe('CategorizationService', () => {
       extractPattern: vi.fn().mockReturnValue(''),
     };
 
+    const mockProjection = {
+      reprojectByIds: vi.fn().mockResolvedValue(undefined),
+    } as unknown as TransactionProjectionService;
+
     service = new CategorizationService(
       mockDb,
       mockRuleEngine as RuleEngineService,
       mockAiCategorizer as AiCategorizerService,
       mockLearningService as LearningService,
+      mockProjection,
     );
   });
 

--- a/apps/api/src/categorization/categorization.module.ts
+++ b/apps/api/src/categorization/categorization.module.ts
@@ -8,9 +8,10 @@ import { MerchantAliasController } from './merchant-alias.controller';
 import { MerchantAliasService } from './merchant-alias.service';
 import { OllamaHealthService } from './ollama-health.service';
 import { AiLogsModule } from '../ai-logs/ai-logs.module';
+import { SyncModule } from '../sync/sync.module';
 
 @Module({
-  imports: [AiLogsModule],
+  imports: [AiLogsModule, SyncModule],
   controllers: [MerchantAliasController],
   providers: [
     RuleEngineService,

--- a/apps/api/src/categorization/categorization.service.ts
+++ b/apps/api/src/categorization/categorization.service.ts
@@ -5,6 +5,7 @@ import { eq, and, isNull, inArray } from 'drizzle-orm';
 import { RuleEngineService } from './rule-engine.service';
 import { AiCategorizerService } from './ai-categorizer.service';
 import { LearningService } from './learning.service';
+import { TransactionProjectionService } from '../sync/transaction-projection.service';
 
 interface CategorizationStats {
   total: number;
@@ -29,6 +30,7 @@ export class CategorizationService {
     private readonly ruleEngine: RuleEngineService,
     private readonly aiCategorizer: AiCategorizerService,
     private readonly learningService: LearningService,
+    private readonly projection: TransactionProjectionService,
   ) {}
 
   /**
@@ -112,6 +114,11 @@ export class CategorizationService {
           .set({ categoryId, updatedAt: new Date() })
           .where(inArray(schema.transactions.id, ids));
       }
+      // Reproject so the web reflects the rule-assigned category instead of the
+      // uncategorized state projected at import time. #89
+      await this.projection.reprojectByIds(
+        [...categorizedByCategoryId.values()].flat(),
+      );
     }
 
     if (stillUncategorized.length === 0) return stats;
@@ -132,6 +139,7 @@ export class CategorizationService {
       );
 
       const remainingAfterAi: any[] = [];
+      const aiCategorizedIds: string[] = [];
 
       for (let i = 0; i < stillUncategorized.length; i++) {
         const result = aiResults[i];
@@ -155,6 +163,7 @@ export class CategorizationService {
               result.confidence,
             );
 
+            aiCategorizedIds.push(stillUncategorized[i].id);
             stats.categorizedByAi++;
           } else {
             remainingAfterAi.push(stillUncategorized[i]);
@@ -167,6 +176,9 @@ export class CategorizationService {
           remainingAfterAi.push(stillUncategorized[i]);
         }
       }
+
+      // Reproject AI-assigned transactions so the web leaves "Uncategorized". #89
+      await this.projection.reprojectByIds(aiCategorizedIds);
 
       stats.uncategorized = remainingAfterAi.length;
     } catch (err: any) {
@@ -205,6 +217,9 @@ export class CategorizationService {
       transactionId,
       newCategoryId,
     );
+
+    // Reproject the override so the web reflects the corrected category. #89
+    await this.projection.reprojectByIds([transactionId]);
   }
 
   /**
@@ -321,6 +336,11 @@ export class CategorizationService {
         .set({ categoryId, updatedAt: new Date() })
         .where(inArray(schema.transactions.id, ids));
     }
+
+    // Reproject rule-assigned transactions so the web leaves "Uncategorized". #89
+    await this.projection.reprojectByIds(
+      [...categorizedByCategoryId.values()].flat(),
+    );
 
     return { categorizedByRule: ruleCount, uncategorizedIds: stillUncategorizedIds };
   }

--- a/apps/api/src/sync/__tests__/transaction-projection.service.spec.ts
+++ b/apps/api/src/sync/__tests__/transaction-projection.service.spec.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TransactionProjectionService } from '../transaction-projection.service';
+
+/**
+ * Contract tests for the shared transaction projection payload (#89 #90):
+ * the local category UUID must be aliased, and reprojection must re-emit for
+ * every mutated row.
+ */
+describe('TransactionProjectionService', () => {
+  let mockDb: any;
+  let mockOutbox: { enqueue: any; enqueueInTx: any };
+  let aliasMapper: { toAliasId: any };
+  let service: TransactionProjectionService;
+
+  beforeEach(() => {
+    mockDb = {
+      select: vi.fn().mockReturnThis(),
+      from: vi.fn().mockReturnThis(),
+      // Chains for the isTransfer lookup (…where().limit()); the reprojectByIds
+      // test overrides `where` to resolve the row list directly.
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue([]),
+    };
+    mockOutbox = {
+      enqueue: vi.fn().mockResolvedValue(undefined),
+      enqueueInTx: vi.fn().mockResolvedValue(undefined),
+    };
+    // Deterministic alias so we can assert the category UUID was obfuscated.
+    aliasMapper = {
+      toAliasId: vi.fn((entity: string, id: string) => `alias:${entity}:${id}`),
+    };
+    service = new TransactionProjectionService(
+      mockDb,
+      mockOutbox as any,
+      aliasMapper as any,
+    );
+  });
+
+  const baseTxn = {
+    id: 'txn-1',
+    userId: 'user-1',
+    accountId: 'acc-1',
+    categoryId: 'cat-uuid-9',
+    amountCents: 1200,
+    date: new Date('2026-07-01T00:00:00.000Z'),
+    isCredit: false,
+    isManual: false,
+    tags: [],
+  };
+
+  it('aliases the local category UUID instead of leaking it (#90)', async () => {
+    mockDb.limit.mockResolvedValue([{ isTransfer: false }]);
+
+    await service.project('transaction.projected.v1', baseTxn);
+
+    expect(mockOutbox.enqueue).toHaveBeenCalledOnce();
+    const payload = mockOutbox.enqueue.mock.calls[0][0].payload;
+    // categoryId is the aliased value, not the raw UUID that was on the row.
+    expect(payload.categoryId).toBe('alias:category:cat-uuid-9');
+    expect(payload.transactionAliasId).toBe('alias:transaction:txn-1');
+    expect(aliasMapper.toAliasId).toHaveBeenCalledWith('category', 'cat-uuid-9');
+  });
+
+  it('emits categoryId: null when the transaction is uncategorized', async () => {
+    await service.project('transaction.projected.v1', {
+      ...baseTxn,
+      categoryId: null,
+    });
+    const payload = mockOutbox.enqueue.mock.calls[0][0].payload;
+    expect(payload.categoryId).toBeNull();
+    // No category lookup performed for an uncategorized transaction.
+    expect(aliasMapper.toAliasId).not.toHaveBeenCalledWith('category', null);
+  });
+
+  it('reflects the category transfer flag from the DB (#89)', async () => {
+    mockDb.limit.mockResolvedValue([{ isTransfer: true }]);
+    await service.project('transaction.projected.v1', baseTxn);
+    const payload = mockOutbox.enqueue.mock.calls[0][0].payload;
+    expect(payload.isTransfer).toBe(true);
+  });
+
+  it('never throws when aliasing fails — best-effort (#89)', async () => {
+    aliasMapper.toAliasId.mockImplementation(() => {
+      throw new Error('ALIAS_SECRET must be set for sync alias mapping');
+    });
+    await expect(
+      service.project('transaction.projected.v1', baseTxn),
+    ).resolves.toBeUndefined();
+    expect(mockOutbox.enqueue).not.toHaveBeenCalled();
+  });
+
+  it('reprojectByIds re-emits a projection for each loaded row (#89)', async () => {
+    mockDb.where.mockResolvedValue([
+      { ...baseTxn, id: 'txn-1', categoryId: null },
+      { ...baseTxn, id: 'txn-2', categoryId: null },
+    ]);
+    await service.reprojectByIds(['txn-1', 'txn-2']);
+    expect(mockOutbox.enqueue).toHaveBeenCalledTimes(2);
+  });
+
+  it('reprojectByIds is a no-op for an empty id list', async () => {
+    await service.reprojectByIds([]);
+    expect(mockDb.select).not.toHaveBeenCalled();
+    expect(mockOutbox.enqueue).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/sync/sync.controller.ts
+++ b/apps/api/src/sync/sync.controller.ts
@@ -216,7 +216,11 @@ export class SyncController {
             accountAliasId: this.aliasMapper.toAliasId('account', txn.account_id),
             amountCents: txn.amount_cents,
             date: new Date(txn.date).toISOString(),
-            categoryId: txn.category_id ?? null,
+            // Alias the local category UUID so backfilled rows match the aliased
+            // categoryId emitted by the live path and category docs. #90
+            categoryId: txn.category_id
+              ? this.aliasMapper.toAliasId('category', txn.category_id)
+              : null,
             isCredit: txn.is_credit,
             isTransfer: txn.is_transfer,
             isManual: false,
@@ -274,11 +278,15 @@ export class SyncController {
           aggregateId: cat.id,
           userId,
           payload: {
-            categoryId: cat.id,
+            // Aliased identifiers so backfilled category docs key and link
+            // identically to the live emitter (categories.service). #90
+            categoryId: this.aliasMapper.toAliasId('category', cat.id),
             name: cat.name,
             icon: cat.icon,
             color: cat.color,
-            parentCategoryId: cat.parent_id ?? null,
+            parentCategoryId: cat.parent_id
+              ? this.aliasMapper.toAliasId('category', cat.parent_id)
+              : null,
             sortOrder: cat.sort_order ?? 0,
             isTransfer: cat.is_transfer ?? false,
           },

--- a/apps/api/src/sync/sync.module.ts
+++ b/apps/api/src/sync/sync.module.ts
@@ -4,6 +4,7 @@ import { AliasMapperService } from './alias-mapper.service';
 import { SigningService } from './signing.service';
 import { SyncDeliveryService } from './sync-delivery.service';
 import { OutboxService } from './outbox.service';
+import { TransactionProjectionService } from './transaction-projection.service';
 import { SyncController } from './sync.controller';
 
 @Module({
@@ -14,6 +15,7 @@ import { SyncController } from './sync.controller';
     SigningService,
     SyncDeliveryService,
     OutboxService,
+    TransactionProjectionService,
   ],
   exports: [
     SanitizerV2Service,
@@ -21,6 +23,7 @@ import { SyncController } from './sync.controller';
     SigningService,
     SyncDeliveryService,
     OutboxService,
+    TransactionProjectionService,
   ],
 })
 export class SyncModule {}

--- a/apps/api/src/sync/transaction-projection.service.ts
+++ b/apps/api/src/sync/transaction-projection.service.ts
@@ -1,0 +1,123 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { eq, inArray, isNull, and } from 'drizzle-orm';
+import { DATABASE_CONNECTION } from '../db/db.module';
+import * as schema from '../db/schema';
+import { OutboxService } from './outbox.service';
+import { AliasMapperService } from './alias-mapper.service';
+
+/**
+ * Single source of truth for building and enqueuing `transaction.projected.v1`
+ * sync events. Owning this in one place keeps the payload contract consistent
+ * across every mutation path (import, manual edit, bulk categorize, split,
+ * rule/AI categorization) so the web projection never goes stale. #89 #90
+ *
+ * Lives in SyncModule (not TransactionsService) so CategorizationService can
+ * reproject without creating a circular module dependency
+ * (transactions → categorization → transactions).
+ */
+@Injectable()
+export class TransactionProjectionService {
+  private readonly logger = new Logger(TransactionProjectionService.name);
+
+  constructor(
+    @Inject(DATABASE_CONNECTION) private readonly db: any,
+    private readonly outbox: OutboxService,
+    private readonly aliasMapper: AliasMapperService,
+  ) {}
+
+  /**
+   * Build the PII-free projection payload for a transaction row. The local
+   * category UUID is obfuscated into an alias so raw identifiers never leave the
+   * NAS, and so it matches the aliased `categoryId` emitted for category docs. #90
+   */
+  private buildPayload(txn: any, isTransfer: boolean): Record<string, unknown> {
+    return {
+      transactionAliasId: this.aliasMapper.toAliasId('transaction', txn.id),
+      accountAliasId: this.aliasMapper.toAliasId('account', txn.accountId),
+      amountCents: txn.amountCents,
+      date: txn.date instanceof Date ? txn.date.toISOString() : txn.date,
+      categoryId: txn.categoryId
+        ? this.aliasMapper.toAliasId('category', txn.categoryId)
+        : null,
+      isCredit: txn.isCredit,
+      isTransfer,
+      isManual: txn.isManual ?? false,
+      isSplitParent: txn.isSplitParent ?? false,
+      tags: txn.tags ?? [],
+      originalAmountCents: txn.originalAmountCents ?? null,
+      currencyCode: txn.currencyCode ?? null,
+    };
+  }
+
+  /** Resolve whether a transaction's category is a transfer (drives web KPI math). */
+  private async resolveIsTransfer(
+    executor: any,
+    categoryId: string | null | undefined,
+  ): Promise<boolean> {
+    if (!categoryId) return false;
+    const rows = await executor
+      .select({ isTransfer: schema.categories.isTransfer })
+      .from(schema.categories)
+      .where(eq(schema.categories.id, categoryId))
+      .limit(1);
+    return rows[0]?.isTransfer ?? false;
+  }
+
+  /**
+   * Enqueue a projection event inside an existing DB transaction (transactional
+   * outbox) so a committed domain write always has a matching outbox event.
+   * If ALIAS_SECRET is missing, this throws and the caller's tx is rolled back.
+   */
+  async projectInTx(tx: any, eventType: string, txn: any): Promise<void> {
+    const isTransfer = await this.resolveIsTransfer(tx, txn.categoryId);
+    await this.outbox.enqueueInTx(tx, {
+      eventType,
+      aggregateType: 'transaction',
+      aggregateId: txn.id,
+      userId: txn.userId,
+      payload: this.buildPayload(txn, isTransfer),
+    });
+  }
+
+  /**
+   * Best-effort projection outside a DB transaction. Aliasing/outbox errors are
+   * caught and logged so the domain operation still succeeds.
+   */
+  async project(eventType: string, txn: any): Promise<void> {
+    try {
+      const isTransfer = await this.resolveIsTransfer(this.db, txn.categoryId);
+      await this.outbox.enqueue({
+        eventType,
+        aggregateType: 'transaction',
+        aggregateId: txn.id,
+        userId: txn.userId,
+        payload: this.buildPayload(txn, isTransfer),
+      });
+    } catch (err) {
+      this.logger.warn(
+        `Skipping outbox enqueue for transaction ${txn.id}: ${(err as Error).message}`,
+      );
+    }
+  }
+
+  /**
+   * Reproject a set of transactions by id after a local mutation (categorize,
+   * bulk categorize, transfer reclassification, split) so the web projection
+   * eventually reflects the final local state. Best-effort per row. #89
+   */
+  async reprojectByIds(ids: string[]): Promise<void> {
+    if (ids.length === 0) return;
+    const rows = await this.db
+      .select()
+      .from(schema.transactions)
+      .where(
+        and(
+          inArray(schema.transactions.id, ids),
+          isNull(schema.transactions.deletedAt),
+        ),
+      );
+    for (const txn of rows) {
+      await this.project('transaction.projected.v1', txn);
+    }
+  }
+}

--- a/apps/api/src/transactions/__tests__/transactions.service.spec.ts
+++ b/apps/api/src/transactions/__tests__/transactions.service.spec.ts
@@ -4,6 +4,7 @@ import { TransactionsService } from '../transactions.service';
 import { DATABASE_CONNECTION } from '../../db/db.module';
 import { OutboxService } from '../../sync/outbox.service';
 import { AliasMapperService } from '../../sync/alias-mapper.service';
+import { TransactionProjectionService } from '../../sync/transaction-projection.service';
 
 vi.mock('../../common/crypto', () => ({
   encryptField: vi.fn().mockReturnValue('encrypted_test_value'),
@@ -40,17 +41,17 @@ describe('TransactionsService', () => {
 
     mockAliasMapper = { toAliasId: vi.fn().mockReturnValue('alias-abc123') };
 
-    const mockOutbox = {
-      enqueue: vi.fn().mockResolvedValue(undefined),
-      enqueueInTx: vi.fn().mockResolvedValue(undefined),
+    const mockProjection = {
+      project: vi.fn().mockResolvedValue(undefined),
+      projectInTx: vi.fn().mockResolvedValue(undefined),
+      reprojectByIds: vi.fn().mockResolvedValue(undefined),
     };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TransactionsService,
         { provide: DATABASE_CONNECTION, useValue: mockDb },
-        { provide: OutboxService, useValue: mockOutbox },
-        { provide: AliasMapperService, useValue: mockAliasMapper },
+        { provide: TransactionProjectionService, useValue: mockProjection },
       ],
     }).compile();
 
@@ -169,9 +170,12 @@ describe('TransactionsService', () => {
       };
       mockAliasMapper = { toAliasId: vi.fn().mockReturnValue('alias-abc123') };
 
+      // Use the real projection service so payload assertions exercise the
+      // actual buildPayload/isTransfer logic through mockOutbox.enqueue.
       const module: TestingModule = await Test.createTestingModule({
         providers: [
           TransactionsService,
+          TransactionProjectionService,
           { provide: DATABASE_CONNECTION, useValue: mockDb },
           { provide: OutboxService, useValue: mockOutbox },
           { provide: AliasMapperService, useValue: mockAliasMapper },

--- a/apps/api/src/transactions/transactions.service.ts
+++ b/apps/api/src/transactions/transactions.service.ts
@@ -6,8 +6,7 @@ import {
   BadRequestException,
 } from '@nestjs/common';
 import { DATABASE_CONNECTION } from '../db/db.module';
-import { OutboxService } from '../sync/outbox.service';
-import { AliasMapperService } from '../sync/alias-mapper.service';
+import { TransactionProjectionService } from '../sync/transaction-projection.service';
 import * as schema from '../db/schema';
 import {
   eq,
@@ -61,8 +60,7 @@ export class TransactionsService {
 
   constructor(
     @Inject(DATABASE_CONNECTION) private readonly db: any,
-    private readonly outbox: OutboxService,
-    private readonly aliasMapper: AliasMapperService,
+    private readonly projection: TransactionProjectionService,
   ) {}
 
   /**
@@ -117,7 +115,7 @@ export class TransactionsService {
         .returning();
 
       const inserted = this.decryptTxn(rows[0]);
-      await this.enqueueTransactionEventInTx(tx, 'transaction.projected.v1', inserted);
+      await this.projection.projectInTx(tx, 'transaction.projected.v1', inserted);
       return inserted;
     });
 
@@ -329,8 +327,8 @@ export class TransactionsService {
       .returning();
     const updatedRow = this.decryptTxn(rows[0]);
     // Best-effort: sync outbox failures (e.g. ALIAS_SECRET not configured) must
-    // not roll back the domain write. enqueueTransactionEvent already catches.
-    await this.enqueueTransactionEvent('transaction.projected.v1', updatedRow);
+    // not roll back the domain write. project() already catches.
+    await this.projection.project('transaction.projected.v1', updatedRow);
     return updatedRow;
   }
 
@@ -409,6 +407,13 @@ export class TransactionsService {
       )
       .returning();
 
+    // Reproject the now-split parent (so the web can flag/exclude it) and the new
+    // child transactions, so the cloud projection reflects the split. #89
+    await this.projection.reprojectByIds([
+      parent.id,
+      ...children.map((c: any) => c.id),
+    ]);
+
     return { parent: { ...parent, isSplitParent: true }, children: children.map((c: any) => this.decryptTxn(c)) };
   }
 
@@ -430,6 +435,10 @@ export class TransactionsService {
         ),
       )
       .returning({ id: schema.transactions.id });
+
+    // Reproject each recategorized transaction so the web projection reflects
+    // the new category instead of showing stale "Uncategorized". #89
+    await this.projection.reprojectByIds(updated.map((u: any) => u.id));
 
     return { updatedCount: updated.length };
   }
@@ -461,96 +470,5 @@ export class TransactionsService {
       date: toBusinessDate(txn.date),
       originalDescription: decryptField(txn.originalDescription),
     };
-  }
-
-  /**
-   * Enqueue a safe, PII-free projection event within an existing DB transaction.
-   * Look up the is_transfer flag for a category. Returns false when the
-   * transaction has no category or the category row is not found.
-   */
-  private async resolveIsTransfer(
-    executor: any,
-    categoryId: string | null | undefined,
-  ): Promise<boolean> {
-    if (!categoryId) return false;
-    const rows = await executor
-      .select({ isTransfer: schema.categories.isTransfer })
-      .from(schema.categories)
-      .where(eq(schema.categories.id, categoryId))
-      .limit(1);
-    return rows[0]?.isTransfer ?? false;
-  }
-
-  /**
-   * Alias mapping errors propagate so the outer transaction can roll back atomically.
-   * If ALIAS_SECRET is missing, the domain write is rolled back and the caller receives an error.
-   */
-  private async enqueueTransactionEventInTx(
-    tx: any,
-    eventType: string,
-    txn: any,
-  ): Promise<void> {
-    const isTransfer = await this.resolveIsTransfer(tx, txn.categoryId);
-    const payload: Record<string, unknown> = {
-      transactionAliasId: this.aliasMapper.toAliasId('transaction', txn.id),
-      accountAliasId: this.aliasMapper.toAliasId('account', txn.accountId),
-      amountCents: txn.amountCents,
-      date: txn.date instanceof Date ? txn.date.toISOString() : txn.date,
-      categoryId: txn.categoryId ?? null,
-      isCredit: txn.isCredit,
-      isTransfer,
-      isManual: txn.isManual ?? false,
-      tags: txn.tags ?? [],
-      originalAmountCents: txn.originalAmountCents ?? null,
-      currencyCode: txn.currencyCode ?? null,
-    };
-
-    await this.outbox.enqueueInTx(tx, {
-      eventType,
-      aggregateType: 'transaction',
-      aggregateId: txn.id,
-      userId: txn.userId,
-      payload,
-    });
-  }
-
-  /**
-   * Enqueue a safe, PII-free projection event for the sync outbox (best-effort).
-   * Aliasing and outbox insert errors are caught and logged so the domain operation
-   * succeeds even when sync secrets are missing or the outbox insert fails.
-   * Prefer enqueueTransactionEventInTx when atomicity with the domain write is required.
-   */
-  private async enqueueTransactionEvent(
-    eventType: string,
-    txn: any,
-  ): Promise<void> {
-    try {
-      const isTransfer = await this.resolveIsTransfer(this.db, txn.categoryId);
-      const payload: Record<string, unknown> = {
-        transactionAliasId: this.aliasMapper.toAliasId('transaction', txn.id),
-        accountAliasId: this.aliasMapper.toAliasId('account', txn.accountId),
-        amountCents: txn.amountCents,
-        date: txn.date instanceof Date ? txn.date.toISOString() : txn.date,
-        categoryId: txn.categoryId ?? null,
-        isCredit: txn.isCredit,
-        isTransfer,
-        isManual: txn.isManual ?? false,
-        tags: txn.tags ?? [],
-        originalAmountCents: txn.originalAmountCents ?? null,
-        currencyCode: txn.currencyCode ?? null,
-      };
-
-      await this.outbox.enqueue({
-        eventType,
-        aggregateType: 'transaction',
-        aggregateId: txn.id,
-        userId: txn.userId,
-        payload,
-      });
-    } catch (err) {
-      this.logger.warn(
-        `Skipping outbox enqueue for transaction ${txn.id}: ${(err as Error).message}`,
-      );
-    }
   }
 }


### PR DESCRIPTION
Closes #89
Closes #90

Companion web changes (required for the split-parent exclusion below) are in a paired PR on `moneypulse-web`.

## #90 — canonical, privacy-preserving projection contract
The category event contract was inconsistent between emitters and with the web ingest, and raw local UUIDs were leaking:
- **Category events** now emit an aliased `categoryId` and `parentCategoryId` (previously: no `categoryId` at all, and `parentId` instead of the `parentCategoryId` the web reads). Fixed in both the live emitter (`categories.service`) and the backfill (`sync.controller`).
- **Transaction events** now alias `categoryId` (previously the raw local UUID), so it links to the aliased category docs and no raw identifier crosses the local-first boundary.

## #89 — reprojection on every mutation path
Only the initial import emitted `transaction.projected.v1`; later category/transfer changes updated the local DB only, leaving Firestore stale (`Uncategorized`, wrong KPIs).
- New **`TransactionProjectionService`** (in `SyncModule`) is the single source of truth for building/enqueuing the projection payload, so `TransactionsService` and `CategorizationService` share one contract **without a circular module dependency** (transactions → categorization → transactions).
- Reprojection now fires after: manual update (already did), **bulk categorize**, **split** (children + parent), **rule-engine + AI categorization**, the **rules-only** pass, and **single recategorize**.
- Split parents now carry `isSplitParent` in the payload so consumers can exclude them (their children carry the real amounts/categories — otherwise KPIs would double-count).

## Design notes
- The projection service resolves `isTransfer` from the category and aliases identifiers in one place; both the transactional (atomic create) and best-effort (mutation) paths go through it.
- Best-effort semantics preserved: a missing `ALIAS_SECRET` logs and skips rather than failing the domain write.

## Test plan
- New `transaction-projection.service.spec.ts`: category-UUID aliasing, `isTransfer` flag, best-effort on missing `ALIAS_SECRET`, reproject fan-out per row, empty-list no-op.
- Updated `transactions.service.spec.ts` / `categorization.service.spec.ts` for the shared projection dependency.
- Full API suite: **483 pass**. `nest build` green.
- Companion `moneypulse-web`: split-parent exclusion in `use-kpis`/`use-transactions` + `fanOutTransaction` persistence; web suite **80 app / 50 functions pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)