### PR TITLE
Fix web unit test heap OOM in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,8 @@ jobs:
 
       - name: Run Web unit tests
         run: pnpm --filter @moneypulse/web test
+        env:
+          NODE_OPTIONS: --max-old-space-size=6144
 
   # ── Integration / E2E Tests ───────────────────────────────
   test-e2e:

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -17,5 +17,11 @@ export default defineConfig({
     setupFiles: ['./src/__tests__/setup.ts'],
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
     css: false,
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        singleFork: true,
+      },
+    },
   },
 });


### PR DESCRIPTION
## Problem
The web package's vitest unit tests hit Node's 4GB heap limit in GitHub Actions, causing a deterministic failure:
```
FATAL ERROR: Ineffective mark-compacts near heap limit — Allocation failed - JavaScript heap out of memory
```

This blocks every PR and has been failing consistently.

## Solution
This fix combines two complementary approaches:

1. **Increase Node heap size** to 6GB via `NODE_OPTIONS=--max-old-space-size=6144` in the CI step env
   - Gives the process more memory headroom
   - Helps accommodate the full test suite in memory

2. **Configure vitest to use single-fork pool** with sequential execution instead of parallel workers
   - Eliminates memory overhead from concurrent worker threads
   - Reduces peak memory usage during test execution
   - Configuration: `pool: 'forks'` with `poolOptions.forks.singleFork: true`

## Files Changed
- `.github/workflows/ci.yml`: Added `NODE_OPTIONS` env to "Run Web unit tests" step
- `apps/web/vitest.config.ts`: Added pool configuration for single-fork sequential execution

## Testing
- The fix should resolve the OOM by reducing peak memory usage and increasing available heap
- If the suite still requires more memory, further optimizations (test splitting, isolate improvements) can be explored in follow-up work