### PR TITLE
# 11.7 Market-joined insights — refi watcher, idle cash, personal-vs-m

### DIFF
--- a/apps/api/src/analytics/__tests__/market-insight-detector.service.spec.ts
+++ b/apps/api/src/analytics/__tests__/market-insight-detector.service.spec.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi } from 'vitest';
+import { MarketInsightDetectorService } from '../market-insight-detector.service';
+import { standardMonthlyPaymentCents, computeLoanState } from '@moneypulse/shared';
+
+function arrWithChain(data: any[]) {
+  return Object.assign([...data], {
+    orderBy: () => ({ limit: (n: number) => Promise.resolve(data.slice(0, n)) }),
+  });
+}
+
+function buildDb(selectQueue: any[], executeQueue: any[] = []) {
+  const db: any = {
+    select: vi.fn(() => ({
+      from: () => ({ where: () => selectQueue.shift() }),
+    })),
+    execute: vi.fn(),
+  };
+  for (const r of executeQueue) db.execute.mockResolvedValueOnce(r);
+  return db;
+}
+
+function buildNotifications(existingKeys: string[] = []) {
+  return {
+    findByMetadata: vi.fn(async (_u: string, key: string) => existingKeys.includes(key)),
+    createAndDispatch: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function callsOfType(notif: any, type: string) {
+  return notif.createAndDispatch.mock.calls.filter((c: any[]) => c[0].type === type);
+}
+
+describe('MarketInsightDetectorService', () => {
+  describe('refi_opportunity', () => {
+    it('fires and matches an independent amortization calc within $1/mo', async () => {
+      const loan = {
+        id: 'loan-1',
+        userId: 'user-1',
+        name: 'Home Mortgage',
+        loanType: 'mortgage',
+        originalBalanceCents: 40_000_000, // $400,000
+        aprBps: 700, // 7.00%
+        termMonths: 360,
+        startDate: '2020-01-01',
+        scheduledPaymentCents: 266_120, // ~$2,661.20 P+I at 7% / 360mo
+      };
+      const db = buildDb([[loan]]);
+      const notif = buildNotifications();
+      const freshness = { getAccountFreshness: vi.fn() };
+      const marketData = {
+        getLatestWithDeltas: vi.fn().mockResolvedValue({ latestValue: 6.0, delta4Week: null }),
+      };
+      const svc = new MarketInsightDetectorService(db, notif as any, freshness as any, marketData as any);
+
+      await svc.checkRefiOpportunities('user-1');
+
+      expect(callsOfType(notif, 'refi_opportunity')).toHaveLength(1);
+      const metadata = notif.createAndDispatch.mock.calls[0][0].metadata;
+
+      // Independent calc: replay the loan to "now" for balance/months elapsed, then the
+      // standard fixed-payment formula at the market rate over the same remaining term.
+      const state = computeLoanState(
+        {
+          originalBalanceCents: loan.originalBalanceCents,
+          aprBps: loan.aprBps,
+          scheduledPaymentCents: loan.scheduledPaymentCents,
+          startDate: loan.startDate,
+        },
+        [],
+      );
+      const remainingTermMonths = loan.termMonths - state.monthsElapsed;
+      const expectedMarketPayment = standardMonthlyPaymentCents(
+        state.currentBalanceCents,
+        600,
+        remainingTermMonths,
+      );
+      const expectedSavings = loan.scheduledPaymentCents - expectedMarketPayment;
+
+      expect(Math.abs(metadata.estimatedMonthlySavingsCents - expectedSavings)).toBeLessThanOrEqual(100);
+    });
+
+    it('does NOT fire when the spread is below threshold', async () => {
+      const loan = {
+        id: 'loan-1',
+        userId: 'user-1',
+        name: 'Home Mortgage',
+        loanType: 'mortgage',
+        originalBalanceCents: 40_000_000,
+        aprBps: 650, // 6.50% — only 0.5pp above a 6.0% market rate
+        termMonths: 360,
+        startDate: '2020-01-01',
+        scheduledPaymentCents: 252_800,
+      };
+      const db = buildDb([[loan]]);
+      const notif = buildNotifications();
+      const freshness = { getAccountFreshness: vi.fn() };
+      const marketData = {
+        getLatestWithDeltas: vi.fn().mockResolvedValue({ latestValue: 6.0, delta4Week: null }),
+      };
+      const svc = new MarketInsightDetectorService(db, notif as any, freshness as any, marketData as any);
+
+      await svc.checkRefiOpportunities('user-1');
+
+      expect(callsOfType(notif, 'refi_opportunity')).toHaveLength(0);
+    });
+  });
+
+  describe('idle_cash', () => {
+    const account = { id: 'acct-1', accountType: 'checking' };
+
+    it('fires when idle cash exceeds the buffer and clears the $100/yr floor', async () => {
+      const db = buildDb(
+        [[account], [{ idleCashBufferMonths: null }]],
+        [
+          { rows: [{ account_id: 'acct-1', balance_cents: 5_000_000 }] }, // $50,000 balance
+          { rows: [{ total_cents: 300_000 }] }, // $3,000 total trailing-3mo expenses → $1,000/mo avg
+        ],
+      );
+      const notif = buildNotifications();
+      const freshness = {
+        getAccountFreshness: vi.fn().mockResolvedValue({ accounts: [{ accountId: 'acct-1', status: 'fresh' }] }),
+      };
+      const marketData = { getLatestWithDeltas: vi.fn().mockResolvedValue({ latestValue: 5.0 }) };
+      const svc = new MarketInsightDetectorService(db, notif as any, freshness as any, marketData as any);
+
+      await svc.checkIdleCash('user-1');
+
+      expect(callsOfType(notif, 'idle_cash')).toHaveLength(1);
+      const metadata = notif.createAndDispatch.mock.calls[0][0].metadata;
+      expect(metadata.bufferCents).toBe(100_000); // 1 month × $1,000
+      expect(metadata.idleCents).toBe(4_900_000);
+      expect(metadata.foregoneCentsPerYear).toBe(Math.round(4_900_000 * 0.05));
+    });
+
+    it('is skipped (freshness-gated) when a relevant account balance is stale', async () => {
+      const db = buildDb([[account], [{ idleCashBufferMonths: null }]]);
+      const notif = buildNotifications();
+      const freshness = {
+        getAccountFreshness: vi.fn().mockResolvedValue({ accounts: [{ accountId: 'acct-1', status: 'stale' }] }),
+      };
+      const marketData = { getLatestWithDeltas: vi.fn() };
+      const svc = new MarketInsightDetectorService(db, notif as any, freshness as any, marketData as any);
+
+      await svc.checkIdleCash('user-1');
+
+      expect(notif.createAndDispatch).not.toHaveBeenCalled();
+      expect(marketData.getLatestWithDeltas).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fuel_vs_market', () => {
+    it('fires when personal MoM% diverges from market MoM% by more than 10pp with >= 3 txns', async () => {
+      const db = buildDb(
+        [],
+        [
+          {
+            rows: [
+              { month: '2024-03-01', total_cents: 20_000, txn_count: 5 }, // +100% MoM vs prior
+              { month: '2024-02-01', total_cents: 10_000, txn_count: 4 },
+            ],
+          },
+        ],
+      );
+      const notif = buildNotifications();
+      const freshness = { getAccountFreshness: vi.fn() };
+      // Market moved from 4.00 -> 4.20 (+5% MoM) — far below the 100% personal move.
+      const marketData = {
+        getLatestWithDeltas: vi.fn().mockResolvedValue({ latestValue: 4.2, delta4Week: 0.2 }),
+      };
+      const svc = new MarketInsightDetectorService(db, notif as any, freshness as any, marketData as any);
+
+      // @ts-expect-error accessing private method for a direct, single-user unit test
+      await svc.checkCategoryVsMarket('user-1', 'fuel_vs_market', 'Fuel', 'gas_retail_regular', 'gas');
+
+      expect(callsOfType(notif, 'fuel_vs_market')).toHaveLength(1);
+    });
+
+    it('does NOT fire with fewer than 3 txns this month', async () => {
+      const db = buildDb(
+        [],
+        [
+          {
+            rows: [
+              { month: '2024-03-01', total_cents: 20_000, txn_count: 2 },
+              { month: '2024-02-01', total_cents: 10_000, txn_count: 4 },
+            ],
+          },
+        ],
+      );
+      const notif = buildNotifications();
+      const freshness = { getAccountFreshness: vi.fn() };
+      const marketData = { getLatestWithDeltas: vi.fn() };
+      const svc = new MarketInsightDetectorService(db, notif as any, freshness as any, marketData as any);
+
+      // @ts-expect-error accessing private method for a direct, single-user unit test
+      await svc.checkCategoryVsMarket('user-1', 'fuel_vs_market', 'Fuel', 'gas_retail_regular', 'gas');
+
+      expect(notif.createAndDispatch).not.toHaveBeenCalled();
+      expect(marketData.getLatestWithDeltas).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('market_update (gas dip)', () => {
+    it('fires when state gas price moved > 3% WoW', async () => {
+      const rows = arrWithChain([
+        { periodDate: '2024-03-15', value: '3.60' },
+        { periodDate: '2024-03-08', value: '3.40' }, // +5.9% WoW
+      ]);
+      const db = buildDb([rows]);
+      const notif = buildNotifications();
+      const freshness = { getAccountFreshness: vi.fn() };
+      const marketData = { getGasState: vi.fn().mockReturnValue('SCA') };
+      const svc = new MarketInsightDetectorService(db, notif as any, freshness as any, marketData as any);
+
+      await svc.checkGasDip('user-1');
+
+      expect(callsOfType(notif, 'market_update')).toHaveLength(1);
+      const metadata = notif.createAndDispatch.mock.calls[0][0].metadata;
+      expect(metadata.wowPercent).toBeCloseTo(5.88, 1);
+    });
+
+    it('does NOT fire when the WoW move is under 3%', async () => {
+      const rows = arrWithChain([
+        { periodDate: '2024-03-15', value: '3.50' },
+        { periodDate: '2024-03-08', value: '3.45' }, // +1.4% WoW
+      ]);
+      const db = buildDb([rows]);
+      const notif = buildNotifications();
+      const freshness = { getAccountFreshness: vi.fn() };
+      const marketData = { getGasState: vi.fn().mockReturnValue('SCA') };
+      const svc = new MarketInsightDetectorService(db, notif as any, freshness as any, marketData as any);
+
+      await svc.checkGasDip('user-1');
+
+      expect(notif.createAndDispatch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/analytics/analytics.module.ts
+++ b/apps/api/src/analytics/analytics.module.ts
@@ -10,15 +10,17 @@ import { ForecastService } from './forecast.service';
 import { AccountFreshnessService } from './account-freshness.service';
 import { FreshnessDetectorService } from './freshness-detector.service';
 import { WatchdogDetectorService } from './watchdog-detector.service';
+import { MarketInsightDetectorService } from './market-insight-detector.service';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { CategorizationModule } from '../categorization/categorization.module';
 import { BillsModule } from '../bills/bills.module';
 import { LoansModule } from '../loans/loans.module';
+import { MarketDataModule } from '../market-data/market-data.module';
 
 @Module({
-  imports: [NotificationsModule, CategorizationModule, BillsModule, LoansModule],
-  providers: [AnalyticsService, AnomalyDetectorService, DigestService, BriefService, BalanceSnapshotService, ForecastService, AccountFreshnessService, FreshnessDetectorService, WatchdogDetectorService],
+  imports: [NotificationsModule, CategorizationModule, BillsModule, LoansModule, MarketDataModule],
+  providers: [AnalyticsService, AnomalyDetectorService, DigestService, BriefService, BalanceSnapshotService, ForecastService, AccountFreshnessService, FreshnessDetectorService, WatchdogDetectorService, MarketInsightDetectorService],
   controllers: [AnalyticsController, DigestController],
-  exports: [AnalyticsService, AnomalyDetectorService, DigestService, BriefService, BalanceSnapshotService, ForecastService, AccountFreshnessService, FreshnessDetectorService, WatchdogDetectorService],
+  exports: [AnalyticsService, AnomalyDetectorService, DigestService, BriefService, BalanceSnapshotService, ForecastService, AccountFreshnessService, FreshnessDetectorService, WatchdogDetectorService, MarketInsightDetectorService],
 })
 export class AnalyticsModule {}

--- a/apps/api/src/analytics/market-insight-detector.service.ts
+++ b/apps/api/src/analytics/market-insight-detector.service.ts
@@ -1,0 +1,397 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { DATABASE_CONNECTION } from '../db/db.module';
+import * as schema from '../db/schema';
+import { and, eq, isNull, sql } from 'drizzle-orm';
+import { NotificationsService } from '../notifications/notifications.service';
+import { AccountFreshnessService } from './account-freshness.service';
+import { MarketDataService } from '../market-data/market-data.service';
+import {
+  MARKET_INSIGHT_THRESHOLDS,
+  computeLoanState,
+  standardMonthlyPaymentCents,
+} from '@moneypulse/shared';
+
+function formatCents(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function pct(value: number): string {
+  return `${value.toFixed(1)}%`;
+}
+
+/**
+ * Market-joined insights (11.7) — the payoff of the market data module (11.6): deterministic
+ * rules that join market_metrics against the user's OWN loans/balances/spend. Like the 11.5
+ * watchdog detectors, these are the sole source of truth for their insight types; AI never
+ * decides whether they fire. Run monthly/weekly from `alert-cron.processor.ts`.
+ */
+@Injectable()
+export class MarketInsightDetectorService {
+  private readonly logger = new Logger(MarketInsightDetectorService.name);
+
+  constructor(
+    @Inject(DATABASE_CONNECTION) private readonly db: any,
+    private readonly notificationsService: NotificationsService,
+    private readonly freshnessService: AccountFreshnessService,
+    private readonly marketDataService: MarketDataService,
+  ) {}
+
+  private async activeUsers(): Promise<Array<{ id: string }>> {
+    return this.db.select({ id: schema.users.id }).from(schema.users).where(isNull(schema.users.deletedAt));
+  }
+
+  // ── 1. Refi watcher (monthly) ────────────────────────────────
+
+  async checkRefiOpportunitiesAllUsers(): Promise<void> {
+    for (const user of await this.activeUsers()) {
+      try {
+        await this.checkRefiOpportunities(user.id);
+      } catch (err: any) {
+        this.logger.error(`Refi check failed for user ${user.id}: ${err.message}`, err.stack);
+      }
+    }
+  }
+
+  async checkRefiOpportunities(userId: string): Promise<void> {
+    const loans = await this.db
+      .select()
+      .from(schema.loans)
+      .where(and(eq(schema.loans.userId, userId), eq(schema.loans.isActive, true), isNull(schema.loans.deletedAt)));
+
+    if (loans.length === 0) return;
+
+    const mortgageMarket = await this.marketDataService.getLatestWithDeltas('mortgage_30y');
+
+    for (const loan of loans) {
+      // Auto loans need a configured benchmark series; skip if none is set (11.6 only
+      // ships a mortgage series today, so auto support is env-gated for when one exists).
+      const market =
+        loan.loanType === 'mortgage'
+          ? mortgageMarket
+          : loan.loanType === 'auto' && process.env.MARKET_AUTO_RATE_METRIC_KEY
+            ? await this.marketDataService.getLatestWithDeltas(process.env.MARKET_AUTO_RATE_METRIC_KEY)
+            : null;
+
+      if (!market || market.latestValue == null) continue;
+
+      const loanAprPercent = loan.aprBps / 100;
+      const spread = loanAprPercent - market.latestValue;
+      if (spread < MARKET_INSIGHT_THRESHOLDS.REFI_SPREAD_THRESHOLD_PP) continue;
+
+      const state = computeLoanState(
+        {
+          originalBalanceCents: loan.originalBalanceCents,
+          aprBps: loan.aprBps,
+          scheduledPaymentCents: loan.scheduledPaymentCents,
+          startDate: loan.startDate,
+        },
+        [],
+      );
+      if (state.currentBalanceCents <= 0) continue;
+
+      const remainingTermMonths = loan.termMonths
+        ? Math.max(1, loan.termMonths - state.monthsElapsed)
+        : 360 - state.monthsElapsed; // 30-yr default fallback if term wasn't recorded
+      if (remainingTermMonths <= 0) continue;
+
+      const marketAprBps = Math.round(market.latestValue * 100);
+      const marketPaymentCents = standardMonthlyPaymentCents(
+        state.currentBalanceCents,
+        marketAprBps,
+        remainingTermMonths,
+      );
+      const savingsCents = loan.scheduledPaymentCents - marketPaymentCents;
+      if (savingsCents <= 0) continue;
+
+      // Dedupe per loan per quarter — a persistent spread shouldn't spam monthly.
+      const now = new Date();
+      const quarter = Math.floor(now.getUTCMonth() / 3) + 1;
+      const dedupeKey = `refi_${loan.id}_${now.getUTCFullYear()}-Q${quarter}`;
+      if (await this.notificationsService.findByMetadata(userId, dedupeKey)) continue;
+
+      await this.notificationsService.createAndDispatch({
+        userId,
+        type: 'refi_opportunity',
+        source: 'market',
+        severity: 'insight',
+        title: 'Possible refinance opportunity',
+        message: `30-yr avg is ${market.latestValue.toFixed(2)}%, yours (${loan.name}) is ${loanAprPercent.toFixed(2)}% — refi could save ~${formatCents(savingsCents)}/mo.`,
+        dedupeKey,
+        metadata: {
+          dedupeKey,
+          loanId: loan.id,
+          loanAprPercent,
+          marketRatePercent: market.latestValue,
+          spreadPercent: spread,
+          currentBalanceCents: state.currentBalanceCents,
+          remainingTermMonths,
+          currentPaymentCents: loan.scheduledPaymentCents,
+          marketPaymentCents,
+          estimatedMonthlySavingsCents: savingsCents,
+        },
+      });
+    }
+  }
+
+  // ── 2. Idle cash (monthly) ───────────────────────────────────
+
+  async checkIdleCashAllUsers(): Promise<void> {
+    for (const user of await this.activeUsers()) {
+      try {
+        await this.checkIdleCash(user.id);
+      } catch (err: any) {
+        this.logger.error(`Idle-cash check failed for user ${user.id}: ${err.message}`, err.stack);
+      }
+    }
+  }
+
+  async checkIdleCash(userId: string): Promise<void> {
+    const accounts = await this.db
+      .select()
+      .from(schema.accounts)
+      .where(
+        and(
+          eq(schema.accounts.userId, userId),
+          isNull(schema.accounts.deletedAt),
+          sql`${schema.accounts.accountType} IN ('checking', 'savings')`,
+        ),
+      );
+    if (accounts.length === 0) return;
+
+    // Freshness gate (11.2): a stale checking/savings account means the balance can't be
+    // trusted, so skip firing entirely rather than risk an incorrect "you have idle cash".
+    const overview = await this.freshnessService.getAccountFreshness(userId);
+    const staleAccountIds = new Set(
+      overview.accounts.filter((a) => a.status === 'stale').map((a) => a.accountId),
+    );
+    const relevantAccountIds = accounts.map((a: any) => a.id);
+    const anyStale = relevantAccountIds.some((id: string) => staleAccountIds.has(id));
+    if (anyStale) {
+      this.logger.debug(`Idle-cash check skipped for user ${userId}: stale checking/savings balance.`);
+      return;
+    }
+
+    // Latest balance per relevant account.
+    const balanceRows = await this.db.execute(sql`
+      SELECT DISTINCT ON (account_id) account_id, balance_cents
+      FROM ${schema.accountBalanceSnapshots}
+      WHERE account_id = ANY(${relevantAccountIds})
+      ORDER BY account_id, snapshot_date DESC
+    `);
+    const totalBalanceCents = (balanceRows.rows ?? balanceRows).reduce(
+      (sum: number, r: any) => sum + Number(r.balance_cents),
+      0,
+    );
+
+    // Trailing-3-month average monthly expenses (all debit spend, all accounts).
+    const expenseRows = await this.db.execute(sql`
+      SELECT COALESCE(SUM(amount_cents), 0)::bigint AS total_cents
+      FROM ${schema.transactions}
+      WHERE user_id = ${userId}
+        AND is_credit = false
+        AND is_split_parent = false
+        AND parent_transaction_id IS NULL
+        AND deleted_at IS NULL
+        AND date >= NOW() - INTERVAL '3 months'
+    `);
+    const trailing3MonthTotalCents = Number((expenseRows.rows ?? expenseRows)[0]?.total_cents ?? 0);
+    const avgMonthlyExpenseCents = Math.round(trailing3MonthTotalCents / 3);
+
+    const settingsRows = await this.db
+      .select()
+      .from(schema.userSettings)
+      .where(eq(schema.userSettings.userId, userId));
+    const bufferMonths =
+      settingsRows[0]?.idleCashBufferMonths ?? MARKET_INSIGHT_THRESHOLDS.IDLE_CASH_BUFFER_MONTHS;
+    const bufferCents = avgMonthlyExpenseCents * bufferMonths;
+
+    const idleCents = totalBalanceCents - bufferCents;
+    if (idleCents <= 0) return;
+
+    const hysa = await this.marketDataService.getLatestWithDeltas('fed_funds_rate');
+    if (hysa.latestValue == null) return;
+
+    const foregoneCentsPerYear = Math.round(idleCents * (hysa.latestValue / 100));
+    if (foregoneCentsPerYear < MARKET_INSIGHT_THRESHOLDS.IDLE_CASH_MIN_FOREGONE_CENTS_PER_YEAR) return;
+
+    const now = new Date();
+    const periodKey = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+    const dedupeKey = `idle_cash_${userId}_${periodKey}`;
+    if (await this.notificationsService.findByMetadata(userId, dedupeKey)) return;
+
+    await this.notificationsService.createAndDispatch({
+      userId,
+      type: 'idle_cash',
+      source: 'market',
+      severity: 'insight',
+      title: 'Idle cash could be earning more',
+      message: `You're holding ~${formatCents(idleCents)} above your ${bufferMonths}-month buffer — moving it to a HYSA at ~${hysa.latestValue.toFixed(2)}% could earn ~${formatCents(foregoneCentsPerYear)}/yr.`,
+      dedupeKey,
+      metadata: {
+        dedupeKey,
+        totalBalanceCents,
+        bufferCents,
+        idleCents,
+        hysaApyPercent: hysa.latestValue,
+        foregoneCentsPerYear,
+      },
+    });
+  }
+
+  // ── 3 & 4. Personal vs market fuel/power (monthly) ───────────
+
+  async checkFuelVsMarketAllUsers(): Promise<void> {
+    for (const user of await this.activeUsers()) {
+      try {
+        await this.checkCategoryVsMarket(user.id, 'fuel_vs_market', 'Fuel', 'gas_retail_regular', 'gas');
+      } catch (err: any) {
+        this.logger.error(`Fuel-vs-market check failed for user ${user.id}: ${err.message}`, err.stack);
+      }
+    }
+  }
+
+  async checkPowerVsMarketAllUsers(): Promise<void> {
+    for (const user of await this.activeUsers()) {
+      try {
+        await this.checkCategoryVsMarket(
+          user.id,
+          'power_vs_market',
+          'Electric',
+          'electricity_residential',
+          'electricity',
+        );
+      } catch (err: any) {
+        this.logger.error(`Power-vs-market check failed for user ${user.id}: ${err.message}`, err.stack);
+      }
+    }
+  }
+
+  private async checkCategoryVsMarket(
+    userId: string,
+    insightType: 'fuel_vs_market' | 'power_vs_market',
+    categoryName: string,
+    metricKey: string,
+    label: string,
+  ): Promise<void> {
+    const monthTotals = await this.db.execute(sql`
+      SELECT
+        date_trunc('month', date) AS month,
+        SUM(amount_cents)::bigint AS total_cents,
+        COUNT(*)::int AS txn_count
+      FROM ${schema.transactions} t
+      JOIN ${schema.categories} c ON c.id = t.category_id
+      WHERE t.user_id = ${userId}
+        AND c.name = ${categoryName}
+        AND t.is_credit = false
+        AND t.is_split_parent = false
+        AND t.parent_transaction_id IS NULL
+        AND t.deleted_at IS NULL
+        AND t.date >= NOW() - INTERVAL '2 months'
+      GROUP BY 1
+      ORDER BY 1 DESC
+      LIMIT 2
+    `);
+    const rows = monthTotals.rows ?? monthTotals;
+    if (rows.length < 2) return;
+
+    const [current, previous] = rows;
+    if (Number(current.txn_count) < MARKET_INSIGHT_THRESHOLDS.FUEL_MIN_TXNS) return;
+    if (Number(previous.total_cents) <= 0) return;
+
+    const personalMoMPercent =
+      ((Number(current.total_cents) - Number(previous.total_cents)) / Number(previous.total_cents)) * 100;
+
+    const market = await this.marketDataService.getLatestWithDeltas(metricKey);
+    if (market.latestValue == null || market.delta4Week == null) return;
+    const priorMarketValue = market.latestValue - market.delta4Week;
+    if (priorMarketValue <= 0) return;
+    const marketMoMPercent = (market.delta4Week / priorMarketValue) * 100;
+
+    const divergence = personalMoMPercent - marketMoMPercent;
+    if (Math.abs(divergence) <= MARKET_INSIGHT_THRESHOLDS.FUEL_POWER_DIVERGENCE_PP) return;
+
+    const now = new Date();
+    const periodKey = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+    const dedupeKey = `${insightType}_${userId}_${periodKey}`;
+    if (await this.notificationsService.findByMetadata(userId, dedupeKey)) return;
+
+    const cause =
+      divergence > 0
+        ? `you're using more ${label}, not just paying more for it`
+        : `${label} prices moved more than your spending did`;
+    const message = `Your ${categoryName} spend is ${pct(personalMoMPercent)} MoM vs the ${pct(marketMoMPercent)} market move — ${cause}.`;
+
+    await this.notificationsService.createAndDispatch({
+      userId,
+      type: insightType,
+      source: 'market',
+      severity: 'insight',
+      title: insightType === 'fuel_vs_market' ? 'Fuel spend vs market price' : 'Utility spend vs market price',
+      message,
+      dedupeKey,
+      metadata: {
+        dedupeKey,
+        categoryName,
+        personalMoMPercent,
+        marketMoMPercent,
+        divergencePercent: divergence,
+        currentMonthCents: Number(current.total_cents),
+        previousMonthCents: Number(previous.total_cents),
+        txnCount: Number(current.txn_count),
+      },
+    });
+  }
+
+  // ── 5. Gas dip note (weekly) ──────────────────────────────────
+
+  async checkGasDipAllUsers(): Promise<void> {
+    for (const user of await this.activeUsers()) {
+      try {
+        await this.checkGasDip(user.id);
+      } catch (err: any) {
+        this.logger.error(`Gas-dip check failed for user ${user.id}: ${err.message}`, err.stack);
+      }
+    }
+  }
+
+  async checkGasDip(userId: string): Promise<void> {
+    const region = this.marketDataService.getGasState();
+    const rows = await this.db
+      .select()
+      .from(schema.marketMetrics)
+      .where(and(eq(schema.marketMetrics.metricKey, 'gas_retail_regular'), eq(schema.marketMetrics.region, region)))
+      .orderBy(sql`period_date DESC`)
+      .limit(2);
+    if (rows.length < 2) return;
+
+    const [latest, prior] = rows;
+    const latestValue = Number(latest.value);
+    const priorValue = Number(prior.value);
+    if (priorValue <= 0) return;
+
+    const wowPercent = ((latestValue - priorValue) / priorValue) * 100;
+    if (Math.abs(wowPercent) < MARKET_INSIGHT_THRESHOLDS.GAS_WOW_PERCENT) return;
+
+    const dedupeKey = `gas_dip_${userId}_${latest.periodDate}`;
+    if (await this.notificationsService.findByMetadata(userId, dedupeKey)) return;
+
+    const direction = wowPercent > 0 ? 'up' : 'down';
+    await this.notificationsService.createAndDispatch({
+      userId,
+      type: 'market_update',
+      source: 'market',
+      severity: 'insight',
+      title: 'Gas price move',
+      message: `State gas prices moved ${direction} ${pct(Math.abs(wowPercent))} week-over-week to $${latestValue.toFixed(2)}/gal.`,
+      dedupeKey,
+      metadata: {
+        dedupeKey,
+        region,
+        latestValue,
+        priorValue,
+        wowPercent,
+        periodDate: latest.periodDate,
+      },
+    });
+  }
+}

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -158,6 +158,9 @@ export const userSettings = pgTable('user_settings', {
   quietHoursEnd: varchar('quiet_hours_end', { length: 5 }).default('08:00'),
   dailyBriefEnabled: boolean('daily_brief_enabled').notNull().default(false),
   dailyBriefHour: integer('daily_brief_hour').notNull().default(7),
+  /** Idle-cash buffer override (11.7), in months of trailing-3-month avg expenses.
+   *  Null falls back to MARKET_INSIGHT_THRESHOLDS.IDLE_CASH_BUFFER_MONTHS (1). */
+  idleCashBufferMonths: integer('idle_cash_buffer_months'),
   createdAt: timestamp('created_at', { withTimezone: true })
     .notNull()
     .defaultNow(),

--- a/apps/api/src/jobs/alert-cron.processor.ts
+++ b/apps/api/src/jobs/alert-cron.processor.ts
@@ -8,6 +8,7 @@ import { BalanceSnapshotService } from '../analytics/balance-snapshot.service';
 import { ForecastService } from '../analytics/forecast.service';
 import { FreshnessDetectorService } from '../analytics/freshness-detector.service';
 import { WatchdogDetectorService } from '../analytics/watchdog-detector.service';
+import { MarketInsightDetectorService } from '../analytics/market-insight-detector.service';
 import { AdvisorDigestService } from '../advisor/digest/advisor-digest.service';
 import { BillsService } from '../bills/bills.service';
 import { LoansService } from '../loans/loans.service';
@@ -31,6 +32,7 @@ export class AlertCronProcessor extends WorkerHost {
     private readonly forecastService: ForecastService,
     private readonly freshnessDetectorService: FreshnessDetectorService,
     private readonly watchdogDetectorService: WatchdogDetectorService,
+    private readonly marketInsightDetectorService: MarketInsightDetectorService,
     private readonly advisorDigestService: AdvisorDigestService,
     private readonly billsService: BillsService,
     private readonly loansService: LoansService,
@@ -126,6 +128,26 @@ export class AlertCronProcessor extends WorkerHost {
         );
         break;
       }
+
+      case 'refi-watch':
+        await this.marketInsightDetectorService.checkRefiOpportunitiesAllUsers();
+        break;
+
+      case 'idle-cash-check':
+        await this.marketInsightDetectorService.checkIdleCashAllUsers();
+        break;
+
+      case 'fuel-vs-market-check':
+        await this.marketInsightDetectorService.checkFuelVsMarketAllUsers();
+        break;
+
+      case 'power-vs-market-check':
+        await this.marketInsightDetectorService.checkPowerVsMarketAllUsers();
+        break;
+
+      case 'gas-dip-check':
+        await this.marketInsightDetectorService.checkGasDipAllUsers();
+        break;
 
       default:
         this.logger.warn(`Unknown alert job: ${job.name}`);

--- a/apps/api/src/jobs/jobs.module.ts
+++ b/apps/api/src/jobs/jobs.module.ts
@@ -145,6 +145,35 @@ export class JobsModule implements OnModuleInit {
         { name: 'market-data-refresh' },
       ),
 
+      // Market-joined insights (11.7) — monthly detectors run on the 2nd (after the
+      // 1st-of-month market-data-adjacent digests) at staggered hours so they don't all
+      // hammer the DB/notification pipeline at once; the weekly gas-dip note runs Mondays.
+      this.alertsQueue.upsertJobScheduler(
+        'monthly-refi-watch',
+        { pattern: '0 10 2 * *' },
+        { name: 'refi-watch' },
+      ),
+      this.alertsQueue.upsertJobScheduler(
+        'monthly-idle-cash-check',
+        { pattern: '15 10 2 * *' },
+        { name: 'idle-cash-check' },
+      ),
+      this.alertsQueue.upsertJobScheduler(
+        'monthly-fuel-vs-market-check',
+        { pattern: '30 10 2 * *' },
+        { name: 'fuel-vs-market-check' },
+      ),
+      this.alertsQueue.upsertJobScheduler(
+        'monthly-power-vs-market-check',
+        { pattern: '45 10 2 * *' },
+        { name: 'power-vs-market-check' },
+      ),
+      this.alertsQueue.upsertJobScheduler(
+        'weekly-gas-dip-check',
+        { pattern: '0 11 * * 1' },
+        { name: 'gas-dip-check' },
+      ),
+
       // Frequent sync delivery sweep for outbox events.
       this.syncQueue.upsertJobScheduler(
         'sync-delivery-sweep',

--- a/apps/api/src/market-data/market-data.service.ts
+++ b/apps/api/src/market-data/market-data.service.ts
@@ -73,6 +73,11 @@ export class MarketDataService {
     return { refreshed, skipped, failed };
   }
 
+  /** Configured EIA gas-price state code — used by the 11.7 gas-dip weekly note. */
+  getGasState(): string {
+    return this.gasState;
+  }
+
   private regionFor(series: MarketSeriesDef): string {
     if (series.metricKey === 'gas_retail_regular') return this.gasState;
     if (series.metricKey === 'electricity_residential') return this.electricityState;

--- a/db/migrations/0019_idle_cash_buffer.sql
+++ b/db/migrations/0019_idle_cash_buffer.sql
@@ -1,0 +1,3 @@
+-- 11.7 idle-cash detector: optional per-user buffer override (months of trailing-3-month
+-- avg expenses). Nullable — null means "use the app default".
+ALTER TABLE "user_settings" ADD COLUMN IF NOT EXISTS "idle_cash_buffer_months" integer;

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1784510000000,
       "tag": "0018_market_metrics",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1784546600000,
+      "tag": "0019_idle_cash_buffer",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -372,3 +372,21 @@ export const MARKET_SERIES: MarketSeriesDef[] = [
  *  track closely, so it's the default. Verify against https://fred.stlouisfed.org
  *  once you have a key if you want a closer benchmark (e.g. a short T-bill series). */
 export const DEFAULT_HYSA_FRED_SERIES = 'FEDFUNDS';
+
+// ── Market-joined insights (11.7) ────────────────────────────
+// Every rule/threshold these market-vs-personal detectors use lives here so a
+// future settings UI can expose overrides without touching detector logic.
+export const MARKET_INSIGHT_THRESHOLDS = {
+  /** Refi watcher: min (loan APR − market rate) spread, in percentage points, to fire. */
+  REFI_SPREAD_THRESHOLD_PP: 0.75,
+  /** Idle cash: default buffer is 1x trailing-3-month avg monthly expenses. */
+  IDLE_CASH_BUFFER_MONTHS: 1,
+  /** Idle cash: min foregone $/yr (in cents) before bothering to flag. */
+  IDLE_CASH_MIN_FOREGONE_CENTS_PER_YEAR: 10_000, // $100/yr
+  /** Fuel/power vs market: min divergence (percentage points) between personal MoM% and market MoM%. */
+  FUEL_POWER_DIVERGENCE_PP: 10,
+  /** Fuel vs market: minimum fuel transactions this month before trusting the MoM%. */
+  FUEL_MIN_TXNS: 3,
+  /** Gas dip note: min week-over-week % move in state gas price to fire a brief update. */
+  GAS_WOW_PERCENT: 3,
+} as const;

--- a/packages/shared/src/loan/amortization.ts
+++ b/packages/shared/src/loan/amortization.ts
@@ -126,3 +126,21 @@ export function projectPayoff(
     amortizes: true,
   };
 }
+
+/**
+ * Standard fixed-rate amortized monthly payment (P+I) to pay off `balanceCents` over
+ * `termMonths` at `aprBps`. Used by the refi watcher (11.7) to compare "what would this
+ * balance cost per month at today's market rate, over the same remaining term" against
+ * what the loan is actually paying. Falls back to straight-line if the rate is zero.
+ */
+export function standardMonthlyPaymentCents(
+  balanceCents: number,
+  aprBps: number,
+  termMonths: number,
+): number {
+  if (termMonths <= 0 || balanceCents <= 0) return 0;
+  const rate = aprBps / 10000 / 12;
+  if (rate === 0) return Math.round(balanceCents / termMonths);
+  const factor = Math.pow(1 + rate, termMonths);
+  return Math.round((balanceCents * rate * factor) / (factor - 1));
+}


### PR DESCRIPTION
Dispatched via coxd (`MyMoney-11-7-market-joined-insights-1784546525`).

Cost: $2.706

🤖 coxd