### PR TITLE
11.6 Market-data module — EIA + FRED clients, market_metrics store, get_market_context MCP tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,22 @@ OLLAMA_MODEL=mistral:7b
 # OPENAI_API_KEY=
 # GOOGLE_API_KEY=   # Gemini (get from Google AI Studio)
 
+# ── Market Data (11.6) — public gas/electricity/rate series, both free ──
+# EIA: register at https://www.eia.gov/opendata/register.php (instant, no cost).
+# FRED: register at https://fred.stlouisfed.org/docs/api/api_key.html (instant, no cost).
+# Neither key is required to run the app — with a key unset, that source's series are
+# skipped (never an error) and the last stored value (if any) keeps being served.
+# EIA_API_KEY=
+# FRED_API_KEY=
+# EIA `duoarea` code for gas prices, `S` + 2-letter state postal code (verify at
+# https://www.eia.gov/opendata/browser/petroleum/pri/gnd — this convention was not
+# live-verified against a real key while writing this).
+MARKET_GAS_STATE=SCA
+# FRED series used as the HYSA-comparable benchmark. No FRED series *is* an actual
+# HYSA APY — FEDFUNDS (effective federal funds rate) is the standard public proxy
+# online-savings yields track closely.
+MARKET_HYSA_FRED_SERIES=FEDFUNDS
+
 # ── AI Advisor — Telegram surface (optional) ─────────────
 # Enables the advisor over Telegram. All optional. The API long-polls Telegram
 # (dials OUT to api.telegram.org via getUpdates) — no inbound URL is ever exposed,

--- a/apps/api/src/advisor/__tests__/mcp-client.service.spec.ts
+++ b/apps/api/src/advisor/__tests__/mcp-client.service.spec.ts
@@ -23,6 +23,7 @@ const ALL_TOOLS = [
   { name: 'get_recent_anomalies', description: 'p', inputSchema: { type: 'object' } },
   { name: 'get_loan_status', description: 'q', inputSchema: { type: 'object' } },
   { name: 'compare_periods', description: 'f', inputSchema: { type: 'object' } },
+  { name: 'get_market_context', description: 'r', inputSchema: { type: 'object' } },
   { name: 'get_transactions', description: 'ROW-LEVEL', inputSchema: { type: 'object' } },
   { name: 'search_transactions', description: 'ROW-LEVEL', inputSchema: { type: 'object' } },
 ];

--- a/apps/api/src/advisor/mcp-client.service.ts
+++ b/apps/api/src/advisor/mcp-client.service.ts
@@ -29,6 +29,7 @@ export const AGGREGATE_TOOL_ALLOWLIST = new Set([
   'get_recent_anomalies',
   'get_loan_status',
   'compare_periods',
+  'get_market_context', // public EIA/FRED data, no user PII — safe for the cloud advisor
 ]);
 
 /** Anthropic tool definition shape (name + description + JSON schema). */

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -24,6 +24,7 @@ import { BillsModule } from './bills/bills.module';
 import { LoansModule } from './loans/loans.module';
 import { InvestmentsModule } from './investments/investments.module';
 import { AdvisorModule } from './advisor/advisor.module';
+import { MarketDataModule } from './market-data/market-data.module';
 
 @Module({
   imports: [
@@ -69,6 +70,7 @@ import { AdvisorModule } from './advisor/advisor.module';
     LoansModule,
     InvestmentsModule,
     AdvisorModule,
+    MarketDataModule,
     HealthModule,
   ],
   providers: [

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -5,6 +5,7 @@ import {
   text,
   integer,
   real,
+  numeric,
   boolean,
   timestamp,
   jsonb,
@@ -887,4 +888,34 @@ export const pushSubscriptionsRelations = relations(
       references: [users.id],
     }),
   }),
+);
+
+// ── Market Data (11.6) ──────────────────────────────────────
+// Append-only time series from public sources (EIA, FRED). Global, not user-scoped —
+// no userId. `source` records provenance; `fetchedAt` lets consumers show data-age and
+// callers detect stale-but-served values during an upstream outage (never break on a
+// failed fetch — serve the last stored value instead).
+
+export const marketMetrics = pgTable(
+  'market_metrics',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    metricKey: varchar('metric_key', { length: 64 }).notNull(),
+    region: varchar('region', { length: 16 }),
+    periodDate: date('period_date').notNull(),
+    value: numeric('value', { precision: 14, scale: 4 }).notNull(),
+    unit: varchar('unit', { length: 32 }).notNull(),
+    source: varchar('source', { length: 16 }).notNull(),
+    fetchedAt: timestamp('fetched_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('uq_market_metrics_key_region_period').on(
+      table.metricKey,
+      table.region,
+      table.periodDate,
+    ),
+    index('idx_market_metrics_key_period').on(table.metricKey, table.periodDate),
+  ],
 );

--- a/apps/api/src/jobs/alert-cron.processor.ts
+++ b/apps/api/src/jobs/alert-cron.processor.ts
@@ -11,6 +11,13 @@ import { WatchdogDetectorService } from '../analytics/watchdog-detector.service'
 import { AdvisorDigestService } from '../advisor/digest/advisor-digest.service';
 import { BillsService } from '../bills/bills.service';
 import { LoansService } from '../loans/loans.service';
+import { MarketDataService } from '../market-data/market-data.service';
+
+const MARKET_DATA_JITTER_MAX_MS = 15 * 60_000; // spread load on the free EIA/FRED tiers
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 @Processor('alerts')
 export class AlertCronProcessor extends WorkerHost {
@@ -27,6 +34,7 @@ export class AlertCronProcessor extends WorkerHost {
     private readonly advisorDigestService: AdvisorDigestService,
     private readonly billsService: BillsService,
     private readonly loansService: LoansService,
+    private readonly marketDataService: MarketDataService,
   ) {
     super();
   }
@@ -92,6 +100,21 @@ export class AlertCronProcessor extends WorkerHost {
           await this.loansService.checkMissedLoanPayments();
         this.logger.log(
           `Loan missed-check: ${checked} loans, ${missed} missed, ${notified} notified`,
+        );
+        break;
+      }
+
+      case 'market-data-refresh': {
+        // Jitter so this repeatable job doesn't hit EIA/FRED's free-tier rate limits
+        // at the exact same second every day. Skipped in tests — a unit test that calls
+        // process() directly must never wait on a real timer (up to 15 real minutes).
+        if (process.env.NODE_ENV !== 'test') {
+          await sleep(Math.floor(Math.random() * MARKET_DATA_JITTER_MAX_MS));
+        }
+        const result = await this.marketDataService.refreshAll();
+        this.logger.log(
+          `Market data refresh: ${result.refreshed.length} refreshed, ` +
+            `${result.skipped.length} skipped, ${result.failed.length} failed`,
         );
         break;
       }

--- a/apps/api/src/jobs/jobs.module.ts
+++ b/apps/api/src/jobs/jobs.module.ts
@@ -10,6 +10,7 @@ import { AnalyticsModule } from '../analytics/analytics.module';
 import { AdvisorModule } from '../advisor/advisor.module';
 import { BillsModule } from '../bills/bills.module';
 import { LoansModule } from '../loans/loans.module';
+import { MarketDataModule } from '../market-data/market-data.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { LoansModule } from '../loans/loans.module';
     AdvisorModule,
     BillsModule,
     LoansModule,
+    MarketDataModule,
   ],
   providers: [AlertCronProcessor, ReminderProcessor, SyncDeliveryProcessor],
 })
@@ -132,6 +134,15 @@ export class JobsModule implements OnModuleInit {
         'daily-loan-missed-check',
         { pattern: '30 5 * * *' },
         { name: 'loan-missed-check' },
+      ),
+
+      // Market data refresh (11.6) — daily 9 AM UTC; the processor adds random jitter
+      // (up to 15min) before calling out, and MarketDataService itself skips any series
+      // whose cadence means it isn't due yet (a weekly EIA series isn't refetched daily).
+      this.alertsQueue.upsertJobScheduler(
+        'daily-market-data-refresh',
+        { pattern: '0 9 * * *' },
+        { name: 'market-data-refresh' },
       ),
 
       // Frequent sync delivery sweep for outbox events.

--- a/apps/api/src/market-data/__tests__/eia.client.spec.ts
+++ b/apps/api/src/market-data/__tests__/eia.client.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EiaClient } from '../eia.client';
+
+function makeConfig(apiKey?: string) {
+  return { get: (key: string) => (key === 'EIA_API_KEY' ? apiKey : undefined) } as any;
+}
+
+// Recorded-shape fixture of EIA v2's /data response envelope (not a live call).
+const EIA_FIXTURE = {
+  response: {
+    data: [
+      { period: '2026-07-14', value: '3.412' },
+      { period: '2026-07-07', value: '3.398' },
+    ],
+  },
+};
+
+describe('EiaClient', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('no-fire: skips the call entirely with no EIA_API_KEY configured', async () => {
+    const client = new EiaClient(makeConfig(undefined));
+    const points = await client.fetchGasPrice('SCA');
+    expect(points).toEqual([]);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('parses a fixture response into typed points, newest first', async () => {
+    fetchSpy.mockResolvedValueOnce({ ok: true, json: async () => EIA_FIXTURE });
+    const client = new EiaClient(makeConfig('test-key'));
+
+    const points = await client.fetchGasPrice('SCA');
+
+    expect(points).toEqual([
+      { period: '2026-07-14', value: 3.412 },
+      { period: '2026-07-07', value: 3.398 },
+    ]);
+    const url = fetchSpy.mock.calls[0][0] as string;
+    expect(url).toContain('petroleum/pri/gnd/data');
+    expect(url).toContain('facets%5Bduoarea%5D%5B%5D=SCA');
+    expect(url).toContain('api_key=test-key');
+  });
+
+  it('electricity route uses stateid/sectorid facets, not duoarea', async () => {
+    fetchSpy.mockResolvedValueOnce({ ok: true, json: async () => EIA_FIXTURE });
+    const client = new EiaClient(makeConfig('test-key'));
+
+    await client.fetchElectricityPrice('CA');
+
+    const url = fetchSpy.mock.calls[0][0] as string;
+    expect(url).toContain('electricity/retail-sales/data');
+    expect(url).toContain('facets%5Bstateid%5D%5B%5D=CA');
+    expect(url).toContain('facets%5Bsectorid%5D%5B%5D=RES');
+  });
+
+  it('no-fire: an HTTP error never throws — returns empty and logs', async () => {
+    fetchSpy.mockResolvedValueOnce({ ok: false, status: 503, text: async () => 'unavailable' });
+    const client = new EiaClient(makeConfig('test-key'));
+
+    const points = await client.fetchGasPrice('SCA');
+    expect(points).toEqual([]);
+  });
+
+  it('no-fire: a network exception never throws — returns empty', async () => {
+    fetchSpy.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    const client = new EiaClient(makeConfig('test-key'));
+
+    const points = await client.fetchGasPrice('SCA');
+    expect(points).toEqual([]);
+  });
+
+  it('drops non-numeric values instead of producing NaN points', async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ response: { data: [{ period: '2026-07-14', value: 'NA' }] } }),
+    });
+    const client = new EiaClient(makeConfig('test-key'));
+
+    const points = await client.fetchGasPrice('SCA');
+    expect(points).toEqual([]);
+  });
+});

--- a/apps/api/src/market-data/__tests__/fred.client.spec.ts
+++ b/apps/api/src/market-data/__tests__/fred.client.spec.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { FredClient } from '../fred.client';
+
+function makeConfig(apiKey?: string) {
+  return { get: (key: string) => (key === 'FRED_API_KEY' ? apiKey : undefined) } as any;
+}
+
+// Recorded-shape fixture of FRED's series/observations response (not a live call).
+const FRED_FIXTURE = {
+  observations: [
+    { date: '2026-07-17', value: '6.81' },
+    { date: '2026-07-10', value: '.' }, // FRED's "missing observation" marker
+    { date: '2026-07-03', value: '6.79' },
+  ],
+};
+
+describe('FredClient', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('no-fire: skips the call entirely with no FRED_API_KEY configured', async () => {
+    const client = new FredClient(makeConfig(undefined));
+    const points = await client.fetchSeries('MORTGAGE30US');
+    expect(points).toEqual([]);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('parses observations and drops the "." missing-value marker', async () => {
+    fetchSpy.mockResolvedValueOnce({ ok: true, json: async () => FRED_FIXTURE });
+    const client = new FredClient(makeConfig('test-key'));
+
+    const points = await client.fetchSeries('MORTGAGE30US');
+
+    expect(points).toEqual([
+      { date: '2026-07-17', value: 6.81 },
+      { date: '2026-07-03', value: 6.79 },
+    ]);
+    const url = fetchSpy.mock.calls[0][0] as string;
+    expect(url).toContain('series_id=MORTGAGE30US');
+    expect(url).toContain('api_key=test-key');
+  });
+
+  it('no-fire: an HTTP error never throws — returns empty and logs', async () => {
+    fetchSpy.mockResolvedValueOnce({ ok: false, status: 429, text: async () => 'rate limited' });
+    const client = new FredClient(makeConfig('test-key'));
+
+    const points = await client.fetchSeries('CPIAUCSL');
+    expect(points).toEqual([]);
+  });
+
+  it('no-fire: a network exception never throws — returns empty', async () => {
+    fetchSpy.mockRejectedValueOnce(new Error('timeout'));
+    const client = new FredClient(makeConfig('test-key'));
+
+    const points = await client.fetchSeries('FEDFUNDS');
+    expect(points).toEqual([]);
+  });
+});

--- a/apps/api/src/market-data/__tests__/market-data.service.spec.ts
+++ b/apps/api/src/market-data/__tests__/market-data.service.spec.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi } from 'vitest';
+import { MarketDataService } from '../market-data.service';
+
+function makeConfig(overrides: Record<string, string> = {}) {
+  return { get: (key: string) => overrides[key] } as any;
+}
+
+/** A drizzle-chain mock: select().from().where().orderBy().limit() resolves `rows`,
+ *  and insert().values().onConflictDoUpdate() records the call in `upserts`. */
+function makeDb(rows: any[] = []) {
+  const upserts: Array<{ values: any; target: any; set: any }> = [];
+  const db = {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          orderBy: vi.fn(() => ({
+            limit: vi.fn().mockResolvedValue(rows),
+          })),
+        })),
+      })),
+    })),
+    insert: vi.fn(() => ({
+      values: (values: any) => ({
+        onConflictDoUpdate: (opts: { target: any; set: any }) => {
+          upserts.push({ values, target: opts.target, set: opts.set });
+          return Promise.resolve();
+        },
+      }),
+    })),
+  };
+  return { db, upserts };
+}
+
+function makeEia(overrides: Partial<Record<string, any>> = {}) {
+  return {
+    fetchGasPrice: vi.fn().mockResolvedValue(overrides.gas ?? []),
+    fetchElectricityPrice: vi.fn().mockResolvedValue(overrides.electricity ?? []),
+  } as any;
+}
+
+function makeFred(points: any[] = []) {
+  return { fetchSeries: vi.fn().mockResolvedValue(points) } as any;
+}
+
+describe('MarketDataService.refreshAll', () => {
+  it('no-fire: never-fetched series are due and get refreshed', async () => {
+    const { db, upserts } = makeDb([]); // isDue's select returns [] -> never fetched -> due
+    const eia = makeEia({ gas: [{ period: '2026-07-14', value: 3.4 }] });
+    const fred = makeFred([{ date: '2026-07-14', value: 6.8 }]);
+    const svc = new MarketDataService(db, makeConfig(), eia, fred);
+
+    const result = await svc.refreshAll();
+
+    expect(result.failed).toEqual([]);
+    expect(result.refreshed).toContain('gas_retail_regular');
+    expect(result.refreshed).toContain('mortgage_30y');
+    expect(upserts.length).toBeGreaterThan(0);
+  });
+
+  it('national-scope series upsert against the "US" sentinel, never NULL region', async () => {
+    // A NULL region would make onConflictDoUpdate silently stop matching existing
+    // rows in Postgres (NULL != NULL in a unique index) -> duplicate-insert every
+    // refresh instead of updating. Assert the sentinel, not NULL, is always used.
+    const { db, upserts } = makeDb([]);
+    const eia = makeEia();
+    const fred = makeFred([{ date: '2026-07-14', value: 6.8 }]);
+    const svc = new MarketDataService(db, makeConfig(), eia, fred);
+
+    await svc.refreshAll();
+
+    const fredUpserts = upserts.filter((u) => u.values.source === 'fred');
+    expect(fredUpserts.length).toBeGreaterThan(0);
+    for (const u of fredUpserts) {
+      expect(u.values.region).toBe('US');
+      expect(u.values.region).not.toBeNull();
+    }
+  });
+
+  it('skips a series with no points returned (no key / outage) without failing', async () => {
+    const { db } = makeDb([]);
+    const eia = makeEia(); // fetchGasPrice/fetchElectricityPrice default to []
+    const fred = makeFred([]); // no key configured -> []
+    const svc = new MarketDataService(db, makeConfig(), eia, fred);
+
+    const result = await svc.refreshAll();
+
+    expect(result.failed).toEqual([]);
+    expect(result.refreshed).toEqual([]);
+    expect(result.skipped.length).toBeGreaterThan(0);
+  });
+
+  it('isolates one series failure — the rest still refresh', async () => {
+    const { db } = makeDb([]);
+    const eia = {
+      fetchGasPrice: vi.fn().mockRejectedValue(new Error('boom')),
+      fetchElectricityPrice: vi.fn().mockResolvedValue([{ period: '2026-07-01', value: 12 }]),
+    } as any;
+    const fred = makeFred([{ date: '2026-07-14', value: 6.8 }]);
+    const svc = new MarketDataService(db, makeConfig(), eia, fred);
+
+    const result = await svc.refreshAll();
+
+    expect(result.failed).toContain('gas_retail_regular');
+    expect(result.refreshed).toContain('electricity_residential');
+    expect(result.refreshed).toContain('mortgage_30y');
+  });
+
+  it('no-fire: a weekly series fetched 2 days ago is skipped, not refetched', async () => {
+    const twoDaysAgo = new Date(Date.now() - 2 * 24 * 3600_000).toISOString();
+    const { db } = makeDb([{ fetchedAt: twoDaysAgo }]); // isDue sees a recent fetch
+    const eia = makeEia({ gas: [{ period: '2026-07-14', value: 3.4 }] });
+    const fred = makeFred([{ date: '2026-07-14', value: 6.8 }]);
+    const svc = new MarketDataService(db, makeConfig(), eia, fred);
+
+    const result = await svc.refreshAll();
+
+    // Every series in MARKET_SERIES has cadence weekly or monthly, all "due" checks
+    // read the same mocked recent-fetch row, so nothing should be refreshed.
+    expect(result.refreshed).toEqual([]);
+    expect(eia.fetchGasPrice).not.toHaveBeenCalled();
+  });
+});
+
+describe('MarketDataService.getLatestWithDeltas', () => {
+  it('computes 4-week and 12-month deltas from history', async () => {
+    const now = new Date('2026-07-14');
+    const rows = [
+      { periodDate: '2026-07-14', value: '3.50', unit: 'usd_per_gallon', fetchedAt: now.toISOString() },
+      { periodDate: '2026-06-09', value: '3.30', unit: 'usd_per_gallon', fetchedAt: now.toISOString() }, // ~5wk back
+      { periodDate: '2025-07-01', value: '3.10', unit: 'usd_per_gallon', fetchedAt: now.toISOString() }, // ~54wk back
+    ];
+    const { db } = makeDb(rows);
+    const svc = new MarketDataService(db, makeConfig(), makeEia(), makeFred());
+
+    const result = await svc.getLatestWithDeltas('gas_retail_regular', 'SCA');
+
+    expect(result.latestValue).toBe(3.5);
+    expect(result.delta4Week).toBeCloseTo(0.2, 5); // 3.50 - 3.30
+    expect(result.delta12Month).toBeCloseTo(0.4, 5); // 3.50 - 3.10
+  });
+
+  it('no-fire: no history returns nulls, not a throw', async () => {
+    const { db } = makeDb([]);
+    const svc = new MarketDataService(db, makeConfig(), makeEia(), makeFred());
+
+    const result = await svc.getLatestWithDeltas('gas_retail_regular', 'SCA');
+
+    expect(result.latestValue).toBeNull();
+    expect(result.delta4Week).toBeNull();
+    expect(result.delta12Month).toBeNull();
+  });
+});

--- a/apps/api/src/market-data/eia.client.ts
+++ b/apps/api/src/market-data/eia.client.ts
@@ -1,0 +1,97 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+/** One data point as returned by EIA's v2 `/data` route. */
+export interface EiaPoint {
+  period: string; // e.g. "2026-07-14" (weekly) or "2026-06" (monthly)
+  value: number;
+}
+
+const EIA_BASE_URL = 'https://api.eia.gov/v2';
+
+/**
+ * Client for EIA's v2 open-data API (https://www.eia.gov/opendata/).
+ *
+ * Route/facet shapes are verified against EIA's own v2 documentation (the
+ * `duoarea`/`product` facets on `petroleum/pri/gnd`, and `stateid`/`sectorid` on
+ * `electricity/retail-sales`) but the exact `duoarea` state code (conventionally
+ * `S` + 2-letter postal code, e.g. `SCA` for California) could not be live-verified
+ * without an API key — confirm it at https://www.eia.gov/opendata/browser/ once you
+ * have one, and correct `MARKET_GAS_STATE` in `.env` if needed. No live calls happen
+ * without `EIA_API_KEY` set — see `fetchGasPrice`/`fetchElectricityPrice`.
+ */
+@Injectable()
+export class EiaClient {
+  private readonly logger = new Logger(EiaClient.name);
+  private readonly apiKey: string | undefined;
+  private readonly timeoutMs = 15_000;
+
+  constructor(private readonly config: ConfigService) {
+    this.apiKey = this.config.get<string>('EIA_API_KEY') || undefined;
+  }
+
+  get isConfigured(): boolean {
+    return Boolean(this.apiKey);
+  }
+
+  /** Weekly regular-gasoline retail price ($/gal) for a state (EIA `duoarea` code). */
+  async fetchGasPrice(duoarea: string): Promise<EiaPoint[]> {
+    return this.fetchSeries('petroleum/pri/gnd', {
+      'facets[duoarea][]': duoarea,
+      'facets[product][]': 'EPMR',
+      frequency: 'weekly',
+    });
+  }
+
+  /** Monthly residential electricity price (¢/kWh) for a state (2-letter postal code). */
+  async fetchElectricityPrice(stateId: string): Promise<EiaPoint[]> {
+    return this.fetchSeries('electricity/retail-sales', {
+      'facets[stateid][]': stateId,
+      'facets[sectorid][]': 'RES',
+      frequency: 'monthly',
+    });
+  }
+
+  /**
+   * Never throws — an outage or bad key must never break a caller (the spec's
+   * "on API failure log + serve last stored values" rule). Empty array on any failure.
+   */
+  private async fetchSeries(
+    route: string,
+    facets: Record<string, string>,
+  ): Promise<EiaPoint[]> {
+    if (!this.apiKey) {
+      this.logger.warn(`EIA_API_KEY not set — skipping ${route}`);
+      return [];
+    }
+    const url = new URL(`${EIA_BASE_URL}/${route}/data/`);
+    url.searchParams.set('api_key', this.apiKey);
+    url.searchParams.set('data[0]', 'value');
+    url.searchParams.set('sort[0][column]', 'period');
+    url.searchParams.set('sort[0][direction]', 'desc');
+    url.searchParams.set('length', '52'); // ~1yr weekly / ~4yr monthly, plenty for deltas
+    for (const [k, v] of Object.entries(facets)) url.searchParams.set(k, v);
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const res = await fetch(url.toString(), { signal: controller.signal });
+      if (!res.ok) {
+        this.logger.error(`EIA ${route} returned ${res.status}: ${await res.text()}`);
+        return [];
+      }
+      const body = (await res.json()) as {
+        response?: { data?: Array<{ period: string; value: number | string }> };
+      };
+      const rows = body.response?.data ?? [];
+      return rows
+        .map((r) => ({ period: r.period, value: Number(r.value) }))
+        .filter((p) => Number.isFinite(p.value));
+    } catch (err: any) {
+      this.logger.error(`EIA ${route} fetch failed: ${err.message}`);
+      return [];
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/apps/api/src/market-data/fred.client.ts
+++ b/apps/api/src/market-data/fred.client.ts
@@ -1,0 +1,72 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+/** One observation as returned by FRED's `series/observations` endpoint. */
+export interface FredPoint {
+  date: string; // "YYYY-MM-DD"
+  value: number;
+}
+
+const FRED_BASE_URL = 'https://api.stlouisfed.org/fred/series/observations';
+
+/**
+ * Client for the St. Louis Fed's FRED API (https://fred.stlouisfed.org/docs/api/fred/).
+ * Stable, well-documented, free-registration endpoint — series IDs used here
+ * (MORTGAGE30US, CPIAUCSL, FEDFUNDS) are long-lived FRED identifiers.
+ */
+@Injectable()
+export class FredClient {
+  private readonly logger = new Logger(FredClient.name);
+  private readonly apiKey: string | undefined;
+  private readonly timeoutMs = 15_000;
+
+  constructor(private readonly config: ConfigService) {
+    this.apiKey = this.config.get<string>('FRED_API_KEY') || undefined;
+  }
+
+  get isConfigured(): boolean {
+    return Boolean(this.apiKey);
+  }
+
+  /**
+   * Fetch the most recent observations for a series. Never throws — an outage or
+   * bad key must never break a caller; returns an empty array on any failure so the
+   * service falls back to the last stored value.
+   */
+  async fetchSeries(seriesId: string, limit = 52): Promise<FredPoint[]> {
+    if (!this.apiKey) {
+      this.logger.warn(`FRED_API_KEY not set — skipping ${seriesId}`);
+      return [];
+    }
+    const url = new URL(FRED_BASE_URL);
+    url.searchParams.set('series_id', seriesId);
+    url.searchParams.set('api_key', this.apiKey);
+    url.searchParams.set('file_type', 'json');
+    url.searchParams.set('sort_order', 'desc');
+    url.searchParams.set('limit', String(limit));
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const res = await fetch(url.toString(), { signal: controller.signal });
+      if (!res.ok) {
+        this.logger.error(`FRED ${seriesId} returned ${res.status}: ${await res.text()}`);
+        return [];
+      }
+      const body = (await res.json()) as {
+        observations?: Array<{ date: string; value: string }>;
+      };
+      const rows = body.observations ?? [];
+      // FRED uses "." for a missing observation at that date — skip those.
+      return rows
+        .filter((r) => r.value !== '.')
+        .map((r) => ({ date: r.date, value: Number(r.value) }))
+        .filter((p) => Number.isFinite(p.value));
+    } catch (err: any) {
+      this.logger.error(`FRED ${seriesId} fetch failed: ${err.message}`);
+      return [];
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/apps/api/src/market-data/market-data.controller.ts
+++ b/apps/api/src/market-data/market-data.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { MarketDataService } from './market-data.service';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+
+/** Thin read-only controller — global public market data, any authenticated user. */
+@ApiTags('Market Data')
+@Controller('market-data')
+@UseGuards(JwtAuthGuard)
+export class MarketDataController {
+  constructor(private readonly marketData: MarketDataService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Latest value + 4-week/12-month deltas for every tracked series' })
+  async getAll() {
+    return this.marketData.getAllLatest();
+  }
+
+  @Get('series')
+  @ApiOperation({ summary: 'Latest value + deltas for one series (optional region override)' })
+  async getSeries(@Query('metricKey') metricKey: string, @Query('region') region?: string) {
+    return this.marketData.getLatestWithDeltas(metricKey, region);
+  }
+}

--- a/apps/api/src/market-data/market-data.module.ts
+++ b/apps/api/src/market-data/market-data.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { MarketDataService } from './market-data.service';
+import { MarketDataController } from './market-data.controller';
+import { EiaClient } from './eia.client';
+import { FredClient } from './fred.client';
+
+@Module({
+  controllers: [MarketDataController],
+  providers: [MarketDataService, EiaClient, FredClient],
+  exports: [MarketDataService],
+})
+export class MarketDataModule {}

--- a/apps/api/src/market-data/market-data.service.ts
+++ b/apps/api/src/market-data/market-data.service.ts
@@ -1,0 +1,201 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { DATABASE_CONNECTION } from '../db/db.module';
+import { marketMetrics } from '../db/schema';
+import { and, eq, desc } from 'drizzle-orm';
+import { ConfigService } from '@nestjs/config';
+import { MARKET_SERIES, DEFAULT_HYSA_FRED_SERIES, type MarketSeriesDef } from '@moneypulse/shared';
+import { EiaClient } from './eia.client';
+import { FredClient } from './fred.client';
+
+/** National-scope sentinel — never write NULL into `region`. Postgres unique
+ * indexes treat NULL as distinct-from-everything, so onConflictDoUpdate would
+ * silently stop matching existing rows and duplicate-insert on every refresh. */
+const NATIONAL_REGION = 'US';
+
+export interface MetricWithDeltas {
+  metricKey: string;
+  region: string;
+  unit: string;
+  latestValue: number | null;
+  latestDate: string | null;
+  fetchedAt: string | null;
+  delta4Week: number | null;
+  delta12Month: number | null;
+}
+
+@Injectable()
+export class MarketDataService {
+  private readonly logger = new Logger(MarketDataService.name);
+  private readonly gasState: string;
+  private readonly electricityState: string;
+  private readonly hysaFredSeries: string;
+
+  constructor(
+    @Inject(DATABASE_CONNECTION) private readonly db: any,
+    private readonly config: ConfigService,
+    private readonly eia: EiaClient,
+    private readonly fred: FredClient,
+  ) {
+    // EIA `duoarea` code convention is `S` + 2-letter postal code (e.g. SCA); verify
+    // against https://www.eia.gov/opendata/browser/ once a real key is available.
+    this.gasState = this.config.get<string>('MARKET_GAS_STATE') || 'SCA';
+    this.electricityState = this.gasState.replace(/^S/, '');
+    this.hysaFredSeries =
+      this.config.get<string>('MARKET_HYSA_FRED_SERIES') || DEFAULT_HYSA_FRED_SERIES;
+  }
+
+  /**
+   * Refresh every configured series, respecting per-series cadence (a weekly series
+   * already fetched this week is skipped — spec: "not refetched daily"). An outage on
+   * one series must never block the others or throw — each series is isolated.
+   */
+  async refreshAll(): Promise<{ refreshed: string[]; skipped: string[]; failed: string[] }> {
+    const refreshed: string[] = [];
+    const skipped: string[] = [];
+    const failed: string[] = [];
+
+    for (const series of MARKET_SERIES) {
+      const region = this.regionFor(series);
+      try {
+        if (!(await this.isDue(series, region))) {
+          skipped.push(series.metricKey);
+          continue;
+        }
+        const wrote = await this.refreshOne(series, region);
+        if (wrote) refreshed.push(series.metricKey);
+        else skipped.push(series.metricKey); // client returned no points (no key / outage)
+      } catch (err: any) {
+        // Never let one series' failure break the sweep — log and move on.
+        this.logger.error(`refresh failed for ${series.metricKey}: ${err.message}`);
+        failed.push(series.metricKey);
+      }
+    }
+    return { refreshed, skipped, failed };
+  }
+
+  private regionFor(series: MarketSeriesDef): string {
+    if (series.metricKey === 'gas_retail_regular') return this.gasState;
+    if (series.metricKey === 'electricity_residential') return this.electricityState;
+    return NATIONAL_REGION;
+  }
+
+  private async isDue(series: MarketSeriesDef, region: string): Promise<boolean> {
+    const last = await this.db
+      .select({ fetchedAt: marketMetrics.fetchedAt })
+      .from(marketMetrics)
+      .where(and(eq(marketMetrics.metricKey, series.metricKey), eq(marketMetrics.region, region)))
+      .orderBy(desc(marketMetrics.fetchedAt))
+      .limit(1);
+    if (last.length === 0) return true; // never fetched — always due
+    const ageMs = Date.now() - new Date(last[0].fetchedAt).getTime();
+    const minGapMs =
+      series.cadence === 'weekly'
+        ? 6 * 24 * 3600_000
+        : series.cadence === 'monthly'
+          ? 27 * 24 * 3600_000
+          : 0; // daily: always due
+    return ageMs >= minGapMs;
+  }
+
+  private async refreshOne(series: MarketSeriesDef, region: string): Promise<boolean> {
+    const points =
+      series.source === 'eia'
+        ? await this.fetchEia(series, region)
+        : await this.fred.fetchSeries(this.fredSeriesId(series), 52);
+    if (points.length === 0) return false;
+
+    const rows = points.map((p) => ({
+      metricKey: series.metricKey,
+      region,
+      periodDate: 'period' in p ? p.period : (p as { date: string }).date,
+      value: String(p.value),
+      unit: series.unit,
+      source: series.source,
+      fetchedAt: new Date(),
+    }));
+
+    for (const row of rows) {
+      await this.db
+        .insert(marketMetrics)
+        .values(row)
+        .onConflictDoUpdate({
+          target: [marketMetrics.metricKey, marketMetrics.region, marketMetrics.periodDate],
+          set: { value: row.value, unit: row.unit, source: row.source, fetchedAt: row.fetchedAt },
+        });
+    }
+    return true;
+  }
+
+  private async fetchEia(series: MarketSeriesDef, region: string) {
+    if (series.metricKey === 'gas_retail_regular') return this.eia.fetchGasPrice(region);
+    if (series.metricKey === 'electricity_residential')
+      return this.eia.fetchElectricityPrice(region);
+    return [];
+  }
+
+  private fredSeriesId(series: MarketSeriesDef): string {
+    if (series.metricKey === 'mortgage_30y') return 'MORTGAGE30US';
+    if (series.metricKey === 'cpi_all_urban') return 'CPIAUCSL';
+    if (series.metricKey === 'fed_funds_rate') return 'FEDFUNDS';
+    return this.hysaFredSeries;
+  }
+
+  /**
+   * Latest value plus 4-week and 12-month deltas for one series — the shape both the
+   * read-only controller and the `get_market_context` MCP tool need.
+   */
+  async getLatestWithDeltas(metricKey: string, region?: string): Promise<MetricWithDeltas> {
+    const resolvedRegion = region ?? this.defaultRegionFor(metricKey);
+    const history = await this.db
+      .select()
+      .from(marketMetrics)
+      .where(and(eq(marketMetrics.metricKey, metricKey), eq(marketMetrics.region, resolvedRegion)))
+      .orderBy(desc(marketMetrics.periodDate))
+      .limit(60); // ~14 months of weekly data — enough for a 12-month lookback
+
+    if (history.length === 0) {
+      return {
+        metricKey,
+        region: resolvedRegion,
+        unit: '',
+        latestValue: null,
+        latestDate: null,
+        fetchedAt: null,
+        delta4Week: null,
+        delta12Month: null,
+      };
+    }
+
+    const latest = history[0];
+    const latestValue = Number(latest.value);
+    const latestDate = new Date(latest.periodDate);
+
+    const find4WeekAgo = history.find(
+      (r: any) => latestDate.getTime() - new Date(r.periodDate).getTime() >= 26 * 24 * 3600_000,
+    );
+    const find12MonthAgo = history.find(
+      (r: any) => latestDate.getTime() - new Date(r.periodDate).getTime() >= 350 * 24 * 3600_000,
+    );
+
+    return {
+      metricKey,
+      region: resolvedRegion,
+      unit: latest.unit,
+      latestValue,
+      latestDate: latest.periodDate,
+      fetchedAt: latest.fetchedAt,
+      delta4Week: find4WeekAgo ? latestValue - Number(find4WeekAgo.value) : null,
+      delta12Month: find12MonthAgo ? latestValue - Number(find12MonthAgo.value) : null,
+    };
+  }
+
+  private defaultRegionFor(metricKey: string): string {
+    if (metricKey === 'gas_retail_regular') return this.gasState;
+    if (metricKey === 'electricity_residential') return this.electricityState;
+    return NATIONAL_REGION;
+  }
+
+  async getAllLatest(): Promise<MetricWithDeltas[]> {
+    return Promise.all(MARKET_SERIES.map((s) => this.getLatestWithDeltas(s.metricKey)));
+  }
+}

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -20,6 +20,7 @@ import { registerGetCategoryTrend } from './tools/get-category-trend.js';
 import { registerGetBudgetHistory } from './tools/get-budget-history.js';
 import { registerGetRecentAnomalies } from './tools/get-recent-anomalies.js';
 import { registerGetLoanStatus } from './tools/get-loan-status.js';
+import { registerGetMarketContext } from './tools/get-market-context.js';
 import { close } from './db.js';
 import http from 'node:http';
 
@@ -47,6 +48,7 @@ registerGetCategoryTrend(server);
 registerGetBudgetHistory(server);
 registerGetRecentAnomalies(server);
 registerGetLoanStatus(server);
+registerGetMarketContext(server);
 
 const mode = process.argv.includes('--sse') ? 'sse' : 'stdio';
 

--- a/apps/mcp-server/src/tools/get-market-context.ts
+++ b/apps/mcp-server/src/tools/get-market-context.ts
@@ -1,0 +1,81 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { query } from '../db.js';
+
+interface MetricRow {
+  metric_key: string;
+  region: string;
+  unit: string;
+  period_date: string;
+  value: string;
+  fetched_at: string;
+}
+
+/** market_metrics is global (not user-scoped) — public EIA/FRED data, safe for the
+ * cloud advisor per the aggregates-only rule (11.6 spec / epic #36). */
+export function registerGetMarketContext(server: McpServer) {
+  server.tool(
+    'get_market_context',
+    'Latest public market data (gas prices, electricity rates, mortgage rate, CPI, fed funds rate) with 4-week and 12-month deltas. Answers "how do rates/prices compare to recent history".',
+    {
+      metricKey: z
+        .string()
+        .optional()
+        .describe(
+          'One of: gas_retail_regular, electricity_residential, mortgage_30y, cpi_all_urban, fed_funds_rate. Omit for all series.',
+        ),
+    },
+    async (params) => {
+      const rows = await query<MetricRow>(
+        `SELECT metric_key, region, unit, period_date::text, value::text, fetched_at::text
+         FROM market_metrics
+         ${params.metricKey ? 'WHERE metric_key = $1' : ''}
+         ORDER BY metric_key, region, period_date DESC`,
+        params.metricKey ? [params.metricKey] : [],
+      );
+
+      if (rows.length === 0) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: 'No market data available yet (EIA/FRED keys may not be configured, or the daily refresh has not run).',
+            },
+          ],
+        };
+      }
+
+      // Group by (metric_key, region); rows are already DESC by period_date within each group.
+      const groups = new Map<string, MetricRow[]>();
+      for (const r of rows) {
+        const k = `${r.metric_key}::${r.region}`;
+        if (!groups.has(k)) groups.set(k, []);
+        groups.get(k)!.push(r);
+      }
+
+      const lines: string[] = [];
+      for (const series of groups.values()) {
+        const latest = series[0];
+        const latestDate = new Date(latest.period_date);
+        const latestValue = Number(latest.value);
+
+        const wk4 = series.find(
+          (r) => latestDate.getTime() - new Date(r.period_date).getTime() >= 26 * 24 * 3600_000,
+        );
+        const mo12 = series.find(
+          (r) => latestDate.getTime() - new Date(r.period_date).getTime() >= 350 * 24 * 3600_000,
+        );
+
+        const fmtDelta = (from?: MetricRow) =>
+          from ? `${(latestValue - Number(from.value)) >= 0 ? '+' : ''}${(latestValue - Number(from.value)).toFixed(2)}` : 'n/a';
+
+        lines.push(
+          `${latest.metric_key} (${latest.region}): ${latestValue} ${latest.unit} as of ${latest.period_date} ` +
+            `[4wk: ${fmtDelta(wk4)}, 12mo: ${fmtDelta(mo12)}] (fetched ${latest.fetched_at})`,
+        );
+      }
+
+      return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
+    },
+  );
+}

--- a/db/migrations/0018_market_metrics.sql
+++ b/db/migrations/0018_market_metrics.sql
@@ -1,0 +1,19 @@
+-- 11.6 Market-data module: public time-series metrics (EIA gas/electricity, FRED rates).
+-- Global, not user-scoped. Append-only; upserts keyed on (metric_key, region, period_date).
+
+CREATE TABLE IF NOT EXISTS "market_metrics" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "metric_key" varchar(64) NOT NULL,
+  "region" varchar(16),
+  "period_date" date NOT NULL,
+  "value" numeric(14, 4) NOT NULL,
+  "unit" varchar(32) NOT NULL,
+  "source" varchar(16) NOT NULL,
+  "fetched_at" timestamp WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_market_metrics_key_region_period"
+  ON "market_metrics" ("metric_key", "region", "period_date");
+
+CREATE INDEX IF NOT EXISTS "idx_market_metrics_key_period"
+  ON "market_metrics" ("metric_key", "period_date");

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1784253300000,
       "tag": "0017_daily_brief",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1784510000000,
+      "tag": "0018_market_metrics",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -314,3 +314,61 @@ export const EXPECTED_FEE_CATEGORY_NAMES: string[] = [
   'Mortgage',
   'Loan Interest',
 ];
+
+// ── Market Data (11.6) ──────────────────────────────────────
+
+/** A single market_metrics series this app tracks, keyed by metric_key. */
+export type MarketSeriesDef = {
+  metricKey: string;
+  source: 'eia' | 'fred';
+  unit: string;
+  /** How often the underlying series actually updates — used to skip a daily
+   *  refresh call for a weekly/monthly series that hasn't rolled over yet. */
+  cadence: 'daily' | 'weekly' | 'monthly';
+  description: string;
+};
+
+export const MARKET_SERIES: MarketSeriesDef[] = [
+  {
+    metricKey: 'gas_retail_regular',
+    source: 'eia',
+    unit: 'usd_per_gallon',
+    cadence: 'weekly',
+    description: 'Regular gasoline retail price ($/gal), state from MARKET_GAS_STATE',
+  },
+  {
+    metricKey: 'electricity_residential',
+    source: 'eia',
+    unit: 'cents_per_kwh',
+    cadence: 'monthly',
+    description: 'Residential electricity price (¢/kWh), state from MARKET_GAS_STATE',
+  },
+  {
+    metricKey: 'mortgage_30y',
+    source: 'fred',
+    unit: 'percent',
+    cadence: 'weekly',
+    description: '30-year fixed mortgage rate (FRED MORTGAGE30US)',
+  },
+  {
+    metricKey: 'cpi_all_urban',
+    source: 'fred',
+    unit: 'index',
+    cadence: 'monthly',
+    description: 'Consumer Price Index, all urban consumers (FRED CPIAUCSL)',
+  },
+  {
+    metricKey: 'fed_funds_rate',
+    source: 'fred',
+    unit: 'percent',
+    cadence: 'monthly',
+    description: 'Effective federal funds rate (FRED FEDFUNDS)',
+  },
+];
+
+/** FRED series ID used as the HYSA-comparable benchmark — env-overridable per the
+ *  spec (`MARKET_HYSA_FRED_SERIES`). No FRED series *is* an actual HYSA APY; FEDFUNDS
+ *  (effective federal funds rate) is the standard public proxy online-savings yields
+ *  track closely, so it's the default. Verify against https://fred.stlouisfed.org
+ *  once you have a key if you want a closer benchmark (e.g. a short T-bill series). */
+export const DEFAULT_HYSA_FRED_SERIES = 'FEDFUNDS';


### PR DESCRIPTION
Closes #104. Phase 11 child 6/10 — public market-data series (gas, electricity, mortgage rate, CPI, fed funds) surfaced to the advisor.

Driven directly (not through the coxd loop) since it needs `EIA_API_KEY`/`FRED_API_KEY` account setup I can't do on the user's behalf — see below.

## What's here
- `apps/api/src/market-data/`: `eia.client.ts` + `fred.client.ts` (never throw — outage/no-key logs + returns `[]`, caller falls back to the last stored value), `market-data.service.ts` (per-series cadence-aware refresh: a weekly series isn't refetched daily), thin read-only controller.
- `market_metrics` table (0018 migration) — append-only, global (not user-scoped).
- Daily BullMQ refresh job (`jobs.module.ts`/`alert-cron.processor.ts`) with in-processor jitter (skipped when `NODE_ENV=test` so a direct `process()` call in a unit test never waits on a real timer).
- `get_market_context` MCP tool, added to the advisor's aggregates-only allowlist (public data, no PII).

## A real bug caught before shipping
Postgres unique indexes treat `NULL` as distinct-from-everything. Writing `NULL` region for national-scope series (mortgage/CPI/fed-funds) would make `onConflictDoUpdate` silently stop matching existing rows → duplicate-insert every refresh instead of updating. Fixed with a `'US'` sentinel instead of `NULL`; covered by a dedicated test (`market-data.service.spec.ts`).

## You'll need to do this part
`EIA_API_KEY` / `FRED_API_KEY` are both free, instant registrations — I can't create accounts on your behalf:
- EIA: https://www.eia.gov/opendata/register.php
- FRED: https://fred.stlouisfed.org/docs/api/api_key.html

Add both to `.env`/NAS `.env` when convenient. The module runs correctly with neither set — it just skips those series (never errors).

**One thing worth verifying once you have a real EIA key**: the `duoarea` state-code convention (`MARKET_GAS_STATE`, default `SCA`) is `S` + postal code per EIA's documented convention, but I couldn't live-test it without a key. Check it resolves at https://www.eia.gov/opendata/browser/petroleum/pri/gnd and adjust the env var if needed — no code change required either way.

FRED series IDs (`MORTGAGE30US`, `CPIAUCSL`, `FEDFUNDS`) are stable/well-known and don't have this caveat.

## Verification
- 66/66 test files, 558/558 tests green (17 new, fixture-based per the spec's "no live calls in CI").
- `nest build` clean, `mcp-server` `tsc` clean.
- Drizzle migration-journal parity checked (self-applied coxd's own gate check).
- Migration is pure-addition + idempotent (`IF NOT EXISTS` throughout, no transaction-hazard DDL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)