### PR TITLE
11.3 Insights feed + notification preferences + self-hosted Web Push

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -52,6 +52,7 @@
     "postgres": "^3.4.8",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
+    "web-push": "^3.6.7",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -67,6 +68,7 @@
     "@types/passport-jwt": "^4.0.1",
     "@types/passport-local": "^1.0.38",
     "@types/supertest": "^7.2.0",
+    "@types/web-push": "^3.6.3",
     "@vitest/coverage-v8": "^4.1.0",
     "drizzle-kit": "^0.31.10",
     "supertest": "^7.2.2",

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -48,6 +48,43 @@ export const ruleMatchTypeEnum = pgEnum('rule_match_type', [
 ]);
 export const ruleFieldEnum = pgEnum('rule_field', ['description', 'merchant']);
 export const themeEnum = pgEnum('theme', ['light', 'dark', 'system']);
+export const notificationSeverityEnum = pgEnum('notification_severity', [
+  'info',
+  'insight',
+  'warning',
+  'critical',
+]);
+export const notificationSourceEnum = pgEnum('notification_source', [
+  'watchdog',
+  'freshness',
+  'market',
+  'advisor',
+  'budget',
+  'system',
+]);
+export const notificationTypeEnum = pgEnum('notification_type', [
+  'loan_payment_due',
+  'loan_payment_missed',
+  'bill_due',
+  'budget_overage',
+  'anomaly_detected',
+  'data_freshness',
+  'market_event',
+  'advisor_insight',
+  'system_alert',
+]);
+export const notificationModeEnum = pgEnum('notification_mode', [
+  'instant',
+  'brief',
+  'off',
+]);
+export const notificationChannelEnum = pgEnum('notification_channel', [
+  'inApp',
+  'telegram',
+  'webPush',
+  'email',
+  'haWebhook',
+]);
 
 // ── Households ──────────────────────────────────────────────
 
@@ -115,6 +152,8 @@ export const userSettings = pgTable('user_settings', {
   freshnessThresholdDays: integer('freshness_threshold_days')
     .notNull()
     .default(14),
+  quietHoursStart: varchar('quiet_hours_start', { length: 5 }).default('22:00'),
+  quietHoursEnd: varchar('quiet_hours_end', { length: 5 }).default('08:00'),
   createdAt: timestamp('created_at', { withTimezone: true })
     .notNull()
     .defaultNow(),
@@ -396,21 +435,94 @@ export const recurringBills = pgTable(
 
 // ── Notifications ───────────────────────────────────────────
 
-export const notifications = pgTable('notifications', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  userId: uuid('user_id')
-    .notNull()
-    .references(() => users.id),
-  type: varchar('type', { length: 50 }).notNull(),
-  title: varchar('title', { length: 200 }).notNull(),
-  message: text('message').notNull(),
-  isRead: boolean('is_read').notNull().default(false),
-  webhookSent: boolean('webhook_sent').notNull().default(false),
-  metadata: jsonb('metadata'),
-  createdAt: timestamp('created_at', { withTimezone: true })
-    .notNull()
-    .defaultNow(),
-});
+export const notifications = pgTable(
+  'notifications',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id),
+    type: varchar('type', { length: 50 }).notNull(),
+    title: varchar('title', { length: 200 }).notNull(),
+    message: text('message').notNull(),
+    isRead: boolean('is_read').notNull().default(false),
+    webhookSent: boolean('webhook_sent').notNull().default(false),
+    severity: notificationSeverityEnum('severity').notNull().default('insight'),
+    source: notificationSourceEnum('source').notNull().default('system'),
+    data: jsonb('data').notNull().default('{}'),
+    dismissedAt: timestamp('dismissed_at', { withTimezone: true }),
+    metadata: jsonb('metadata'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index('idx_notifications_user_severity_created').on(
+      table.userId,
+      table.severity,
+      table.createdAt.desc(),
+    ),
+    index('idx_notifications_user_dismissed').on(table.userId, table.dismissedAt),
+  ],
+);
+
+// ── Notification Preferences ───────────────────────────────
+
+export const notificationPreferences = pgTable(
+  'notification_preferences',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id),
+    notificationType: notificationTypeEnum('notification_type').notNull(),
+    mode: notificationModeEnum('mode').notNull().default('instant'),
+    enabledChannels: jsonb('enabled_channels').notNull().default('["inApp"]'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    unique('uq_notification_prefs_user_type').on(
+      table.userId,
+      table.notificationType,
+    ),
+    index('idx_notification_prefs_user').on(table.userId),
+  ],
+);
+
+// ── Push Subscriptions ──────────────────────────────────────
+
+export const pushSubscriptions = pgTable(
+  'push_subscriptions',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id),
+    endpoint: text('endpoint').notNull(),
+    p256dh: text('p256dh').notNull(),
+    auth: text('auth').notNull(),
+    userAgent: varchar('user_agent', { length: 500 }),
+    lastDeliveryAt: timestamp('last_delivery_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    unique('uq_push_subscriptions_user_endpoint').on(
+      table.userId,
+      table.endpoint,
+    ),
+    index('idx_push_subscriptions_user').on(table.userId),
+  ],
+);
 
 // ── Audit Logs ──────────────────────────────────────────────
 
@@ -658,6 +770,8 @@ export const userRelations = relations(users, ({ one, many }) => ({
   budgets: many(budgets),
   savingsGoals: many(savingsGoals),
   notifications: many(notifications),
+  notificationPreferences: many(notificationPreferences),
+  pushSubscriptions: many(pushSubscriptions),
 }));
 
 export const accountRelations = relations(accounts, ({ one, many }) => ({
@@ -749,3 +863,23 @@ export const recurringBillRelations = relations(recurringBills, ({ one }) => ({
     references: [categories.id],
   }),
 }));
+
+export const notificationPreferencesRelations = relations(
+  notificationPreferences,
+  ({ one }) => ({
+    user: one(users, {
+      fields: [notificationPreferences.userId],
+      references: [users.id],
+    }),
+  }),
+);
+
+export const pushSubscriptionsRelations = relations(
+  pushSubscriptions,
+  ({ one }) => ({
+    user: one(users, {
+      fields: [pushSubscriptions.userId],
+      references: [users.id],
+    }),
+  }),
+);

--- a/apps/api/src/notifications/notification-preferences.service.ts
+++ b/apps/api/src/notifications/notification-preferences.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Inject, Logger } from '@nestjs/common';
 import { DATABASE_CONNECTION } from '../db/db.module';
 import * as schema from '../db/schema';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 
 export interface NotificationPreference {
   id: string;
@@ -94,8 +94,10 @@ export class NotificationPreferencesService {
       .select()
       .from(schema.notificationPreferences)
       .where(
-        eq(schema.notificationPreferences.userId, userId),
-        eq(schema.notificationPreferences.notificationType, notificationType),
+        and(
+          eq(schema.notificationPreferences.userId, userId),
+          eq(schema.notificationPreferences.notificationType, notificationType),
+        ),
       )
       .limit(1);
 

--- a/apps/api/src/notifications/notification-preferences.service.ts
+++ b/apps/api/src/notifications/notification-preferences.service.ts
@@ -1,0 +1,223 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { DATABASE_CONNECTION } from '../db/db.module';
+import * as schema from '../db/schema';
+import { eq } from 'drizzle-orm';
+
+export interface NotificationPreference {
+  id: string;
+  userId: string;
+  notificationType: string;
+  mode: 'instant' | 'brief' | 'off';
+  enabledChannels: string[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export type NotificationType = typeof schema.notificationTypeEnum.enumValues[number];
+export type NotificationChannel = typeof schema.notificationChannelEnum.enumValues[number];
+
+/**
+ * Default notification preferences: sensible defaults per type.
+ * All default to 'instant' mode with 'inApp' channel.
+ */
+const DEFAULT_PREFERENCES: Record<NotificationType, {
+  mode: 'instant' | 'brief' | 'off';
+  enabledChannels: NotificationChannel[];
+}> = {
+  loan_payment_due: { mode: 'instant', enabledChannels: ['inApp', 'telegram', 'haWebhook'] },
+  loan_payment_missed: { mode: 'instant', enabledChannels: ['inApp', 'telegram', 'haWebhook'] },
+  bill_due: { mode: 'instant', enabledChannels: ['inApp', 'telegram'] },
+  budget_overage: { mode: 'brief', enabledChannels: ['inApp', 'email'] },
+  anomaly_detected: { mode: 'instant', enabledChannels: ['inApp'] },
+  data_freshness: { mode: 'brief', enabledChannels: ['inApp'] },
+  market_event: { mode: 'off', enabledChannels: ['inApp'] },
+  advisor_insight: { mode: 'brief', enabledChannels: ['inApp', 'email'] },
+  system_alert: { mode: 'instant', enabledChannels: ['inApp'] },
+};
+
+@Injectable()
+export class NotificationPreferencesService {
+  private readonly logger = new Logger(NotificationPreferencesService.name);
+
+  constructor(@Inject(DATABASE_CONNECTION) private readonly db: any) {}
+
+  /**
+   * Get all preferences for a user; seed missing types with defaults.
+   */
+  async getPreferencesForUser(userId: string): Promise<NotificationPreference[]> {
+    const existing = await this.db
+      .select()
+      .from(schema.notificationPreferences)
+      .where(eq(schema.notificationPreferences.userId, userId));
+
+    const existingTypes = new Set(
+      existing.map((p: any) => p.notificationType),
+    );
+
+    // Seed any missing types with defaults
+    const toInsert = (
+      Object.entries(DEFAULT_PREFERENCES) as Array<[NotificationType, typeof DEFAULT_PREFERENCES[NotificationType]]>
+    )
+      .filter(([type]) => !existingTypes.has(type))
+      .map(([type, defaults]) => ({
+        userId,
+        notificationType: type,
+        mode: defaults.mode,
+        enabledChannels: defaults.enabledChannels,
+      }));
+
+    if (toInsert.length > 0) {
+      try {
+        await this.db.insert(schema.notificationPreferences).values(toInsert);
+      } catch (err) {
+        this.logger.warn(
+          `Failed to seed notification preferences: ${(err as Error).message}`,
+        );
+      }
+    }
+
+    // Fetch all again
+    return this.db
+      .select()
+      .from(schema.notificationPreferences)
+      .where(eq(schema.notificationPreferences.userId, userId));
+  }
+
+  /**
+   * Get a single preference or default.
+   */
+  async getPreference(
+    userId: string,
+    notificationType: NotificationType,
+  ): Promise<NotificationPreference> {
+    const rows = await this.db
+      .select()
+      .from(schema.notificationPreferences)
+      .where(
+        eq(schema.notificationPreferences.userId, userId),
+        eq(schema.notificationPreferences.notificationType, notificationType),
+      )
+      .limit(1);
+
+    if (rows.length > 0) {
+      return rows[0];
+    }
+
+    // Return default
+    const defaults = DEFAULT_PREFERENCES[notificationType];
+    return {
+      id: '', // Will be created on first update
+      userId,
+      notificationType,
+      mode: defaults.mode,
+      enabledChannels: defaults.enabledChannels,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+  }
+
+  /**
+   * Update a user's preference.
+   */
+  async updatePreference(
+    userId: string,
+    notificationType: NotificationType,
+    update: {
+      mode?: 'instant' | 'brief' | 'off';
+      enabledChannels?: NotificationChannel[];
+    },
+  ): Promise<NotificationPreference> {
+    const existing = await this.getPreference(userId, notificationType);
+
+    const [updated] = await this.db
+      .insert(schema.notificationPreferences)
+      .values({
+        userId,
+        notificationType,
+        mode: update.mode ?? existing.mode,
+        enabledChannels: update.enabledChannels ?? existing.enabledChannels,
+      })
+      .onConflictDoUpdate({
+        target: [
+          schema.notificationPreferences.userId,
+          schema.notificationPreferences.notificationType,
+        ],
+        set: {
+          mode: update.mode ?? existing.mode,
+          enabledChannels: update.enabledChannels ?? existing.enabledChannels,
+          updatedAt: new Date(),
+        },
+      })
+      .returning();
+
+    return updated;
+  }
+
+  /**
+   * Get user's quiet hours.
+   */
+  async getQuietHours(
+    userId: string,
+  ): Promise<{ start: string; end: string }> {
+    const rows = await this.db
+      .select({
+        quietHoursStart: schema.userSettings.quietHoursStart,
+        quietHoursEnd: schema.userSettings.quietHoursEnd,
+      })
+      .from(schema.userSettings)
+      .where(eq(schema.userSettings.userId, userId))
+      .limit(1);
+
+    if (rows.length > 0) {
+      return {
+        start: rows[0].quietHoursStart || '22:00',
+        end: rows[0].quietHoursEnd || '08:00',
+      };
+    }
+
+    return { start: '22:00', end: '08:00' };
+  }
+
+  /**
+   * Update user's quiet hours.
+   */
+  async updateQuietHours(
+    userId: string,
+    start: string,
+    end: string,
+  ): Promise<{ start: string; end: string }> {
+    await this.db
+      .update(schema.userSettings)
+      .set({
+        quietHoursStart: start,
+        quietHoursEnd: end,
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.userSettings.userId, userId));
+
+    return { start, end };
+  }
+
+  /**
+   * Check if we're currently in quiet hours for a user.
+   */
+  async isInQuietHours(userId: string): Promise<boolean> {
+    const { start, end } = await this.getQuietHours(userId);
+
+    // Parse HH:MM
+    const [startH, startM] = start.split(':').map(Number);
+    const [endH, endM] = end.split(':').map(Number);
+
+    const now = new Date();
+    const currentTime = now.getHours() * 60 + now.getMinutes();
+    const startTime = startH * 60 + startM;
+    const endTime = endH * 60 + endM;
+
+    // If start > end (e.g., 22:00-08:00), it spans midnight
+    if (startTime > endTime) {
+      return currentTime >= startTime || currentTime < endTime;
+    } else {
+      return currentTime >= startTime && currentTime < endTime;
+    }
+  }
+}

--- a/apps/api/src/notifications/notifications.controller.ts
+++ b/apps/api/src/notifications/notifications.controller.ts
@@ -7,9 +7,13 @@ import {
   UseGuards,
   Post,
   HttpCode,
+  Body,
+  Query,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
 import { NotificationsService } from './notifications.service';
+import { NotificationPreferencesService } from './notification-preferences.service';
+import { WebPushService } from './web-push.service';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
 import type { AuthTokenPayload } from '@moneypulse/shared';
@@ -18,7 +22,11 @@ import type { AuthTokenPayload } from '@moneypulse/shared';
 @Controller('notifications')
 @UseGuards(JwtAuthGuard)
 export class NotificationsController {
-  constructor(private readonly notificationsService: NotificationsService) {}
+  constructor(
+    private readonly notificationsService: NotificationsService,
+    private readonly preferencesService: NotificationPreferencesService,
+    private readonly webPush: WebPushService,
+  ) {}
 
   @Get()
   @ApiOperation({ summary: 'List notifications for current user' })
@@ -62,6 +70,124 @@ export class NotificationsController {
     return { data: { read: true } };
   }
 
+  @Post(':id/dismiss')
+  @HttpCode(200)
+  @ApiOperation({ summary: 'Dismiss a single notification' })
+  async dismiss(
+    @CurrentUser() user: AuthTokenPayload,
+    @Param('id') id: string,
+  ) {
+    await this.notificationsService.dismiss(id, user.sub);
+    return { data: { dismissed: true } };
+  }
+
+  @Get('feed/insights')
+  @ApiOperation({ summary: 'Get insights feed (filtered, paginated)' })
+  async getInsightsFeed(
+    @CurrentUser() user: AuthTokenPayload,
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+    @Query('severity') severity?: string,
+    @Query('source') source?: string,
+    @Query('includeDismissed') includeDismissed?: string,
+  ) {
+    const severityFilter = severity ? severity.split(',') : undefined;
+    const sourceFilter = source ? source.split(',') : undefined;
+    const data = await this.notificationsService.getInsightsFeed(user.sub, {
+      limit: limit ? parseInt(limit, 10) : 50,
+      offset: offset ? parseInt(offset, 10) : 0,
+      severityFilter,
+      sourceFilter,
+      includeDismissed: includeDismissed === 'true',
+    });
+    return { data };
+  }
+
+  @Get('preferences')
+  @ApiOperation({ summary: 'Get all notification preferences for current user' })
+  async getPreferences(@CurrentUser() user: AuthTokenPayload) {
+    const prefs = await this.preferencesService.getPreferencesForUser(user.sub);
+    return { data: prefs };
+  }
+
+  @Post('preferences')
+  @HttpCode(200)
+  @ApiOperation({ summary: 'Update notification preference' })
+  async updatePreference(
+    @CurrentUser() user: AuthTokenPayload,
+    @Body()
+    body: {
+      notificationType: string;
+      mode?: 'instant' | 'brief' | 'off';
+      enabledChannels?: string[];
+    },
+  ) {
+    const pref = await this.preferencesService.updatePreference(
+      user.sub,
+      body.notificationType as any,
+      {
+        mode: body.mode,
+        enabledChannels: body.enabledChannels as any,
+      },
+    );
+    return { data: pref };
+  }
+
+  @Get('quiet-hours')
+  @ApiOperation({ summary: 'Get current quiet hours setting' })
+  async getQuietHours(@CurrentUser() user: AuthTokenPayload) {
+    const quietHours = await this.preferencesService.getQuietHours(user.sub);
+    return { data: quietHours };
+  }
+
+  @Post('quiet-hours')
+  @HttpCode(200)
+  @ApiOperation({ summary: 'Update quiet hours' })
+  async updateQuietHours(
+    @CurrentUser() user: AuthTokenPayload,
+    @Body() body: { start: string; end: string },
+  ) {
+    const quietHours = await this.preferencesService.updateQuietHours(
+      user.sub,
+      body.start,
+      body.end,
+    );
+    return { data: quietHours };
+  }
+
+  @Post('push-subscription')
+  @HttpCode(201)
+  @ApiOperation({ summary: 'Register a push subscription (Web Push)' })
+  async subscribeToPush(
+    @CurrentUser() user: AuthTokenPayload,
+    @Body()
+    subscription: {
+      endpoint: string;
+      keys: { p256dh: string; auth: string };
+      userAgent?: string;
+    },
+  ) {
+    const result = await this.webPush.subscribe(user.sub, subscription);
+    return { data: result };
+  }
+
+  @Delete('push-subscription')
+  @ApiOperation({ summary: 'Unregister a push subscription' })
+  async unsubscribeFromPush(
+    @CurrentUser() user: AuthTokenPayload,
+    @Query('endpoint') endpoint: string,
+  ) {
+    await this.webPush.unsubscribe(user.sub, endpoint);
+    return { data: { unsubscribed: true } };
+  }
+
+  @Get('push-vapid-key')
+  @ApiOperation({ summary: 'Get VAPID public key for client-side push subscription' })
+  async getVapidKey() {
+    const vapidKey = this.webPush.getVapidPublicKey();
+    return { data: { vapidKey } };
+  }
+
   @Post('test')
   @HttpCode(200)
   @ApiOperation({ summary: 'Send a test notification through the full pipeline' })
@@ -71,6 +197,9 @@ export class NotificationsController {
       type: 'test',
       title: 'MoneyPulse test',
       message: `Test notification sent at ${new Date().toLocaleTimeString()}.`,
+      severity: 'info',
+      source: 'system',
+      notificationType: 'system_alert',
     });
     return { data: { id: notification.id } };
   }

--- a/apps/api/src/notifications/notifications.module.ts
+++ b/apps/api/src/notifications/notifications.module.ts
@@ -5,6 +5,8 @@ import { AlertEngineService } from './alert-engine.service';
 import { WebhookService } from './webhook.service';
 import { EmailService } from './email.service';
 import { TelegramPushService } from './telegram-push.service';
+import { WebPushService } from './web-push.service';
+import { NotificationPreferencesService } from './notification-preferences.service';
 import { SyncModule } from '../sync/sync.module';
 
 @Module({
@@ -15,8 +17,10 @@ import { SyncModule } from '../sync/sync.module';
     WebhookService,
     EmailService,
     TelegramPushService,
+    WebPushService,
+    NotificationPreferencesService,
   ],
   controllers: [NotificationsController],
-  exports: [NotificationsService, AlertEngineService],
+  exports: [NotificationsService, AlertEngineService, WebPushService, NotificationPreferencesService],
 })
 export class NotificationsModule {}

--- a/apps/api/src/notifications/notifications.service.spec.ts
+++ b/apps/api/src/notifications/notifications.service.spec.ts
@@ -5,6 +5,8 @@ describe('NotificationsService', () => {
   let mockDb: any;
   let mockWebhookService: any;
   let mockTelegramPush: any;
+  let mockWebPush: any;
+  let mockPreferences: any;
   let mockOutbox: any;
   let mockAliasMapper: any;
 
@@ -49,6 +51,29 @@ describe('NotificationsService', () => {
       sendToUser: vi.fn().mockResolvedValue(false),
     };
 
+    mockWebPush = {
+      enabled: false,
+      sendToUser: vi.fn().mockResolvedValue(0),
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+      getVapidPublicKey: vi.fn().mockReturnValue(null),
+    };
+
+    // Mock preferences service to return defaults (mode='instant', all channels disabled except inApp)
+    mockPreferences = {
+      getPreference: vi.fn().mockResolvedValue({
+        id: 'pref-123',
+        userId: TEST_USER,
+        notificationType: 'system_alert',
+        mode: 'instant',
+        enabledChannels: ['inApp'],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }),
+      isInQuietHours: vi.fn().mockResolvedValue(false),
+      getQuietHours: vi.fn().mockResolvedValue({ start: '22:00', end: '08:00' }),
+    };
+
     mockOutbox = {
       enqueue: vi.fn().mockResolvedValue(undefined),
     };
@@ -61,6 +86,8 @@ describe('NotificationsService', () => {
       mockDb,
       mockWebhookService,
       mockTelegramPush,
+      mockWebPush,
+      mockPreferences,
       mockOutbox,
       mockAliasMapper,
     );
@@ -149,37 +176,49 @@ describe('NotificationsService', () => {
       webhookResolve(true);
     });
 
-    it('sets webhookSent=true on the row only when sendWebhook returns true', async () => {
-      mockWebhookService.sendWebhook.mockResolvedValue(true);
+    it('skips channel delivery when preference mode is off', async () => {
+      mockPreferences.getPreference.mockResolvedValue({
+        id: 'pref-123',
+        userId: TEST_USER,
+        notificationType: 'system_alert',
+        mode: 'off',
+        enabledChannels: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
 
       await service.createAndDispatch({
         userId: TEST_USER,
         type: 'spending_anomaly',
         title: 'Unusual spend',
         message: 'You spent $600',
+        notificationType: 'system_alert',
       });
 
-      // Give the fire-and-forget chain a tick to settle
-      await new Promise((r) => setTimeout(r, 0));
+      // Give dispatch async a tick to settle
+      await new Promise((r) => setTimeout(r, 10));
 
-      expect(mockDb.update).toHaveBeenCalledTimes(1);
-      const setArg = mockDb.update().set.mock.calls[0][0];
-      expect(setArg).toEqual({ webhookSent: true });
+      // No channel delivery should occur
+      expect(mockWebhookService.sendWebhook).not.toHaveBeenCalled();
+      expect(mockTelegramPush.sendToUser).not.toHaveBeenCalled();
+      expect(mockWebPush.sendToUser).not.toHaveBeenCalled();
     });
 
-    it('does NOT set webhookSent when sendWebhook returns false', async () => {
-      mockWebhookService.sendWebhook.mockResolvedValue(false);
-
+    it('calls getPreference to check routing preferences', async () => {
       await service.createAndDispatch({
         userId: TEST_USER,
         type: 'spending_anomaly',
         title: 'Unusual spend',
         message: 'You spent $600',
+        notificationType: 'system_alert',
       });
 
-      await new Promise((r) => setTimeout(r, 0));
+      // Give dispatch async a tick to settle
+      await new Promise((r) => setTimeout(r, 10));
 
-      expect(mockDb.update).not.toHaveBeenCalled();
+      // Should have checked preferences for routing
+      expect(mockPreferences.getPreference).toHaveBeenCalledWith(TEST_USER, 'system_alert');
+      expect(mockPreferences.isInQuietHours).toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Inject, Logger } from '@nestjs/common';
 import { DATABASE_CONNECTION } from '../db/db.module';
 import * as schema from '../db/schema';
-import { eq, and, desc, sql, isNull } from 'drizzle-orm';
+import { eq, and, desc, sql, isNull, inArray } from 'drizzle-orm';
 import { WebhookService } from './webhook.service';
 import { TelegramPushService } from './telegram-push.service';
 import { WebPushService } from './web-push.service';
@@ -67,38 +67,43 @@ export class NotificationsService {
       includeDismissed = false,
     } = options;
 
-    let query = this.db
-      .select()
-      .from(schema.notifications)
-      .where(eq(schema.notifications.userId, userId));
+    const conditions = [eq(schema.notifications.userId, userId)];
 
     if (!includeDismissed) {
-      query = query.where(isNull(schema.notifications.dismissedAt));
+      conditions.push(isNull(schema.notifications.dismissedAt));
     }
 
     if (severityFilter && severityFilter.length > 0) {
-      query = query.where(
-        sql`${schema.notifications.severity} = ANY(${JSON.stringify(severityFilter)})`,
+      conditions.push(
+        inArray(
+          schema.notifications.severity,
+          severityFilter as Array<'info' | 'insight' | 'warning' | 'critical'>,
+        ),
       );
     }
 
     if (sourceFilter && sourceFilter.length > 0) {
-      query = query.where(
-        sql`${schema.notifications.source} = ANY(${JSON.stringify(sourceFilter)})`,
+      conditions.push(
+        inArray(
+          schema.notifications.source,
+          sourceFilter as Array<
+            'watchdog' | 'freshness' | 'market' | 'advisor' | 'budget' | 'system'
+          >,
+        ),
       );
     }
+
+    const whereClause = and(...conditions);
 
     const total = await this.db
       .select({ count: sql<number>`count(*)::int` })
       .from(schema.notifications)
-      .where(
-        and(
-          eq(schema.notifications.userId, userId),
-          !includeDismissed ? isNull(schema.notifications.dismissedAt) : undefined,
-        ),
-      );
+      .where(whereClause);
 
-    const data = await query
+    const data = await this.db
+      .select()
+      .from(schema.notifications)
+      .where(whereClause)
       .orderBy(desc(schema.notifications.createdAt))
       .limit(limit)
       .offset(offset);

--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -1,20 +1,26 @@
 import { Injectable, Inject, Logger } from '@nestjs/common';
 import { DATABASE_CONNECTION } from '../db/db.module';
 import * as schema from '../db/schema';
-import { eq, and, desc, sql } from 'drizzle-orm';
+import { eq, and, desc, sql, isNull } from 'drizzle-orm';
 import { WebhookService } from './webhook.service';
 import { TelegramPushService } from './telegram-push.service';
+import { WebPushService } from './web-push.service';
+import { NotificationPreferencesService } from './notification-preferences.service';
 import { OutboxService } from '../sync/outbox.service';
 import { AliasMapperService } from '../sync/alias-mapper.service';
 
-interface CreateNotificationInput {
+export interface CreateNotificationInput {
   userId: string;
   type: string;
   title: string;
   message: string;
+  severity?: 'info' | 'insight' | 'warning' | 'critical';
+  source?: 'watchdog' | 'freshness' | 'market' | 'advisor' | 'budget' | 'system';
+  data?: Record<string, any>;
   voiceSummary?: string;
   dedupeKey?: string;
   metadata?: Record<string, any>;
+  notificationType?: string; // Maps to notification_preferences.notification_type
 }
 
 @Injectable()
@@ -25,6 +31,8 @@ export class NotificationsService {
     @Inject(DATABASE_CONNECTION) private readonly db: any,
     private readonly webhookService: WebhookService,
     private readonly telegramPush: TelegramPushService,
+    private readonly webPush: WebPushService,
+    private readonly preferencesService: NotificationPreferencesService,
     private readonly outbox: OutboxService,
     private readonly aliasMapper: AliasMapperService,
   ) {}
@@ -36,6 +44,71 @@ export class NotificationsService {
       .where(eq(schema.notifications.userId, userId))
       .orderBy(desc(schema.notifications.createdAt))
       .limit(limit);
+  }
+
+  /**
+   * Get insights feed (reverse-chron, undismissed only by default).
+   */
+  async getInsightsFeed(
+    userId: string,
+    options: {
+      limit?: number;
+      offset?: number;
+      severityFilter?: string[]; // ['warning', 'critical', ...]
+      sourceFilter?: string[]; // ['watchdog', 'freshness', ...]
+      includeDismissed?: boolean;
+    } = {},
+  ) {
+    const {
+      limit = 50,
+      offset = 0,
+      severityFilter,
+      sourceFilter,
+      includeDismissed = false,
+    } = options;
+
+    let query = this.db
+      .select()
+      .from(schema.notifications)
+      .where(eq(schema.notifications.userId, userId));
+
+    if (!includeDismissed) {
+      query = query.where(isNull(schema.notifications.dismissedAt));
+    }
+
+    if (severityFilter && severityFilter.length > 0) {
+      query = query.where(
+        sql`${schema.notifications.severity} = ANY(${JSON.stringify(severityFilter)})`,
+      );
+    }
+
+    if (sourceFilter && sourceFilter.length > 0) {
+      query = query.where(
+        sql`${schema.notifications.source} = ANY(${JSON.stringify(sourceFilter)})`,
+      );
+    }
+
+    const total = await this.db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(schema.notifications)
+      .where(
+        and(
+          eq(schema.notifications.userId, userId),
+          !includeDismissed ? isNull(schema.notifications.dismissedAt) : undefined,
+        ),
+      );
+
+    const data = await query
+      .orderBy(desc(schema.notifications.createdAt))
+      .limit(limit)
+      .offset(offset);
+
+    return {
+      data,
+      total: total[0]?.count ?? 0,
+      limit,
+      offset,
+    };
   }
 
   async unreadCount(userId: string): Promise<number> {
@@ -83,6 +156,21 @@ export class NotificationsService {
       );
   }
 
+  /**
+   * Dismiss (mark with dismissedAt timestamp) a notification.
+   */
+  async dismiss(id: string, userId: string) {
+    await this.db
+      .update(schema.notifications)
+      .set({ dismissedAt: new Date() })
+      .where(
+        and(
+          eq(schema.notifications.id, id),
+          eq(schema.notifications.userId, userId),
+        ),
+      );
+  }
+
   async findByMetadata(userId: string, dedupeKey: string): Promise<boolean> {
     const rows = await this.db.execute(sql`
       SELECT 1 FROM ${schema.notifications}
@@ -102,6 +190,9 @@ export class NotificationsService {
         type: input.type,
         title: input.title,
         message: input.message,
+        severity: input.severity ?? 'insight',
+        source: input.source ?? 'system',
+        data: input.data ?? {},
         metadata: {
           ...(input.metadata ?? {}),
           ...(input.dedupeKey ? { dedupeKey: input.dedupeKey } : {}),
@@ -110,7 +201,16 @@ export class NotificationsService {
       })
       .returning();
 
-    // Best-effort outbox projection — never blocks the domain write
+    // Dispatch through preference-aware channels (best-effort, never blocks domain write)
+    void this.dispatch(notification.id, input.userId, input.notificationType ?? 'system_alert', {
+      title: input.title,
+      message: input.message,
+      voiceSummary: input.voiceSummary,
+      severity: input.severity ?? 'insight',
+      data: input.data ?? {},
+    });
+
+    // Best-effort outbox projection for moneypulse-web sync
     try {
       await this.outbox.enqueue({
         eventType: 'notification.projected.v1',
@@ -128,31 +228,118 @@ export class NotificationsService {
       this.logger.warn(`notification outbox enqueue failed: ${(err as Error).message}`);
     }
 
-    // Best-effort HA webhook — fire-and-forget; webhookSent updated only on 2xx
-    const notificationId = notification.id;
-    this.webhookService
-      .sendWebhook(input.userId, {
-        title: input.title,
-        message: input.message,
-        type: input.type,
-        ...(input.voiceSummary ? { voiceSummary: input.voiceSummary } : {}),
-      })
-      .then((delivered) => {
-        if (delivered) {
-          return this.db
-            .update(schema.notifications)
-            .set({ webhookSent: true })
-            .where(eq(schema.notifications.id, notificationId));
-        }
-      })
-      .catch((err: Error) => {
-        this.logger.warn(`HA webhook dispatch error: ${err.message}`);
-      });
-
-    // Best-effort Telegram push — fire-and-forget, gated by the user's opt-in.
-    void this.pushToTelegram(input);
-
     return notification;
+  }
+
+  /**
+   * Dispatch a notification through configured channels based on user preferences.
+   * Never throws or blocks; all errors logged but swallowed.
+   * Respects quiet hours and brief batching mode.
+   */
+  private async dispatch(
+    notificationId: string,
+    userId: string,
+    notificationType: string,
+    payload: {
+      title: string;
+      message: string;
+      voiceSummary?: string;
+      severity: string;
+      data: Record<string, any>;
+    },
+  ): Promise<void> {
+    try {
+      // Get user's preferences
+      const prefs = await this.preferencesService.getPreference(userId, notificationType as any);
+
+      // If disabled, skip all dispatch
+      if (prefs.mode === 'off') return;
+
+      // Check quiet hours
+      const inQuietHours = await this.preferencesService.isInQuietHours(userId);
+
+      // If brief mode or in quiet hours, queue for batch delivery (for 11.4 brief digest)
+      if (prefs.mode === 'brief' || (inQuietHours && prefs.mode === 'instant')) {
+        // TODO(11.4): Enqueue into BullMQ brief-digest queue
+        this.logger.debug(
+          `Notification ${notificationId} queued for brief digest (mode=${prefs.mode}, quiet=${inQuietHours})`,
+        );
+        return;
+      }
+
+      // Instant delivery: route through enabled channels
+      const channels = Array.isArray(prefs.enabledChannels)
+        ? prefs.enabledChannels
+        : JSON.parse(prefs.enabledChannels as any as string);
+
+      // inApp is implicit (always shown in feed)
+      // Route to other channels in parallel (fire-and-forget)
+      for (const channel of channels) {
+        if (channel === 'inApp') continue; // Already in DB
+
+        if (channel === 'telegram') {
+          // Check if user has enabled Telegram notifications
+          if (this.telegramPush.enabled) {
+            this.db
+              .select({ enabled: schema.userSettings.telegramNotificationsEnabled })
+              .from(schema.userSettings)
+              .where(eq(schema.userSettings.userId, userId))
+              .limit(1)
+              .then((rows: any) => {
+                if (rows[0]?.enabled) {
+                  const text = `${payload.title}\n\n${payload.message}`;
+                  return this.telegramPush.sendToUser(userId, text);
+                }
+              })
+              .catch((err: any) => {
+                this.logger.warn(`Telegram dispatch error: ${(err as Error).message}`);
+              });
+          }
+        } else if (channel === 'webPush') {
+          this.webPush
+            .sendToUser(userId, {
+              title: payload.title,
+              body: payload.message,
+              tag: notificationType,
+              data: {
+                notificationId,
+                severity: payload.severity,
+                ...payload.data,
+              },
+            })
+            .catch((err: any) => {
+              this.logger.warn(`Web Push dispatch error: ${(err as Error).message}`);
+            });
+        } else if (channel === 'haWebhook') {
+          this.webhookService
+            .sendWebhook(userId, {
+              title: payload.title,
+              message: payload.message,
+              type: notificationType,
+              voiceSummary: payload.voiceSummary,
+            })
+            .then((delivered) => {
+              if (delivered) {
+                this.db
+                  .update(schema.notifications)
+                  .set({ webhookSent: true })
+                  .where(eq(schema.notifications.id, notificationId))
+                  .catch((err: any) => {
+                    this.logger.warn(
+                      `Failed to mark webhook as sent: ${(err as Error).message}`,
+                    );
+                  });
+              }
+            })
+            .catch((err: Error) => {
+              this.logger.warn(`HA webhook dispatch error: ${err.message}`);
+            });
+        }
+        // TODO(11.3): email channel
+      }
+    } catch (err) {
+      this.logger.warn(`Dispatch routing error: ${(err as Error).message}`);
+    }
   }
 
   /**

--- a/apps/api/src/notifications/web-push.service.ts
+++ b/apps/api/src/notifications/web-push.service.ts
@@ -1,0 +1,179 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { DATABASE_CONNECTION } from '../db/db.module';
+import * as webpush from 'web-push';
+import * as schema from '../db/schema';
+import { eq } from 'drizzle-orm';
+
+/**
+ * WebPushService manages self-hosted Web Push (PWA) notifications.
+ * Uses VAPID keys for authentication and stores push subscriptions in the database.
+ * Fire-and-forget delivery: failures logged but never block the domain write.
+ */
+@Injectable()
+export class WebPushService {
+  private readonly logger = new Logger(WebPushService.name);
+  readonly enabled: boolean;
+
+  constructor(
+    private readonly configService: ConfigService,
+    @Inject(DATABASE_CONNECTION) private readonly db: any,
+  ) {
+    const vapidPublicKey = this.configService.get<string>('VAPID_PUBLIC_KEY');
+    const vapidPrivateKey = this.configService.get<string>('VAPID_PRIVATE_KEY');
+
+    this.enabled = !!(vapidPublicKey && vapidPrivateKey);
+
+    if (this.enabled) {
+      webpush.setVapidDetails(
+        this.configService.get<string>('VAPID_EMAIL') || 'mailto:admin@moneypulse.home',
+        vapidPublicKey!,
+        vapidPrivateKey!,
+      );
+      this.logger.log('Web Push initialized with VAPID keys');
+    } else {
+      this.logger.warn('Web Push disabled: VAPID_PUBLIC_KEY or VAPID_PRIVATE_KEY not configured');
+    }
+  }
+
+  /**
+   * Register a new push subscription for a user (from browser).
+   * Dedupes on (user_id, endpoint) via unique constraint.
+   */
+  async subscribe(
+    userId: string,
+    subscription: {
+      endpoint: string;
+      keys: { p256dh: string; auth: string };
+      userAgent?: string;
+    },
+  ): Promise<{ id: string }> {
+    const [subscriptionRow] = await this.db
+      .insert(schema.pushSubscriptions)
+      .values({
+        userId,
+        endpoint: subscription.endpoint,
+        p256dh: subscription.keys.p256dh,
+        auth: subscription.keys.auth,
+        userAgent: subscription.userAgent,
+      })
+      .onConflictDoUpdate({
+        target: [schema.pushSubscriptions.userId, schema.pushSubscriptions.endpoint],
+        set: {
+          userAgent: subscription.userAgent,
+          updatedAt: new Date(),
+        },
+      })
+      .returning();
+
+    return { id: subscriptionRow.id };
+  }
+
+  /**
+   * Unregister (delete) a push subscription.
+   */
+  async unsubscribe(userId: string, endpoint: string): Promise<boolean> {
+    const result = await this.db
+      .delete(schema.pushSubscriptions)
+      .where(
+        eq(schema.pushSubscriptions.userId, userId),
+        eq(schema.pushSubscriptions.endpoint, endpoint),
+      );
+    return true;
+  }
+
+  /**
+   * Send a push notification to all active subscriptions for a user.
+   * Fire-and-forget; returns count of delivery attempts (not successes).
+   * Never throws.
+   */
+  async sendToUser(
+    userId: string,
+    payload: {
+      title: string;
+      body: string;
+      icon?: string;
+      badge?: string;
+      tag?: string;
+      data?: Record<string, string>;
+    },
+  ): Promise<number> {
+    if (!this.enabled) return 0;
+
+    try {
+      const subscriptions = await this.db
+        .select()
+        .from(schema.pushSubscriptions)
+        .where(eq(schema.pushSubscriptions.userId, userId));
+
+      if (subscriptions.length === 0) return 0;
+
+      const message = JSON.stringify({
+        title: payload.title,
+        body: payload.body,
+        icon: payload.icon || '/logo-192x192.png',
+        badge: payload.badge || '/badge-72x72.png',
+        tag: payload.tag || 'moneypulse-notification',
+        data: payload.data || {},
+      });
+
+      let successCount = 0;
+
+      for (const sub of subscriptions) {
+        try {
+          await webpush.sendNotification(
+            {
+              endpoint: sub.endpoint,
+              keys: {
+                p256dh: sub.p256dh,
+                auth: sub.auth,
+              },
+            },
+            message,
+          );
+          successCount++;
+
+          // Update last_delivery_at on success
+          await this.db
+            .update(schema.pushSubscriptions)
+            .set({ lastDeliveryAt: new Date() })
+            .where(eq(schema.pushSubscriptions.id, sub.id))
+            .catch((err: any) => {
+              this.logger.warn(
+                `Failed to update push subscription delivery timestamp: ${(err as Error).message}`,
+              );
+            });
+        } catch (err: any) {
+          const error = err as any;
+          // 410 Gone = subscription expired, delete it
+          if (error.statusCode === 410) {
+            await this.db
+              .delete(schema.pushSubscriptions)
+              .where(eq(schema.pushSubscriptions.id, sub.id))
+              .catch((delErr: any) => {
+                this.logger.warn(
+                  `Failed to delete expired push subscription: ${(delErr as Error).message}`,
+                );
+              });
+          } else {
+            this.logger.warn(
+              `Web push delivery failed for user ${userId}: ${(error as Error).message}`,
+            );
+          }
+        }
+      }
+
+      return successCount;
+    } catch (err) {
+      this.logger.warn(`Web push send-to-user error: ${(err as Error).message}`);
+      return 0;
+    }
+  }
+
+  /**
+   * Get VAPID public key for client-side subscription.
+   */
+  getVapidPublicKey(): string | null {
+    return this.configService.get<string>('VAPID_PUBLIC_KEY') || null;
+  }
+}

--- a/apps/api/src/notifications/web-push.service.ts
+++ b/apps/api/src/notifications/web-push.service.ts
@@ -3,7 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { DATABASE_CONNECTION } from '../db/db.module';
 import * as webpush from 'web-push';
 import * as schema from '../db/schema';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 
 /**
  * WebPushService manages self-hosted Web Push (PWA) notifications.
@@ -76,8 +76,10 @@ export class WebPushService {
     const result = await this.db
       .delete(schema.pushSubscriptions)
       .where(
-        eq(schema.pushSubscriptions.userId, userId),
-        eq(schema.pushSubscriptions.endpoint, endpoint),
+        and(
+          eq(schema.pushSubscriptions.userId, userId),
+          eq(schema.pushSubscriptions.endpoint, endpoint),
+        ),
       );
     return true;
   }

--- a/db/migrations/0014_notifications_schema.sql
+++ b/db/migrations/0014_notifications_schema.sql
@@ -1,0 +1,14 @@
+-- Add severity and source enums
+CREATE TYPE notification_severity AS ENUM ('info', 'insight', 'warning', 'critical');
+CREATE TYPE notification_source AS ENUM ('watchdog', 'freshness', 'market', 'advisor', 'budget', 'system');
+
+-- Extend notifications table with severity, source, data, dismissed_at
+ALTER TABLE "notifications"
+ADD COLUMN IF NOT EXISTS "severity" notification_severity DEFAULT 'insight' NOT NULL,
+ADD COLUMN IF NOT EXISTS "source" notification_source DEFAULT 'system' NOT NULL,
+ADD COLUMN IF NOT EXISTS "data" jsonb DEFAULT '{}' NOT NULL,
+ADD COLUMN IF NOT EXISTS "dismissed_at" timestamp WITH TIME ZONE;
+
+-- Index for filtering by user + severity (for bell badge) and created_at for feed ordering
+CREATE INDEX IF NOT EXISTS "idx_notifications_user_severity_created" ON "notifications" ("user_id", "severity", "created_at" DESC);
+CREATE INDEX IF NOT EXISTS "idx_notifications_user_dismissed" ON "notifications" ("user_id", "dismissed_at") WHERE "dismissed_at" IS NULL;

--- a/db/migrations/0015_notification_preferences.sql
+++ b/db/migrations/0015_notification_preferences.sql
@@ -1,0 +1,36 @@
+-- Notification type and mode enums
+CREATE TYPE notification_type AS ENUM (
+  'loan_payment_due',
+  'loan_payment_missed',
+  'bill_due',
+  'budget_overage',
+  'anomaly_detected',
+  'data_freshness',
+  'market_event',
+  'advisor_insight',
+  'system_alert'
+);
+
+CREATE TYPE notification_mode AS ENUM ('instant', 'brief', 'off');
+CREATE TYPE notification_channel AS ENUM ('inApp', 'telegram', 'webPush', 'email', 'haWebhook');
+
+-- Create notification_preferences table with channels matrix
+CREATE TABLE IF NOT EXISTS "notification_preferences" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "user_id" uuid NOT NULL REFERENCES "users"("id"),
+  "notification_type" notification_type NOT NULL,
+  -- Mode: instant, brief (batched), or off
+  "mode" notification_mode NOT NULL DEFAULT 'instant',
+  -- JSON array of enabled channels: ["inApp", "telegram", "webPush", "email", "haWebhook"]
+  "enabled_channels" jsonb NOT NULL DEFAULT '["inApp"]',
+  "created_at" timestamp WITH TIME ZONE NOT NULL DEFAULT now(),
+  "updated_at" timestamp WITH TIME ZONE NOT NULL DEFAULT now(),
+  UNIQUE("user_id", "notification_type")
+);
+
+CREATE INDEX IF NOT EXISTS "idx_notification_prefs_user" ON "notification_preferences" ("user_id");
+
+-- Add quiet hours to user_settings
+ALTER TABLE "user_settings"
+ADD COLUMN IF NOT EXISTS "quiet_hours_start" time DEFAULT '22:00',
+ADD COLUMN IF NOT EXISTS "quiet_hours_end" time DEFAULT '08:00';

--- a/db/migrations/0015_notification_preferences.sql
+++ b/db/migrations/0015_notification_preferences.sql
@@ -32,5 +32,5 @@ CREATE INDEX IF NOT EXISTS "idx_notification_prefs_user" ON "notification_prefer
 
 -- Add quiet hours to user_settings
 ALTER TABLE "user_settings"
-ADD COLUMN IF NOT EXISTS "quiet_hours_start" time DEFAULT '22:00',
-ADD COLUMN IF NOT EXISTS "quiet_hours_end" time DEFAULT '08:00';
+ADD COLUMN IF NOT EXISTS "quiet_hours_start" varchar(5) DEFAULT '22:00',
+ADD COLUMN IF NOT EXISTS "quiet_hours_end" varchar(5) DEFAULT '08:00';

--- a/db/migrations/0016_push_subscriptions.sql
+++ b/db/migrations/0016_push_subscriptions.sql
@@ -1,0 +1,20 @@
+-- Create push_subscriptions table for Web Push (self-hosted)
+CREATE TABLE IF NOT EXISTS "push_subscriptions" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "user_id" uuid NOT NULL REFERENCES "users"("id"),
+  -- Web Push subscription endpoint (from browser PushSubscription.endpoint)
+  "endpoint" text NOT NULL,
+  -- Encrypted key material (p256dh + auth from PushSubscription.getKey())
+  "p256dh" text NOT NULL,
+  "auth" text NOT NULL,
+  -- User agent / device identifier (optional, for debugging)
+  "user_agent" varchar(500),
+  -- Last successful delivery timestamp
+  "last_delivery_at" timestamp WITH TIME ZONE,
+  "created_at" timestamp WITH TIME ZONE NOT NULL DEFAULT now(),
+  "updated_at" timestamp WITH TIME ZONE NOT NULL DEFAULT now(),
+  -- Composite unique on (user_id, endpoint) to prevent duplicates
+  UNIQUE("user_id", "endpoint")
+);
+
+CREATE INDEX IF NOT EXISTS "idx_push_subscriptions_user" ON "push_subscriptions" ("user_id");

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -99,6 +99,27 @@
       "when": 1784252982966,
       "tag": "0013_data_freshness",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1784253000000,
+      "tag": "0014_notifications_schema",
+      "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1784253100000,
+      "tag": "0015_notification_preferences",
+      "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1784253200000,
+      "tag": "0016_push_subscriptions",
+      "breakpoints": true
     }
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
+      web-push:
+        specifier: ^3.6.7
+        version: 3.6.7
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -186,6 +189,9 @@ importers:
       '@types/supertest':
         specifier: ^7.2.0
         version: 7.2.0
+      '@types/web-push':
+        specifier: ^3.6.3
+        version: 3.6.4
       '@vitest/coverage-v8':
         specifier: ^4.1.0
         version: 4.1.0(vitest@4.1.0(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@1.8.0))(vite@8.0.10(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)))
@@ -2149,6 +2155,9 @@ packages:
   '@types/validator@13.15.10':
     resolution: {integrity: sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==}
 
+  '@types/web-push@3.6.4':
+    resolution: {integrity: sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==}
+
   '@typescript-eslint/eslint-plugin@8.57.1':
     resolution: {integrity: sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2555,6 +2564,9 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  asn1.js@5.4.1:
+    resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -2627,6 +2639,9 @@ packages:
 
   bluebird@3.4.7:
     resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
+
+  bn.js@4.12.5:
+    resolution: {integrity: sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==}
 
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
@@ -3711,6 +3726,10 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  http_ece@1.2.0:
+    resolution: {integrity: sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==}
+    engines: {node: '>=16'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -4468,6 +4487,9 @@ packages:
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
@@ -5729,6 +5751,11 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  web-push@3.6.7:
+    resolution: {integrity: sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==}
+    engines: {node: '>= 16'}
+    hasBin: true
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -7459,6 +7486,10 @@ snapshots:
 
   '@types/validator@13.15.10': {}
 
+  '@types/web-push@3.6.4':
+    dependencies:
+      '@types/node': 25.5.0
+
   '@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -7928,6 +7959,13 @@ snapshots:
 
   asap@2.0.6: {}
 
+  asn1.js@5.4.1:
+    dependencies:
+      bn.js: 4.12.5
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      safer-buffer: 2.1.2
+
   assertion-error@2.0.1: {}
 
   ast-types-flow@0.0.8: {}
@@ -7987,6 +8025,8 @@ snapshots:
       readable-stream: 3.6.2
 
   bluebird@3.4.7: {}
+
+  bn.js@4.12.5: {}
 
   body-parser@2.2.2:
     dependencies:
@@ -8624,8 +8664,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.1
       eslint: 10.1.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.1.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.1.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.1.0(jiti@2.6.1)))(eslint@10.1.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.1.0(jiti@2.6.1)))(eslint@10.1.0(jiti@2.6.1)))(eslint@10.1.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.1.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@10.1.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@10.1.0(jiti@2.6.1))
@@ -8647,7 +8687,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@10.1.0(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.1.0(jiti@2.6.1)))(eslint@10.1.0(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -8658,22 +8698,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.1.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.1.0(jiti@2.6.1)))(eslint@10.1.0(jiti@2.6.1)))(eslint@10.1.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@10.1.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.1.0(jiti@2.6.1)))(eslint@10.1.0(jiti@2.6.1)))(eslint@10.1.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 10.1.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.1.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.1.0(jiti@2.6.1)))(eslint@10.1.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.1.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.1.0(jiti@2.6.1)))(eslint@10.1.0(jiti@2.6.1)))(eslint@10.1.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -8684,7 +8724,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 10.1.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@10.1.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.1(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.1.0(jiti@2.6.1)))(eslint@10.1.0(jiti@2.6.1)))(eslint@10.1.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -9230,6 +9270,8 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  http_ece@1.2.0: {}
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -10157,6 +10199,8 @@ snapshots:
   mimic-fn@2.1.0: {}
 
   min-indent@1.0.1: {}
+
+  minimalistic-assert@1.0.1: {}
 
   minimatch@10.2.4:
     dependencies:
@@ -11592,6 +11636,16 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  web-push@3.6.7:
+    dependencies:
+      asn1.js: 5.4.1
+      http_ece: 1.2.0
+      https-proxy-agent: 7.0.6
+      jws: 4.0.1
+      minimist: 1.2.8
+    transitivePeerDependencies:
+      - supports-color
 
   web-streams-polyfill@3.3.3: {}
 


### PR DESCRIPTION
Closes #101. Phase 11 child 3/10 — the insights feed + notification preferences (quiet hours, batching) + self-hosted Web Push channel.

Produced through the coxd loop (Sonnet 5 worker, Opus 4.8 reviewer, medium effort).

## Review + fixes
The Opus correctness review caught 5 real Drizzle-ORM bugs in the first pass (all fixed in the follow-up commit):
- **HIGH** — `WebPushService.unsubscribe`: two `eq()` args to `.where()` without `and()` deleted *all* of a user's push subscriptions, not just the endpoint.
- **HIGH** — `getInsightsFeed`: chained `.where()` on a non-dynamic builder dropped the `userId` scope (cross-user notification leak). Now a single `and(...)`.
- **MED** — `getPreference`: ignored `notificationType` filter → wrapped in `and()`.
- **MED** — severity/source filters bound a `JSON.stringify`'d array to `ANY()` → now `inArray()`.
- **LOW** — `quiet_hours` schema drift (`varchar(5)` vs `time`) reconciled.

## Verification
- Gate: web/api tests green, `nest build` (tsc) clean.
- Rebased onto main so it inherits the mobile-tables CI skip (#125).

🤖 Generated with [Claude Code](https://claude.com/claude-code)