### PR TITLE
12.1 Recommendation layer — evidence contract, decision memory, agent 

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -17,6 +17,7 @@ import { CategorizationModule } from './categorization/categorization.module';
 import { AnalyticsModule } from './analytics/analytics.module';
 import { BudgetsModule } from './budgets/budgets.module';
 import { NotificationsModule } from './notifications/notifications.module';
+import { RecommendationsModule } from './recommendations/recommendations.module';
 import { JobsModule } from './jobs/jobs.module';
 import { AiLogsModule } from './ai-logs/ai-logs.module';
 import { SyncModule } from './sync/sync.module';
@@ -64,6 +65,7 @@ import { MarketDataModule } from './market-data/market-data.module';
     AnalyticsModule,
     BudgetsModule,
     NotificationsModule,
+    RecommendationsModule,
     SyncModule,
     JobsModule,
     AiLogsModule,

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -101,6 +101,23 @@ export const categoryBucketEnum = pgEnum('category_bucket', [
   'wants',
   'savings_debt',
 ]);
+// 12.1: Recommendation layer — extends the notifications row with an evidence
+// contract + decision memory (fail-closed render/dispatch; see notifications.service.ts).
+export const notificationKindEnum = pgEnum('notification_kind', [
+  'insight',
+  'recommendation',
+]);
+export const recommendationConfidenceBandEnum = pgEnum(
+  'recommendation_confidence_band',
+  ['high', 'medium', 'low'],
+);
+export const recommendationDecisionEnum = pgEnum('recommendation_decision', [
+  'accepted',
+  'rejected',
+  'dismissed',
+  'snoozed',
+  'not_applicable',
+]);
 export const payFrequencyEnum = pgEnum('pay_frequency', [
   'weekly',
   'biweekly',
@@ -491,6 +508,28 @@ export const notifications = pgTable(
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
       .defaultNow(),
+
+    // ── 12.1 recommendation layer (evidence contract + decision memory) ──
+    /** 'insight' (observation) vs 'recommendation' (actionable, requires evidence). */
+    kind: notificationKindEnum('kind').notNull().default('insight'),
+    actionSummary: varchar('action_summary', { length: 500 }),
+    /** {minCentsPerYear, maxCentsPerYear, basis} — a range, never false precision. */
+    expectedImpact: jsonb('expected_impact'),
+    /** Array of {source, ref, value, unit, observedAt}. Required (non-empty) for recommendations. */
+    evidence: jsonb('evidence'),
+    /** Array of assumption strings. Required (non-empty) for recommendations. */
+    assumptions: jsonb('assumptions'),
+    confidenceBand: recommendationConfidenceBandEnum('confidence_band'),
+    calculationVersion: varchar('calculation_version', { length: 50 }),
+    /** {id, version} of the producing agent. */
+    producer: jsonb('producer'),
+    expiresAt: timestamp('expires_at', { withTimezone: true }),
+    decision: recommendationDecisionEnum('decision'),
+    decisionReason: text('decision_reason'),
+    decidedAt: timestamp('decided_at', { withTimezone: true }),
+    snoozedUntil: timestamp('snoozed_until', { withTimezone: true }),
+    /** Persisted reason a generation pass suppressed re-raising this topic. */
+    suppressedReason: text('suppressed_reason'),
   },
   (table) => [
     index('idx_notifications_user_severity_created').on(
@@ -499,6 +538,11 @@ export const notifications = pgTable(
       table.createdAt.desc(),
     ),
     index('idx_notifications_user_dismissed').on(table.userId, table.dismissedAt),
+    index('idx_notifications_user_type_decision').on(
+      table.userId,
+      table.type,
+      table.decidedAt.desc(),
+    ),
   ],
 );
 

--- a/apps/api/src/notifications/notifications.controller.ts
+++ b/apps/api/src/notifications/notifications.controller.ts
@@ -81,6 +81,26 @@ export class NotificationsController {
     return { data: { dismissed: true } };
   }
 
+  @Post(':id/decision')
+  @HttpCode(200)
+  @ApiOperation({ summary: 'Record a decision on a recommendation (accept/reject/dismiss/snooze)' })
+  async recordDecision(
+    @CurrentUser() user: AuthTokenPayload,
+    @Param('id') id: string,
+    @Body()
+    body: {
+      decision: 'accepted' | 'rejected' | 'dismissed' | 'snoozed' | 'not_applicable';
+      reason?: string;
+      snoozedUntil?: string;
+    },
+  ) {
+    const updated = await this.notificationsService.recordDecision(id, user.sub, body.decision, {
+      reason: body.reason,
+      snoozedUntil: body.snoozedUntil ? new Date(body.snoozedUntil) : undefined,
+    });
+    return { data: updated };
+  }
+
   @Get('feed/insights')
   @ApiOperation({ summary: 'Get insights feed (filtered, paginated)' })
   async getInsightsFeed(

--- a/apps/api/src/notifications/notifications.service.spec.ts
+++ b/apps/api/src/notifications/notifications.service.spec.ts
@@ -115,6 +115,87 @@ describe('NotificationsService', () => {
       expect(mockDb.insert).toHaveBeenCalledTimes(1);
     });
 
+    describe('12.1 fail-closed recommendation evidence contract', () => {
+      it('never dispatches a recommendation missing evidence/assumptions/confidence', async () => {
+        const result = await service.createAndDispatch({
+          userId: TEST_USER,
+          type: 'cash_placement',
+          title: 'Move idle cash',
+          message: 'Move $20,000 to a higher-yield account.',
+          kind: 'recommendation',
+          // evidence/assumptions/confidenceBand all omitted — must fail closed.
+        });
+
+        // Domain write still happens (audit trail of the agent run)...
+        expect(result).toEqual(INSERTED_ROW);
+        // ...but nothing was dispatched through any channel.
+        expect(mockWebhookService.sendWebhook).not.toHaveBeenCalled();
+        expect(mockTelegramPush.sendToUser).not.toHaveBeenCalled();
+        expect(mockWebPush.sendToUser).not.toHaveBeenCalled();
+        // Nor projected to the web-sync outbox.
+        expect(mockOutbox.enqueue).not.toHaveBeenCalled();
+      });
+
+      it('never dispatches when evidence is present but assumptions/confidence are missing', async () => {
+        await service.createAndDispatch({
+          userId: TEST_USER,
+          type: 'cash_placement',
+          title: 'Move idle cash',
+          message: 'Move $20,000 to a higher-yield account.',
+          kind: 'recommendation',
+          evidence: [
+            { source: 'FRED', ref: 'MORTGAGE30US', value: 5.9, observedAt: '2026-07-10' },
+          ],
+          // assumptions + confidenceBand still missing.
+        });
+
+        expect(mockOutbox.enqueue).not.toHaveBeenCalled();
+        expect(mockWebPush.sendToUser).not.toHaveBeenCalled();
+      });
+
+      it('dispatches a complete recommendation (full evidence contract) normally', async () => {
+        mockWebPush.enabled = true;
+        mockPreferences.getPreference.mockResolvedValue({
+          id: 'pref-123',
+          userId: TEST_USER,
+          notificationType: 'system_alert',
+          mode: 'instant',
+          enabledChannels: ['inApp', 'webPush'],
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        });
+
+        await service.createAndDispatch({
+          userId: TEST_USER,
+          type: 'cash_placement',
+          title: 'Move idle cash',
+          message: 'Move $20,000 to a higher-yield account.',
+          kind: 'recommendation',
+          evidence: [
+            { source: 'FRED', ref: 'MORTGAGE30US', value: 5.9, observedAt: '2026-07-10' },
+          ],
+          assumptions: ['Balances fresh as of last sync.'],
+          confidenceBand: 'high',
+          calculationVersion: '1',
+          producer: { id: 'cash-manager', version: '1' },
+        });
+
+        expect(mockOutbox.enqueue).toHaveBeenCalledTimes(1);
+      });
+
+      it('an insight (non-recommendation) row is unaffected by the evidence contract', async () => {
+        await service.createAndDispatch({
+          userId: TEST_USER,
+          type: 'spending_anomaly',
+          title: 'Unusual spend',
+          message: 'You spent $600 at Merchant X',
+          kind: 'insight',
+        });
+
+        expect(mockOutbox.enqueue).toHaveBeenCalledTimes(1);
+      });
+    });
+
     it('enqueues a notification.projected.v1 event with body (not message)', async () => {
       await service.createAndDispatch({
         userId: TEST_USER,
@@ -285,6 +366,84 @@ describe('NotificationsService', () => {
         expect.objectContaining({ briefedAt: expect.any(Date) }),
       );
     });
+  });
+});
+
+describe('NotificationsService.getInsightsFeed — 12.1 fail-closed render contract', () => {
+  const TEST_USER = 'user-abc';
+  const INCOMPLETE_RECOMMENDATION = {
+    id: 'notif-rec-incomplete',
+    userId: TEST_USER,
+    type: 'cash_placement',
+    kind: 'recommendation',
+    evidence: null,
+    assumptions: null,
+    confidenceBand: null,
+    createdAt: new Date().toISOString(),
+  };
+  const COMPLETE_RECOMMENDATION = {
+    id: 'notif-rec-complete',
+    userId: TEST_USER,
+    type: 'cash_placement',
+    kind: 'recommendation',
+    evidence: [{ source: 'FRED', ref: 'MORTGAGE30US', value: 5.9, observedAt: '2026-07-10' }],
+    assumptions: ['Balances fresh as of last sync.'],
+    confidenceBand: 'high',
+    createdAt: new Date().toISOString(),
+  };
+  const PLAIN_INSIGHT = {
+    id: 'notif-insight',
+    userId: TEST_USER,
+    type: 'spending_anomaly',
+    kind: 'insight',
+    evidence: null,
+    assumptions: null,
+    confidenceBand: null,
+    createdAt: new Date().toISOString(),
+  };
+
+  it('withholds a recommendation row missing evidence/assumptions/confidence from the feed', async () => {
+    const rows = [INCOMPLETE_RECOMMENDATION, COMPLETE_RECOMMENDATION, PLAIN_INSIGHT];
+
+    const selectChain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      offset: vi.fn().mockResolvedValue(rows),
+    };
+    // First .select() call (the count query) resolves via `where` directly (no offset chain).
+    let callCount = 0;
+    const mockDb = {
+      select: vi.fn().mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) {
+          return {
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockResolvedValue([{ count: rows.length }]),
+            }),
+          };
+        }
+        return selectChain;
+      }),
+    };
+
+    const service = new NotificationsService(
+      mockDb,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    );
+
+    const result = await service.getInsightsFeed(TEST_USER);
+
+    const ids = result.data.map((r: any) => r.id);
+    expect(ids).toContain(COMPLETE_RECOMMENDATION.id);
+    expect(ids).toContain(PLAIN_INSIGHT.id);
+    expect(ids).not.toContain(INCOMPLETE_RECOMMENDATION.id);
   });
 });
 

--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -8,6 +8,13 @@ import { WebPushService } from './web-push.service';
 import { NotificationPreferencesService } from './notification-preferences.service';
 import { OutboxService } from '../sync/outbox.service';
 import { AliasMapperService } from '../sync/alias-mapper.service';
+import {
+  EvidenceItem,
+  ExpectedImpact,
+  ConfidenceBand,
+  hasCompleteEvidence,
+  describeMissingEvidence,
+} from '../recommendations/recommendation-evidence';
 
 export interface CreateNotificationInput {
   userId: string;
@@ -21,6 +28,18 @@ export interface CreateNotificationInput {
   dedupeKey?: string;
   metadata?: Record<string, any>;
   notificationType?: string; // Maps to notification_preferences.notification_type
+
+  // ── 12.1 recommendation layer ──
+  /** Defaults to 'insight'. 'recommendation' rows are held to the evidence contract below. */
+  kind?: 'insight' | 'recommendation';
+  actionSummary?: string;
+  expectedImpact?: ExpectedImpact;
+  evidence?: EvidenceItem[];
+  assumptions?: string[];
+  confidenceBand?: ConfidenceBand;
+  calculationVersion?: string;
+  producer?: { id: string; version: string };
+  expiresAt?: Date;
 }
 
 @Injectable()
@@ -100,13 +119,26 @@ export class NotificationsService {
       .from(schema.notifications)
       .where(whereClause);
 
-    const data = await this.db
+    const rawData = await this.db
       .select()
       .from(schema.notifications)
       .where(whereClause)
       .orderBy(desc(schema.notifications.createdAt))
       .limit(limit)
       .offset(offset);
+
+    // Fail-closed render contract (12.1): a `recommendation` row missing evidence,
+    // assumptions, or a confidence band must never render in the feed, no matter how
+    // it ended up in the table. `insight` rows are unaffected.
+    const data = rawData.filter((row: any) => {
+      const renderable = hasCompleteEvidence(row);
+      if (!renderable) {
+        this.logger.warn(
+          `Feed: withheld recommendation ${row.id} (${describeMissingEvidence(row)})`,
+        );
+      }
+      return renderable;
+    });
 
     return {
       data,
@@ -177,6 +209,35 @@ export class NotificationsService {
   }
 
   /**
+   * Record a decision (accept/reject/dismiss/snooze/not_applicable) on a
+   * recommendation row — the decision memory that powers 12.1's decision-aware
+   * suppression. Scoped to the owning user; no-ops (silently) if the row isn't theirs.
+   */
+  async recordDecision(
+    id: string,
+    userId: string,
+    decision: 'accepted' | 'rejected' | 'dismissed' | 'snoozed' | 'not_applicable',
+    options: { reason?: string; snoozedUntil?: Date } = {},
+  ) {
+    const [updated] = await this.db
+      .update(schema.notifications)
+      .set({
+        decision,
+        decisionReason: options.reason,
+        decidedAt: new Date(),
+        snoozedUntil: decision === 'snoozed' ? options.snoozedUntil : null,
+      })
+      .where(
+        and(
+          eq(schema.notifications.id, id),
+          eq(schema.notifications.userId, userId),
+        ),
+      )
+      .returning();
+    return updated;
+  }
+
+  /**
    * Fetch insights that were routed to "brief" batching (11.3 dispatch) and haven't
    * yet been folded into a delivered daily brief. Undismissed only.
    */
@@ -216,6 +277,19 @@ export class NotificationsService {
   }
 
   async createAndDispatch(input: CreateNotificationInput) {
+    const kind = input.kind ?? 'insight';
+
+    // Fail-closed evidence contract (12.1): a `recommendation` row missing evidence,
+    // assumptions, or a confidence band is recorded (for audit — the producing agent
+    // run itself succeeded) but MUST NEVER be delivered through any channel. It's also
+    // excluded from the feed by `getInsightsFeed`'s render-contract filter.
+    const renderable = hasCompleteEvidence({
+      kind,
+      evidence: input.evidence,
+      assumptions: input.assumptions,
+      confidenceBand: input.confidenceBand,
+    });
+
     // Domain write — must always succeed
     const [notification] = await this.db
       .insert(schema.notifications)
@@ -227,6 +301,15 @@ export class NotificationsService {
         severity: input.severity ?? 'insight',
         source: input.source ?? 'system',
         data: input.data ?? {},
+        kind,
+        actionSummary: input.actionSummary,
+        expectedImpact: input.expectedImpact,
+        evidence: input.evidence,
+        assumptions: input.assumptions,
+        confidenceBand: input.confidenceBand,
+        calculationVersion: input.calculationVersion,
+        producer: input.producer,
+        expiresAt: input.expiresAt,
         metadata: {
           ...(input.metadata ?? {}),
           ...(input.dedupeKey ? { dedupeKey: input.dedupeKey } : {}),
@@ -234,6 +317,14 @@ export class NotificationsService {
         },
       })
       .returning();
+
+    if (!renderable) {
+      this.logger.error(
+        `Dispatch withheld: recommendation ${notification.id} (type=${input.type}) ` +
+          `is missing evidence/assumptions/confidence — fail-closed, not delivered.`,
+      );
+      return notification;
+    }
 
     // Dispatch through preference-aware channels (best-effort, never blocks domain write)
     void this.dispatch(notification.id, input.userId, input.notificationType ?? 'system_alert', {

--- a/apps/api/src/recommendations/__tests__/agent-runner.service.spec.ts
+++ b/apps/api/src/recommendations/__tests__/agent-runner.service.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AgentRunnerService } from '../agent-runner.service';
+import { AgentManifestViolationError, defineAgentManifest } from '../agent-manifest';
+
+const CASH_MANAGER_MANIFEST = defineAgentManifest({
+  id: 'cash-manager',
+  version: '1',
+  schedule: 'monthly',
+  toolAllowlist: ['get_account_balances', 'get_market_context'],
+  privacyClass: 'aggregates_cloud_ok',
+  outputTypes: ['recommendation'],
+  featureFlag: 'advisor_cash_manager',
+});
+
+describe('AgentRunnerService', () => {
+  let runner: AgentRunnerService;
+  let toolCaller: ReturnType<typeof vi.fn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    runner = new AgentRunnerService();
+    toolCaller = vi.fn().mockResolvedValue({ text: 'ok' });
+    errorSpy = vi.spyOn((runner as any).logger, 'error').mockImplementation(() => {});
+  });
+
+  it('allows tool calls within the manifest allowlist', async () => {
+    const result = await runner.runAgent(CASH_MANAGER_MANIFEST, toolCaller, async (callTool) => {
+      return callTool('get_account_balances', {});
+    });
+
+    expect(result.ok).toBe(true);
+    expect(toolCaller).toHaveBeenCalledWith('get_account_balances', {});
+  });
+
+  it('is a run failure (logged, not thrown) when an agent calls a tool outside its manifest allowlist', async () => {
+    const result = await runner.runAgent(CASH_MANAGER_MANIFEST, toolCaller, async (callTool) => {
+      return callTool('get_transactions', {}); // not in the manifest — raw data, never allowed
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeInstanceOf(AgentManifestViolationError);
+    // The underlying tool implementation must never actually be invoked.
+    expect(toolCaller).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy.mock.calls[0][0]).toContain('cash-manager');
+  });
+
+  it('rejects a manifest at validation time if an aggregates_cloud_ok agent allowlists a non-aggregate tool', () => {
+    const badManifest = defineAgentManifest({
+      id: 'bad-agent',
+      version: '1',
+      schedule: 'monthly',
+      toolAllowlist: ['get_transactions'], // raw data — not on AGGREGATE_TOOL_ALLOWLIST
+      privacyClass: 'aggregates_cloud_ok',
+      outputTypes: ['recommendation'],
+      featureFlag: 'advisor_bad_agent',
+    });
+
+    expect(() => runner.validateManifest(badManifest)).toThrow(/aggregates_cloud_ok/);
+  });
+
+  it('does not enforce the aggregate allowlist for local_only agents', () => {
+    const localManifest = defineAgentManifest({
+      id: 'local-agent',
+      version: '1',
+      schedule: 'monthly',
+      toolAllowlist: ['get_transactions', 'search_transactions'],
+      privacyClass: 'local_only',
+      outputTypes: ['insight'],
+      featureFlag: 'advisor_local_agent',
+    });
+
+    expect(() => runner.validateManifest(localManifest)).not.toThrow();
+  });
+
+  it('logs and reports failure for any other error the work function throws', async () => {
+    const result = await runner.runAgent(CASH_MANAGER_MANIFEST, toolCaller, async () => {
+      throw new Error('boom');
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.message).toBe('boom');
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/recommendations/__tests__/recommendation-evidence.spec.ts
+++ b/apps/api/src/recommendations/__tests__/recommendation-evidence.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { hasCompleteEvidence, describeMissingEvidence } from '../recommendation-evidence';
+
+describe('hasCompleteEvidence (12.1 fail-closed render contract)', () => {
+  it('is always true for insight-kind rows regardless of evidence', () => {
+    expect(hasCompleteEvidence({ kind: 'insight' })).toBe(true);
+    expect(
+      hasCompleteEvidence({ kind: 'insight', evidence: null, assumptions: null, confidenceBand: null }),
+    ).toBe(true);
+  });
+
+  it('is false for a recommendation with no evidence at all', () => {
+    expect(
+      hasCompleteEvidence({
+        kind: 'recommendation',
+        evidence: null,
+        assumptions: ['some assumption'],
+        confidenceBand: 'high',
+      }),
+    ).toBe(false);
+  });
+
+  it('is false for a recommendation with an empty evidence array', () => {
+    expect(
+      hasCompleteEvidence({
+        kind: 'recommendation',
+        evidence: [],
+        assumptions: ['some assumption'],
+        confidenceBand: 'high',
+      }),
+    ).toBe(false);
+  });
+
+  it('is false for a recommendation missing assumptions', () => {
+    expect(
+      hasCompleteEvidence({
+        kind: 'recommendation',
+        evidence: [{ source: 'FRED', ref: 'MORTGAGE30US', value: 5.9, observedAt: '2026-07-10' }],
+        assumptions: [],
+        confidenceBand: 'high',
+      }),
+    ).toBe(false);
+  });
+
+  it('is false for a recommendation missing confidence_band', () => {
+    expect(
+      hasCompleteEvidence({
+        kind: 'recommendation',
+        evidence: [{ source: 'FRED', ref: 'MORTGAGE30US', value: 5.9, observedAt: '2026-07-10' }],
+        assumptions: ['some assumption'],
+        confidenceBand: null,
+      }),
+    ).toBe(false);
+  });
+
+  it('is false when an evidence item is malformed (missing source/ref/observedAt)', () => {
+    expect(
+      hasCompleteEvidence({
+        kind: 'recommendation',
+        evidence: [{ source: 'FRED', value: 5.9 }],
+        assumptions: ['some assumption'],
+        confidenceBand: 'high',
+      }),
+    ).toBe(false);
+  });
+
+  it('is true for a fully-evidenced recommendation', () => {
+    expect(
+      hasCompleteEvidence({
+        kind: 'recommendation',
+        evidence: [{ source: 'FRED', ref: 'MORTGAGE30US', value: 5.9, observedAt: '2026-07-10' }],
+        assumptions: ['Balances fresh as of last sync.'],
+        confidenceBand: 'medium',
+      }),
+    ).toBe(true);
+  });
+
+  it('describeMissingEvidence names every missing piece', () => {
+    const reason = describeMissingEvidence({
+      kind: 'recommendation',
+      evidence: null,
+      assumptions: null,
+      confidenceBand: null,
+    });
+    expect(reason).toContain('missing evidence');
+    expect(reason).toContain('missing assumptions');
+    expect(reason).toContain('missing confidence_band');
+  });
+
+  it('describeMissingEvidence is empty for non-recommendation rows', () => {
+    expect(describeMissingEvidence({ kind: 'insight' })).toBe('');
+  });
+});

--- a/apps/api/src/recommendations/__tests__/recommendation-suppression.service.spec.ts
+++ b/apps/api/src/recommendations/__tests__/recommendation-suppression.service.spec.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi } from 'vitest';
+import { evaluateSuppression, RecommendationSuppressionService } from '../recommendation-suppression.service';
+
+describe('evaluateSuppression (12.1 decision-aware suppression, pure logic)', () => {
+  it('does not suppress when there is no prior decision', () => {
+    const result = evaluateSuppression({
+      priorDecision: null,
+      currentCalculationVersion: '1',
+      currentInputs: { spreadBps: 25 },
+    });
+    expect(result.suppressed).toBe(false);
+  });
+
+  it('suppresses a rejected decision with unchanged inputs and same calculation_version', () => {
+    const result = evaluateSuppression({
+      priorDecision: {
+        decision: 'rejected',
+        decisionReason: 'not worth the hassle',
+        calculationVersion: '1',
+        decidedAt: '2026-07-01T00:00:00Z',
+        inputsFingerprint: { spreadBps: 25 },
+      },
+      currentCalculationVersion: '1',
+      currentInputs: { spreadBps: 25 },
+    });
+    expect(result.suppressed).toBe(true);
+    expect(result.reason).toMatch(/rejected/);
+    expect(result.reason).toContain('not worth the hassle');
+  });
+
+  it('suppresses a not_applicable decision the same way', () => {
+    const result = evaluateSuppression({
+      priorDecision: {
+        decision: 'not_applicable',
+        calculationVersion: '1',
+        inputsFingerprint: { spreadBps: 25 },
+      },
+      currentCalculationVersion: '1',
+      currentInputs: { spreadBps: 25 },
+    });
+    expect(result.suppressed).toBe(true);
+  });
+
+  it('does not suppress (re-raises) when calculation_version changed', () => {
+    const result = evaluateSuppression({
+      priorDecision: {
+        decision: 'rejected',
+        calculationVersion: '1',
+        inputsFingerprint: { spreadBps: 25 },
+      },
+      currentCalculationVersion: '2',
+      currentInputs: { spreadBps: 25 },
+    });
+    expect(result.suppressed).toBe(false);
+  });
+
+  it('does not suppress (re-raises) when an input changes materially beyond tolerance', () => {
+    const result = evaluateSuppression({
+      priorDecision: {
+        decision: 'rejected',
+        calculationVersion: '1',
+        inputsFingerprint: { spreadBps: 25 },
+      },
+      currentCalculationVersion: '1',
+      currentInputs: { spreadBps: 80 }, // spread widened well beyond tolerance
+      toleranceByKey: { spreadBps: 50 },
+    });
+    expect(result.suppressed).toBe(false);
+  });
+
+  it('stays suppressed when the input change is within tolerance', () => {
+    const result = evaluateSuppression({
+      priorDecision: {
+        decision: 'rejected',
+        calculationVersion: '1',
+        inputsFingerprint: { spreadBps: 25 },
+      },
+      currentCalculationVersion: '1',
+      currentInputs: { spreadBps: 30 },
+      toleranceByKey: { spreadBps: 50 },
+    });
+    expect(result.suppressed).toBe(true);
+  });
+
+  it('suppresses while snoozed_until is in the future, regardless of inputs', () => {
+    const result = evaluateSuppression({
+      priorDecision: {
+        decision: 'snoozed',
+        snoozedUntil: '2099-01-01T00:00:00Z',
+      },
+      currentCalculationVersion: '1',
+      currentInputs: { spreadBps: 999 },
+      now: new Date('2026-07-21T00:00:00Z'),
+    });
+    expect(result.suppressed).toBe(true);
+  });
+
+  it('does not suppress once snoozed_until has passed', () => {
+    const result = evaluateSuppression({
+      priorDecision: {
+        decision: 'snoozed',
+        snoozedUntil: '2020-01-01T00:00:00Z',
+      },
+      currentCalculationVersion: '1',
+      currentInputs: { spreadBps: 25 },
+      now: new Date('2026-07-21T00:00:00Z'),
+    });
+    expect(result.suppressed).toBe(false);
+  });
+
+  it('does not suppress an accepted decision', () => {
+    const result = evaluateSuppression({
+      priorDecision: { decision: 'accepted', calculationVersion: '1', inputsFingerprint: {} },
+      currentCalculationVersion: '1',
+      currentInputs: {},
+    });
+    expect(result.suppressed).toBe(false);
+  });
+});
+
+describe('RecommendationSuppressionService.checkAndSuppress', () => {
+  it('persists the suppression reason on the prior row when suppressing', async () => {
+    const priorRow = {
+      id: 'notif-1',
+      decision: 'rejected',
+      decisionReason: 'declined',
+      calculationVersion: '1',
+      decidedAt: '2026-07-01T00:00:00Z',
+      snoozedUntil: null,
+      data: { inputsFingerprint: { spreadBps: 25 } },
+    };
+
+    const whereMock = vi.fn().mockResolvedValue(undefined);
+    const setMock = vi.fn().mockReturnValue({ where: whereMock });
+    const updateMock = vi.fn().mockReturnValue({ set: setMock });
+
+    const selectChain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue([priorRow]),
+    };
+    const db = {
+      select: vi.fn().mockReturnValue(selectChain),
+      update: updateMock,
+    };
+
+    const service = new RecommendationSuppressionService(db);
+    const result = await service.checkAndSuppress('user-1', 'cash_placement', '1', {
+      spreadBps: 25,
+    });
+
+    expect(result.suppressed).toBe(true);
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    expect(setMock).toHaveBeenCalledWith(
+      expect.objectContaining({ suppressedReason: expect.stringContaining('rejected') }),
+    );
+  });
+
+  it('does not touch the DB update when not suppressed', async () => {
+    const selectChain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue([]),
+    };
+    const updateMock = vi.fn();
+    const db = { select: vi.fn().mockReturnValue(selectChain), update: updateMock };
+
+    const service = new RecommendationSuppressionService(db);
+    const result = await service.checkAndSuppress('user-1', 'cash_placement', '1', {
+      spreadBps: 25,
+    });
+
+    expect(result.suppressed).toBe(false);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/recommendations/agent-manifest.ts
+++ b/apps/api/src/recommendations/agent-manifest.ts
@@ -1,0 +1,40 @@
+/**
+ * 12.1 — lightweight agent manifests. A typed constant, not a runtime: each advisory
+ * agent (Cash Manager, Investment Coach, Savings Coach, ...) declares what it is
+ * allowed to touch. The `AgentRunnerService` enforces the tool allowlist + privacy
+ * class centrally so no individual agent implementation has to be trusted to police
+ * itself.
+ */
+
+export type PrivacyClass = 'aggregates_cloud_ok' | 'local_only';
+
+export interface AgentManifest {
+  id: string;
+  version: string;
+  /** Human-readable cadence description, e.g. "monthly" or "on-demand". Not parsed. */
+  schedule: string;
+  /** Exhaustive list of MCP tool names this agent may call. */
+  toolAllowlist: readonly string[];
+  privacyClass: PrivacyClass;
+  outputTypes: readonly string[];
+  /** Feature flag key gating this agent; the runner must check it before running. */
+  featureFlag: string;
+}
+
+/** Raised when an agent run calls a tool outside its manifest's allowlist. */
+export class AgentManifestViolationError extends Error {
+  constructor(
+    public readonly agentId: string,
+    public readonly toolName: string,
+  ) {
+    super(
+      `Agent "${agentId}" called tool "${toolName}" outside its manifest tool allowlist`,
+    );
+    this.name = 'AgentManifestViolationError';
+  }
+}
+
+/** Frozen at import time — manifests are constants, not mutable config. */
+export function defineAgentManifest(manifest: AgentManifest): AgentManifest {
+  return Object.freeze({ ...manifest, toolAllowlist: Object.freeze([...manifest.toolAllowlist]) });
+}

--- a/apps/api/src/recommendations/agent-runner.service.ts
+++ b/apps/api/src/recommendations/agent-runner.service.ts
@@ -1,0 +1,86 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { AGGREGATE_TOOL_ALLOWLIST } from '../advisor/mcp-client.service';
+import { AgentManifest, AgentManifestViolationError } from './agent-manifest';
+
+/** A tool call function the runner wraps with allowlist enforcement — usually
+ * `McpClientService.callTool` bound to a userId. */
+export type ToolCaller = (toolName: string, input: unknown) => Promise<unknown>;
+
+export interface AgentRunResult<T> {
+  ok: boolean;
+  agentId: string;
+  result?: T;
+  error?: Error;
+}
+
+/**
+ * 12.1 — the agent runner. Extends the 11.9 `AdvisorReviewService`/digest-service
+ * pattern (fixed prompt/tool-use loop driven by a schedule) with centralized
+ * manifest enforcement: every tool call an agent makes is checked against its
+ * manifest's `toolAllowlist` before it's allowed through, and `aggregates_cloud_ok`
+ * agents are additionally checked against the app-wide aggregate-tool allowlist at
+ * validation time. A violation is a run failure — logged, never silently ignored —
+ * not a warning the agent can shrug off.
+ */
+@Injectable()
+export class AgentRunnerService {
+  private readonly logger = new Logger(AgentRunnerService.name);
+
+  /**
+   * Validate a manifest's internal consistency: `aggregates_cloud_ok` agents may only
+   * declare tools that are themselves on the app-wide aggregates-only allowlist (the
+   * privacy boundary is the agent boundary — #36 / Phase 12 principle 1). `local_only`
+   * agents have no such restriction (and must never be run through a cloud provider —
+   * enforced by the caller, not here).
+   */
+  validateManifest(manifest: AgentManifest): void {
+    if (manifest.privacyClass !== 'aggregates_cloud_ok') return;
+    const disallowed = manifest.toolAllowlist.filter(
+      (tool) => !AGGREGATE_TOOL_ALLOWLIST.has(tool),
+    );
+    if (disallowed.length > 0) {
+      throw new Error(
+        `Agent manifest "${manifest.id}" declares aggregates_cloud_ok but allowlists ` +
+          `non-aggregate tool(s): ${disallowed.join(', ')}`,
+      );
+    }
+  }
+
+  /**
+   * Wrap a `toolCaller` so any tool call outside `manifest.toolAllowlist` throws
+   * before reaching the real implementation.
+   */
+  private guard(manifest: AgentManifest, toolCaller: ToolCaller): ToolCaller {
+    return async (toolName: string, input: unknown) => {
+      if (!manifest.toolAllowlist.includes(toolName)) {
+        throw new AgentManifestViolationError(manifest.id, toolName);
+      }
+      return toolCaller(toolName, input);
+    };
+  }
+
+  /**
+   * Run an agent's work function with a manifest-guarded tool caller. Any
+   * `AgentManifestViolationError` (or other error) thrown by `work` is caught,
+   * logged as a run failure, and returned as `{ok: false, error}` rather than
+   * propagated — callers (schedulers) should check `.ok` rather than try/catch.
+   */
+  async runAgent<T>(
+    manifest: AgentManifest,
+    toolCaller: ToolCaller,
+    work: (guardedCallTool: ToolCaller) => Promise<T>,
+  ): Promise<AgentRunResult<T>> {
+    this.validateManifest(manifest);
+    const guarded = this.guard(manifest, toolCaller);
+    try {
+      const result = await work(guarded);
+      return { ok: true, agentId: manifest.id, result };
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      this.logger.error(
+        `Agent run failure [${manifest.id} v${manifest.version}]: ${error.message}`,
+      );
+      return { ok: false, agentId: manifest.id, error };
+    }
+  }
+}

--- a/apps/api/src/recommendations/recommendation-evidence.ts
+++ b/apps/api/src/recommendations/recommendation-evidence.ts
@@ -1,0 +1,77 @@
+/**
+ * 12.1 — the recommendation evidence contract.
+ *
+ * A `recommendation`-kind notification row is only allowed to render in the feed or
+ * be dispatched through a delivery channel when it carries complete evidence: at
+ * least one evidence row, at least one stated assumption, and a confidence band.
+ * `insight`-kind rows (observations, not actions) are unaffected — this contract is
+ * scoped to `kind === 'recommendation'` per the Phase 12 spec (fail-closed render).
+ */
+
+export interface EvidenceItem {
+  source: string;
+  ref: string;
+  value: number | string;
+  unit?: string;
+  observedAt: string;
+}
+
+export interface ExpectedImpact {
+  minCentsPerYear: number;
+  maxCentsPerYear: number;
+  basis: string;
+}
+
+export type ConfidenceBand = 'high' | 'medium' | 'low';
+
+/** Minimal shape this module needs from a notification row — deliberately loose so
+ * it works against both the Drizzle row shape and plain test fixtures. */
+export interface RecommendationEvidenceFields {
+  kind?: string | null;
+  evidence?: unknown;
+  assumptions?: unknown;
+  confidenceBand?: string | null;
+}
+
+/**
+ * True when `row` is NOT a recommendation (no contract applies) or IS a recommendation
+ * with complete evidence. False means the row must be neither rendered nor delivered.
+ */
+export function hasCompleteEvidence(row: RecommendationEvidenceFields): boolean {
+  if (row.kind !== 'recommendation') return true;
+
+  const evidence = row.evidence;
+  const assumptions = row.assumptions;
+
+  if (!Array.isArray(evidence) || evidence.length === 0) return false;
+  if (!Array.isArray(assumptions) || assumptions.length === 0) return false;
+  if (!row.confidenceBand) return false;
+
+  return evidence.every(
+    (item) =>
+      item &&
+      typeof item === 'object' &&
+      typeof item.source === 'string' &&
+      item.source.length > 0 &&
+      typeof item.ref === 'string' &&
+      item.ref.length > 0 &&
+      item.value !== undefined &&
+      item.value !== null &&
+      typeof item.observedAt === 'string' &&
+      item.observedAt.length > 0,
+  );
+}
+
+/** Human-readable reason a recommendation failed the evidence contract (for logging). */
+export function describeMissingEvidence(row: RecommendationEvidenceFields): string {
+  if (row.kind !== 'recommendation') return '';
+  const reasons: string[] = [];
+  if (!Array.isArray(row.evidence) || row.evidence.length === 0) {
+    reasons.push('missing evidence');
+  }
+  if (!Array.isArray(row.assumptions) || row.assumptions.length === 0) {
+    reasons.push('missing assumptions');
+  }
+  if (!row.confidenceBand) reasons.push('missing confidence_band');
+  return reasons.join(', ') || 'malformed evidence item';
+}

--- a/apps/api/src/recommendations/recommendation-suppression.service.ts
+++ b/apps/api/src/recommendations/recommendation-suppression.service.ts
@@ -1,0 +1,158 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { and, desc, eq, isNotNull } from 'drizzle-orm';
+import { DATABASE_CONNECTION } from '../db/db.module';
+import * as schema from '../db/schema';
+
+export type Decision =
+  | 'accepted'
+  | 'rejected'
+  | 'dismissed'
+  | 'snoozed'
+  | 'not_applicable';
+
+export interface PriorDecisionRecord {
+  id?: string;
+  decision: Decision | null;
+  decisionReason?: string | null;
+  calculationVersion?: string | null;
+  snoozedUntil?: Date | string | null;
+  decidedAt?: Date | string | null;
+  /** Numeric inputs the recommendation was computed from, for tolerance comparison. */
+  inputsFingerprint?: Record<string, number> | null;
+}
+
+export interface SuppressionCheckInput {
+  priorDecision: PriorDecisionRecord | null;
+  currentCalculationVersion: string;
+  currentInputs: Record<string, number>;
+  /** Absolute tolerance per input key; a key missing here defaults to 0 (any change re-raises). */
+  toleranceByKey?: Record<string, number>;
+  now?: Date;
+}
+
+export interface SuppressionResult {
+  suppressed: boolean;
+  reason?: string;
+}
+
+/**
+ * Decision-aware suppression (12.1): a `rejected`/`not_applicable` decision with
+ * unchanged inputs (same `calculationVersion`, inputs within tolerance) means the
+ * recommendation is suppressed on the next generation pass. A material input change
+ * (any tracked input moving beyond its tolerance) re-raises it, citing the prior
+ * decision. `snoozed` suppresses until `snoozedUntil` passes regardless of inputs.
+ * Pure function — no DB access — so it's exhaustively unit-testable.
+ */
+export function evaluateSuppression(input: SuppressionCheckInput): SuppressionResult {
+  const { priorDecision, currentCalculationVersion, currentInputs } = input;
+  const now = input.now ?? new Date();
+  const tolerance = input.toleranceByKey ?? {};
+
+  if (!priorDecision || !priorDecision.decision) {
+    return { suppressed: false };
+  }
+
+  if (priorDecision.decision === 'snoozed') {
+    const until = priorDecision.snoozedUntil ? new Date(priorDecision.snoozedUntil) : null;
+    if (until && until.getTime() > now.getTime()) {
+      return { suppressed: true, reason: `Snoozed until ${until.toISOString()}.` };
+    }
+    return { suppressed: false };
+  }
+
+  if (priorDecision.decision !== 'rejected' && priorDecision.decision !== 'not_applicable') {
+    return { suppressed: false };
+  }
+
+  if (priorDecision.calculationVersion !== currentCalculationVersion) {
+    return { suppressed: false };
+  }
+
+  const priorInputs = priorDecision.inputsFingerprint ?? {};
+  const changedKeys: string[] = [];
+  const keys = new Set([...Object.keys(priorInputs), ...Object.keys(currentInputs)]);
+  for (const key of keys) {
+    const before = priorInputs[key] ?? 0;
+    const after = currentInputs[key] ?? 0;
+    const allowed = tolerance[key] ?? 0;
+    if (Math.abs(after - before) > allowed) {
+      changedKeys.push(key);
+    }
+  }
+
+  if (changedKeys.length > 0) {
+    return { suppressed: false };
+  }
+
+  const decidedDate = priorDecision.decidedAt ? new Date(priorDecision.decidedAt) : null;
+  const when = decidedDate ? decidedDate.toISOString().slice(0, 10) : 'previously';
+  return {
+    suppressed: true,
+    reason: `Suppressed: ${priorDecision.decision} on ${when}${
+      priorDecision.decisionReason ? ` ("${priorDecision.decisionReason}")` : ''
+    }; inputs unchanged since.`,
+  };
+}
+
+/**
+ * Thin DB-backed wrapper: looks up the most recent decided row for this user+type,
+ * evaluates suppression, and — when suppressed — persists the reason on that row so
+ * the suppression is auditable (`suppressed_reason`).
+ */
+@Injectable()
+export class RecommendationSuppressionService {
+  private readonly logger = new Logger(RecommendationSuppressionService.name);
+
+  constructor(@Inject(DATABASE_CONNECTION) private readonly db: any) {}
+
+  async checkAndSuppress(
+    userId: string,
+    type: string,
+    currentCalculationVersion: string,
+    currentInputs: Record<string, number>,
+    toleranceByKey?: Record<string, number>,
+  ): Promise<SuppressionResult> {
+    const rows = await this.db
+      .select()
+      .from(schema.notifications)
+      .where(
+        and(
+          eq(schema.notifications.userId, userId),
+          eq(schema.notifications.type, type),
+          isNotNull(schema.notifications.decision),
+        ),
+      )
+      .orderBy(desc(schema.notifications.decidedAt))
+      .limit(1);
+
+    const prior = rows[0];
+    const priorDecision: PriorDecisionRecord | null = prior
+      ? {
+          id: prior.id,
+          decision: prior.decision,
+          decisionReason: prior.decisionReason,
+          calculationVersion: prior.calculationVersion,
+          snoozedUntil: prior.snoozedUntil,
+          decidedAt: prior.decidedAt,
+          inputsFingerprint: (prior.data as any)?.inputsFingerprint ?? null,
+        }
+      : null;
+
+    const result = evaluateSuppression({
+      priorDecision,
+      currentCalculationVersion,
+      currentInputs,
+      toleranceByKey,
+    });
+
+    if (result.suppressed && prior) {
+      await this.db
+        .update(schema.notifications)
+        .set({ suppressedReason: result.reason })
+        .where(eq(schema.notifications.id, prior.id));
+      this.logger.log(`Suppressed "${type}" for user ${userId}: ${result.reason}`);
+    }
+
+    return result;
+  }
+}

--- a/apps/api/src/recommendations/recommendations.module.ts
+++ b/apps/api/src/recommendations/recommendations.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { AgentRunnerService } from './agent-runner.service';
+import { RecommendationSuppressionService } from './recommendation-suppression.service';
+
+/**
+ * 12.1 — the recommendation layer's runtime pieces: the agent manifest runner
+ * (tool-allowlist + privacy-class enforcement) and decision-aware suppression.
+ * The evidence contract itself (`recommendation-evidence.ts`) is pure functions
+ * consumed directly by `NotificationsService`, not a provider.
+ */
+@Module({
+  providers: [AgentRunnerService, RecommendationSuppressionService],
+  exports: [AgentRunnerService, RecommendationSuppressionService],
+})
+export class RecommendationsModule {}

--- a/db/migrations/0025_recommendation_layer.sql
+++ b/db/migrations/0025_recommendation_layer.sql
@@ -1,0 +1,31 @@
+-- 12.1: Recommendation layer — evidence contract + decision memory.
+-- Extends the existing notifications table (11.3); NOT a new table.
+
+CREATE TYPE notification_kind AS ENUM ('insight', 'recommendation');
+CREATE TYPE recommendation_confidence_band AS ENUM ('high', 'medium', 'low');
+CREATE TYPE recommendation_decision AS ENUM (
+  'accepted',
+  'rejected',
+  'dismissed',
+  'snoozed',
+  'not_applicable'
+);
+
+ALTER TABLE "notifications"
+ADD COLUMN IF NOT EXISTS "kind" notification_kind DEFAULT 'insight' NOT NULL,
+ADD COLUMN IF NOT EXISTS "action_summary" varchar(500),
+ADD COLUMN IF NOT EXISTS "expected_impact" jsonb,
+ADD COLUMN IF NOT EXISTS "evidence" jsonb,
+ADD COLUMN IF NOT EXISTS "assumptions" jsonb,
+ADD COLUMN IF NOT EXISTS "confidence_band" recommendation_confidence_band,
+ADD COLUMN IF NOT EXISTS "calculation_version" varchar(50),
+ADD COLUMN IF NOT EXISTS "producer" jsonb,
+ADD COLUMN IF NOT EXISTS "expires_at" timestamp WITH TIME ZONE,
+ADD COLUMN IF NOT EXISTS "decision" recommendation_decision,
+ADD COLUMN IF NOT EXISTS "decision_reason" text,
+ADD COLUMN IF NOT EXISTS "decided_at" timestamp WITH TIME ZONE,
+ADD COLUMN IF NOT EXISTS "snoozed_until" timestamp WITH TIME ZONE,
+ADD COLUMN IF NOT EXISTS "suppressed_reason" text;
+
+-- Support decision-aware suppression lookups (same topic/type, latest decision first).
+CREATE INDEX IF NOT EXISTS "idx_notifications_user_type_decision" ON "notifications" ("user_id", "type", "decided_at" DESC);

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1784560200000,
       "tag": "0024_paycheck_profiles",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1784560300000,
+      "tag": "0025_recommendation_layer",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Committed successfully. Summary of what was implemented for Phase 12.1:

**Schema/migration** (`db/migrations/0025_recommendation_layer.sql`, `apps/api/src/db/schema.ts`): extends the existing `notifications` table (no new table) with `kind`, `action_summary`, `expected_impact`, `evidence`, `assumptions`, `confidence_band`, `calculation_version`, `producer`, `expires_at`, and decision-memory columns (`decision`, `decision_reason`, `decided_at`, `snoozed_until`, `suppressed_reason`).

**Fail-closed evidence contract** (`recommendations/recommendation-evidence.ts`): `hasCompleteEvidence()` is the single source of truth, applied in two places:
- `NotificationsService.getInsightsFeed` filters out incomplete recommendation rows before they reach the feed.
- `NotificationsService.createAndDispatch` still writes the row (audit trail) but returns before dispatching through any channel (webhook/Telegram/webPush) or projecting to the sync outbox when evidence is incomplete.

**Decision memory**: `NotificationsService.recordDecision` + `POST /notifications/:id/decision` (user-scoped like the existing dismiss/markRead endpoints).

**Decision-aware suppression** (`recommendation-suppression.service.ts`): pure `evaluateSuppression()` plus a thin DB-backed `RecommendationSuppressionService.checkAndSuppress` that persists `suppressed_reason` on the prior row.

**Agent manifests + runner** (`agent-manifest.ts`, `agent-runner.service.ts`): typed manifest constant; `AgentRunnerService` validates `aggregates_cloud_ok` manifests against the existing `AGGREGATE_TOOL_ALLOWLIST`, and wraps agent tool calls so an out-of-manifest call is a logged run failure (`{ok:false, error}`) rather than an uncaught crash.

All new logic is covered by tests (46 passing) proving: a recommendation without evidence never renders/delivers; rejected decisions with unchanged inputs are suppressed with a stored reason (and re-raised on material change/version bump); an agent calling a tool outside its manifest

_(summary truncated)_

---
### Test evidence
```
 .../notifications/notifications.service.spec.ts    | 159 ++++++++++++++++++
 .../__tests__/agent-runner.service.spec.ts         |  85 ++++++++++
 .../__tests__/recommendation-evidence.spec.ts      |  93 +++++++++++
 .../recommendation-suppression.service.spec.ts     | 178 +++++++++++++++++++++
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- n/a (no check configured) `lint`
- ✅ `build`

### Review
**Review verdict:** approve

Findings (advisory — did not block landing):
- [low/advisory] apps/api/src/notifications/notifications.service.ts:130 — The render-contract filter runs AFTER the count query and limit/offset pagination, so `total` is inflated by withheld recommendations and pages containing incomplete rows return fewer than `limit` items. Fail-closed intent is preserved (bad rows never render), but clients relying on `total` for paging see inconsistent counts. Consider filtering in the WHERE clause or computing total from the filtered set.
- [low/advisory] apps/api/src/recommendations/recommendation-suppression.service.ts:132 — checkAndSuppress reads `prior.data.inputsFingerprint`, but createAndDispatch never persists inputsFingerprint into `data`, so decision-aware suppression tolerance comparisons will always see prior inputs = {} once wired to real producers. New code not yet wired end-to-end; verify the producer populates the fingerprint.
- [low/advisory] apps/api/src/notifications/notifications.service.ts:214 — recordDecision does not validate that the target row is kind='recommendation' or that snoozedUntil is provided when decision='snoozed' (undefined snoozedUntil silently yields a non-suppressing snooze). Minor input-validation hardening.

---
Dispatched via coxd (`MyMoney-12-1-recommendation-layer-ev-1784631999`) · cost $2.366 · 🤖 coxd