### PR TITLE
fix(market-data): EIA electricity route needs data[0]=price, not value

### DIFF
--- a/apps/api/src/market-data/__tests__/eia.client.spec.ts
+++ b/apps/api/src/market-data/__tests__/eia.client.spec.ts
@@ -50,16 +50,35 @@ describe('EiaClient', () => {
     expect(url).toContain('api_key=test-key');
   });
 
-  it('electricity route uses stateid/sectorid facets, not duoarea', async () => {
-    fetchSpy.mockResolvedValueOnce({ ok: true, json: async () => EIA_FIXTURE });
+  it('electricity route uses stateid/sectorid facets and the "price" data field', async () => {
+    // Live-verified 2026-07-20: electricity/retail-sales rejects data[0]=value with a 400
+    // ("The only valid data are 'revenue', 'sales', 'price', and 'customers'") — unlike
+    // petroleum/pri/gnd, which does accept 'value'. Response rows are keyed by whatever
+    // field was requested, so a fixture with a `price` key (not `value`) must parse.
+    const ELECTRICITY_FIXTURE = {
+      response: { data: [{ period: '2026-06', price: '24.31' }] },
+    };
+    fetchSpy.mockResolvedValueOnce({ ok: true, json: async () => ELECTRICITY_FIXTURE });
     const client = new EiaClient(makeConfig('test-key'));
 
-    await client.fetchElectricityPrice('CA');
+    const points = await client.fetchElectricityPrice('CA');
 
     const url = fetchSpy.mock.calls[0][0] as string;
     expect(url).toContain('electricity/retail-sales/data');
     expect(url).toContain('facets%5Bstateid%5D%5B%5D=CA');
     expect(url).toContain('facets%5Bsectorid%5D%5B%5D=RES');
+    expect(url).toContain('data%5B0%5D=price');
+    expect(points).toEqual([{ period: '2026-06', value: 24.31 }]);
+  });
+
+  it('the gas-price route still requests data[0]=value (unaffected by the fix)', async () => {
+    fetchSpy.mockResolvedValueOnce({ ok: true, json: async () => EIA_FIXTURE });
+    const client = new EiaClient(makeConfig('test-key'));
+
+    await client.fetchGasPrice('SCA');
+
+    const url = fetchSpy.mock.calls[0][0] as string;
+    expect(url).toContain('data%5B0%5D=value');
   });
 
   it('no-fire: an HTTP error never throws — returns empty and logs', async () => {

--- a/apps/api/src/market-data/eia.client.ts
+++ b/apps/api/src/market-data/eia.client.ts
@@ -45,11 +45,14 @@ export class EiaClient {
 
   /** Monthly residential electricity price (¢/kWh) for a state (2-letter postal code). */
   async fetchElectricityPrice(stateId: string): Promise<EiaPoint[]> {
-    return this.fetchSeries('electricity/retail-sales', {
-      'facets[stateid][]': stateId,
-      'facets[sectorid][]': 'RES',
-      frequency: 'monthly',
-    });
+    // electricity/retail-sales does NOT accept 'value' as a data field (unlike
+    // petroleum/pri/gnd) — confirmed live: EIA 400s with "The only valid data are
+    // 'revenue', 'sales', 'price', and 'customers'." 'price' is the ¢/kWh series.
+    return this.fetchSeries(
+      'electricity/retail-sales',
+      { 'facets[stateid][]': stateId, 'facets[sectorid][]': 'RES', frequency: 'monthly' },
+      'price',
+    );
   }
 
   /**
@@ -59,6 +62,7 @@ export class EiaClient {
   private async fetchSeries(
     route: string,
     facets: Record<string, string>,
+    dataField: string = 'value',
   ): Promise<EiaPoint[]> {
     if (!this.apiKey) {
       this.logger.warn(`EIA_API_KEY not set — skipping ${route}`);
@@ -66,7 +70,7 @@ export class EiaClient {
     }
     const url = new URL(`${EIA_BASE_URL}/${route}/data/`);
     url.searchParams.set('api_key', this.apiKey);
-    url.searchParams.set('data[0]', 'value');
+    url.searchParams.set('data[0]', dataField);
     url.searchParams.set('sort[0][column]', 'period');
     url.searchParams.set('sort[0][direction]', 'desc');
     url.searchParams.set('length', '52'); // ~1yr weekly / ~4yr monthly, plenty for deltas
@@ -81,11 +85,11 @@ export class EiaClient {
         return [];
       }
       const body = (await res.json()) as {
-        response?: { data?: Array<{ period: string; value: number | string }> };
+        response?: { data?: Array<Record<string, unknown>> };
       };
       const rows = body.response?.data ?? [];
       return rows
-        .map((r) => ({ period: r.period, value: Number(r.value) }))
+        .map((r) => ({ period: r.period as string, value: Number(r[dataField]) }))
         .filter((p) => Number.isFinite(p.value));
     } catch (err: any) {
       this.logger.error(`EIA ${route} fetch failed: ${err.message}`);


### PR DESCRIPTION
Found this live: once the EIA/FRED keys were actually enabled on the NAS and a refresh ran, logs showed 4/5 series populated cleanly (gas, mortgage, CPI, fed funds — all with real, correct values) but `electricity_residential` 400'd:

> "Invalid data 'value' provided. The only valid data are 'revenue', 'sales', 'price', and 'customers'."

`petroleum/pri/gnd` (gas prices) accepts `data[0]=value`; `electricity/retail-sales` doesn't — it needs `price`. My original implementation hardcoded `value` for both routes (documented as a caveat in the original #104 PR — this is exactly the kind of thing that needed a real key to catch).

## Fix
`fetchSeries` now takes a `dataField` parameter (default `'value'`, unchanged for gas) and reads the response row by that same key. `fetchElectricityPrice` passes `'price'`.

## Verification
- 66/66 test files, 559/559 tests (added a regression test with a `price`-keyed fixture, and one confirming the gas route's `data[0]=value` is unaffected).
- `nest build` clean.
- Not yet re-verified against the live API (that requires another refresh cycle) — recommend triggering one manually after merge+deploy to confirm `electricity_residential` populates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)