### PR TITLE
Fix: subscriptions never auto-detected; clarify Cash Runway timing

### DIFF
--- a/apps/api/src/ingestion/ingestion.module.ts
+++ b/apps/api/src/ingestion/ingestion.module.ts
@@ -14,6 +14,7 @@ import { CategorizationModule } from '../categorization/categorization.module';
 import { SyncModule } from '../sync/sync.module';
 import { AnalyticsModule } from '../analytics/analytics.module';
 import { EmbeddingsModule } from '../embeddings/embeddings.module';
+import { BillsModule } from '../bills/bills.module';
 
 @Module({
   imports: [
@@ -24,6 +25,7 @@ import { EmbeddingsModule } from '../embeddings/embeddings.module';
     SyncModule,
     AnalyticsModule,
     EmbeddingsModule,
+    BillsModule,
   ],
   controllers: [IngestionController],
   providers: [
@@ -58,6 +60,16 @@ export class IngestionModule implements OnModuleInit {
       'embed-reconcile-sweep',
       { every: 15 * 60 * 1000 }, // every 15 minutes
       { name: 'embed-reconcile' },
+    );
+
+    // Backfill sweep: catches users whose recurring bills were never detected
+    // (imported before the per-import redetect hook existed). Daily is plenty —
+    // detection only needs to run once per user's data to populate the
+    // Subscriptions dashboard stat, and it's idempotent to re-run.
+    await this.ingestionQueue.upsertJobScheduler(
+      'bills-redetect-sweep',
+      { every: 24 * 60 * 60 * 1000 }, // every 24 hours
+      { name: 'bills-redetect' },
     );
   }
 }

--- a/apps/api/src/jobs/__tests__/ai-categorize-resilience.spec.ts
+++ b/apps/api/src/jobs/__tests__/ai-categorize-resilience.spec.ts
@@ -101,8 +101,9 @@ function makeProcessor(opts: {
     mockOllamaHealth as any,                      // 12 ollamaHealth
     { snapshotForUser: vi.fn().mockResolvedValue(undefined) } as any, // 13 balanceSnapshotService
     { embedTransactions: vi.fn().mockResolvedValue({ embedded: 0, failed: 0 }) } as any, // 14 embeddingService
-    { add: vi.fn() } as any,                      // 15 alertsQueue
-    { add: ingestionQueueAddSpy } as any,         // 16 ingestionQueue
+    { redetectAndDedupe: vi.fn().mockResolvedValue(undefined) } as any, // 15 billsService
+    { add: vi.fn() } as any,                      // 16 alertsQueue
+    { add: ingestionQueueAddSpy } as any,         // 17 ingestionQueue
   );
 
   return { processor, mockOllamaHealth, categorizeSpy, ingestionQueueAddSpy, mockDb };

--- a/apps/api/src/jobs/ingestion.processor.ts
+++ b/apps/api/src/jobs/ingestion.processor.ts
@@ -23,6 +23,7 @@ import { AnomalyDetectorService } from '../analytics/anomaly-detector.service';
 import { WatchdogDetectorService } from '../analytics/watchdog-detector.service';
 import { BalanceSnapshotService } from '../analytics/balance-snapshot.service';
 import { EmbeddingService } from '../embeddings/embedding.service';
+import { BillsService } from '../bills/bills.service';
 import type { ParsedTransaction } from '@moneypulse/shared';
 import { encryptField } from '../common/crypto';
 
@@ -54,6 +55,7 @@ export class IngestionProcessor extends WorkerHost {
     private readonly ollamaHealth: OllamaHealthService,
     private readonly balanceSnapshotService: BalanceSnapshotService,
     private readonly embeddingService: EmbeddingService,
+    private readonly billsService: BillsService,
     @InjectQueue('alerts') private readonly alertsQueue: Queue,
     @InjectQueue(INGESTION_QUEUE) private readonly ingestionQueue: Queue,
   ) {
@@ -83,6 +85,9 @@ export class IngestionProcessor extends WorkerHost {
     }
     if (job.name === 'embed-reconcile') {
       return this.processEmbedReconcileSweep();
+    }
+    if (job.name === 'bills-redetect') {
+      return this.processBillsRedetectSweep();
     }
 
     const { uploadId, userId, accountId, filePath, fileType } = job.data as IngestionJobData;
@@ -247,6 +252,12 @@ export class IngestionProcessor extends WorkerHost {
           this.balanceSnapshotService.snapshotForUser(userId).catch((err) =>
             this.logger.warn(`Balance snapshot failed for user ${userId}: ${err.message}`),
           );
+          // Best-effort recurring-bill redetection so the Subscriptions stat
+          // stays populated — previously only ran when a user manually hit
+          // POST /bills/detect, so it silently stayed empty forever otherwise.
+          this.billsService.redetectAndDedupe(userId).catch((err) =>
+            this.logger.warn(`Recurring-bill redetect failed for user ${userId}: ${err.message}`),
+          );
         }
 
         return;
@@ -399,6 +410,12 @@ export class IngestionProcessor extends WorkerHost {
         // Best-effort balance snapshot so dashboard trend is current
         this.balanceSnapshotService.snapshotForUser(userId).catch((err) =>
           this.logger.warn(`Balance snapshot failed for user ${userId}: ${err.message}`),
+        );
+        // Best-effort recurring-bill redetection so the Subscriptions stat
+        // stays populated — previously only ran when a user manually hit
+        // POST /bills/detect, so it silently stayed empty forever otherwise.
+        this.billsService.redetectAndDedupe(userId).catch((err) =>
+          this.logger.warn(`Recurring-bill redetect failed for user ${userId}: ${err.message}`),
         );
       }
     } catch (err: any) {
@@ -840,5 +857,35 @@ export class IngestionProcessor extends WorkerHost {
     this.logger.log(
       `Embed reconcile sweep: enqueued ${rows.length} txns across ${byUser.size} user(s)`,
     );
+  }
+
+  /**
+   * Backfill sweep: catches users whose recurring bills were never detected
+   * (transactions imported before the per-import hook existed, or a prior
+   * detection attempt failed). Runs daily — bills detection is cheap and
+   * idempotent, so re-running it for every active user is fine.
+   */
+  private async processBillsRedetectSweep(): Promise<void> {
+    const result = await this.db.execute(sql`
+      SELECT DISTINCT user_id AS "userId"
+      FROM transactions
+      WHERE deleted_at IS NULL
+    `);
+    const rows = (result.rows ?? result) as Array<{ userId: string }>;
+
+    if (rows.length === 0) {
+      this.logger.debug('Bills redetect sweep: no users with transactions found');
+      return;
+    }
+
+    for (const { userId } of rows) {
+      try {
+        await this.billsService.redetectAndDedupe(userId);
+      } catch (err: any) {
+        this.logger.warn(`Bills redetect sweep failed for user ${userId}: ${err.message}`);
+      }
+    }
+
+    this.logger.log(`Bills redetect sweep: processed ${rows.length} user(s)`);
   }
 }

--- a/apps/web/src/app/(protected)/page.tsx
+++ b/apps/web/src/app/(protected)/page.tsx
@@ -193,7 +193,7 @@ export default function DashboardPage() {
               ? `${cashRunwayData.data.months.toFixed(1)} mo`
               : '—'
           }
-          subtitle="liquid ÷ avg monthly expenses"
+          subtitle="liquid ÷ avg monthly expenses, as of today"
           icon={ArrowDownUp}
           accentColor="primary"
         />


### PR DESCRIPTION
## What
- **Real bug**: `detectRecurring()` (recurring-bill detection feeding the Subscriptions dashboard stat) only ran on an explicit `POST /bills/detect` call, which nothing else ever triggered. Any account whose transactions were imported before this fix has an empty `recurring_bills` table and a permanently-blank Subscriptions card.
- **Fix**: hook `billsService.redetectAndDedupe(userId)` into both ingestion paths (CSV/Excel + PDF) as a best-effort, non-blocking step — same pattern as the existing balance-snapshot hook. Also added a daily `bills-redetect-sweep` job (mirrors the existing `ai-reconcile-sweep`/`embed-reconcile-sweep` pattern) so users with data imported before this PR catch up automatically within 24h, without needing to re-import anything.
- **Not a bug, clarified**: Savings Rate / Cash Runway / Subscriptions don't respond to the dashboard's month-range filter. Confirmed intentional — these are rolling/point-in-time KPIs (trailing-12-month series, trailing-3-month runway, currently-active subscriptions), structurally different from the period-scoped cards (income vs. expense, category breakdown, etc.). Savings Rate already surfaces its own month in the subtitle; added the same "as of today" clarity to Cash Runway's subtitle so it reads as designed rather than broken.

## Test plan
- [x] `vitest run` on `bills/`, `jobs/__tests__/ingestion.processor.sync.spec.ts`, `jobs/__tests__/ai-categorize-resilience.spec.ts` — 59/59 pass
- [x] `tsc --noEmit` clean on both touched files (api + web)
- [ ] After deploy: confirm the daily sweep populates real subscriptions within 24h (or trigger `POST /bills/detect` once manually for immediate effect)