### PR TITLE
fix(web): exclude vitest.config.ts from production build type-check

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -36,6 +36,7 @@
     ".next/dev/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "vitest.config.ts"
   ]
 }


### PR DESCRIPTION
Hotfix: #111's OOM fix broke `next build` (poolOptions type error in vitest.config.ts, which the web tsconfig type-checks). CI runs tests not the full build, so it passed while main's build broke — surfaced by the NAS deploy of #110. Excludes the test config from the build; keeps singleFork. **Verified `pnpm --filter @moneypulse/web build` passes locally.**