### PR TITLE
12.2 Holdings & security prices — declared shares, autonomous EOD quot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,15 @@ MARKET_GAS_STATE=SCA
 # online-savings yields track closely.
 MARKET_HYSA_FRED_SERIES=FEDFUNDS
 
+# 12.2 Holdings & security prices. Stooq (stocks/ETFs) needs no key. Alpha Vantage
+# is only needed for mutual-fund NAVs Stooq doesn't cover (e.g. VTSAX) — register at
+# https://www.alphavantage.co/support/#api-key (instant, no cost). Unset = that
+# fallback is skipped (never an error); the last stored price keeps being served.
+# ALPHAVANTAGE_API_KEY=
+# Holdings older than this many days trigger a freshness insight + dataCaveat on
+# any derived fact (portfolio value, allocation) that used them.
+HOLDINGS_STALE_DAYS=90
+
 # ── AI Advisor — Telegram surface (optional) ─────────────
 # Enables the advisor over Telegram. All optional. The API long-polls Telegram
 # (dials OUT to api.telegram.org via getUpdates) — no inbound URL is ever exposed,

--- a/apps/api/src/advisor/__tests__/mcp-client.service.spec.ts
+++ b/apps/api/src/advisor/__tests__/mcp-client.service.spec.ts
@@ -28,6 +28,8 @@ const ALL_TOOLS = [
   { name: 'get_cash_runway', description: 't', inputSchema: { type: 'object' } },
   { name: 'get_subscription_total', description: 'u', inputSchema: { type: 'object' } },
   { name: 'get_yoy_comparison', description: 'v', inputSchema: { type: 'object' } },
+  { name: 'get_portfolio_value', description: 'w', inputSchema: { type: 'object' } },
+  { name: 'get_allocation', description: 'x', inputSchema: { type: 'object' } },
   { name: 'get_transactions', description: 'ROW-LEVEL', inputSchema: { type: 'object' } },
   { name: 'search_transactions', description: 'ROW-LEVEL', inputSchema: { type: 'object' } },
   {

--- a/apps/api/src/advisor/mcp-client.service.ts
+++ b/apps/api/src/advisor/mcp-client.service.ts
@@ -34,6 +34,8 @@ export const AGGREGATE_TOOL_ALLOWLIST = new Set([
   'get_cash_runway',
   'get_subscription_total',
   'get_yoy_comparison',
+  'get_portfolio_value', // holdings x latest EOD close, aggregate only
+  'get_allocation', // percent-of-portfolio by ticker, aggregate only
 ]);
 
 /** Anthropic tool definition shape (name + description + JSON schema). */

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -659,6 +659,51 @@ export const investmentSnapshots = pgTable('investment_snapshots', {
     .defaultNow(),
 });
 
+// ── Investment Holdings & Security Prices (Phase 12.2) ──────
+// Append-only, same history-kept pattern as investment_snapshots above: an "edit"
+// inserts a new row with a newer as_of date rather than mutating.
+
+export const investmentHoldings = pgTable(
+  'investment_holdings',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    investmentAccountId: uuid('investment_account_id')
+      .notNull()
+      .references(() => investmentAccounts.id),
+    ticker: varchar('ticker', { length: 20 }).notNull(),
+    shareCount: numeric('share_count', { precision: 20, scale: 6 }).notNull(),
+    asOf: date('as_of').notNull(),
+    notes: varchar('notes', { length: 500 }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index('idx_investment_holdings_account').on(
+      table.investmentAccountId,
+      table.ticker,
+      table.asOf,
+    ),
+  ],
+);
+
+/** Global (not user-scoped) EOD close prices — same shape as market_metrics.
+ * Only tickers actually held are fetched (see SecurityPricesService). */
+export const securityPrices = pgTable(
+  'security_prices',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    ticker: varchar('ticker', { length: 20 }).notNull(),
+    priceDate: date('price_date').notNull(),
+    closeCents: integer('close_cents').notNull(),
+    currency: varchar('currency', { length: 8 }).notNull().default('USD'),
+    source: varchar('source', { length: 16 }).notNull(),
+    fetchedAt: timestamp('fetched_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index('idx_security_prices_ticker_latest').on(table.ticker, table.priceDate),
+  ],
+);
+
 // ── Loans (mortgage / auto payoff tracker) ──────────────────
 
 export const loans = pgTable('loans', {

--- a/apps/api/src/investments/__tests__/investments.service.spec.ts
+++ b/apps/api/src/investments/__tests__/investments.service.spec.ts
@@ -139,4 +139,56 @@ describe('InvestmentsService', () => {
       expect(result[0].balanceCents).toBe(10000);
     });
   });
+
+  describe('addHolding', () => {
+    it('throws ForbiddenException when declaring a holding on another user\'s account', async () => {
+      mockDb.limit.mockResolvedValue([{ ...baseAccount, userId: otherId }]);
+      await expect(
+        service.addHolding(userId, accountId, {
+          ticker: 'VTI',
+          shareCount: 100,
+          asOf: '2026-07-01',
+        }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('appends a new holding row rather than mutating an existing one', async () => {
+      mockDb.limit.mockResolvedValue([baseAccount]);
+      const holdingRow = {
+        id: 'hold-1',
+        investmentAccountId: accountId,
+        ticker: 'VTI',
+        shareCount: '100',
+        asOf: '2026-07-01',
+        notes: null,
+      };
+      mockDb.returning.mockResolvedValue([holdingRow]);
+      const result = await service.addHolding(userId, accountId, {
+        ticker: 'VTI',
+        shareCount: 100,
+        asOf: '2026-07-01',
+      });
+      expect(mockDb.insert).toHaveBeenCalled();
+      expect(mockDb.update).not.toHaveBeenCalled(); // append, never mutate
+      expect(result.ticker).toBe('VTI');
+    });
+  });
+
+  describe('getHoldings', () => {
+    it('throws ForbiddenException when reading another user\'s holdings', async () => {
+      mockDb.limit.mockResolvedValue([{ ...baseAccount, userId: otherId }]);
+      await expect(service.getHoldings(userId, accountId)).rejects.toThrow(ForbiddenException);
+    });
+
+    it('returns holding history newest-first for owned account', async () => {
+      mockDb.limit.mockResolvedValue([baseAccount]);
+      const rows = [
+        { id: 'h2', ticker: 'VTI', shareCount: '110', asOf: '2026-07-15' },
+        { id: 'h1', ticker: 'VTI', shareCount: '100', asOf: '2026-07-01' },
+      ];
+      mockDb.orderBy.mockResolvedValue(rows);
+      const result = await service.getHoldings(userId, accountId);
+      expect(result).toEqual(rows);
+    });
+  });
 });

--- a/apps/api/src/investments/investments.controller.ts
+++ b/apps/api/src/investments/investments.controller.ts
@@ -18,11 +18,13 @@ import {
   createInvestmentAccountSchema,
   updateInvestmentAccountSchema,
   addSnapshotSchema,
+  addHoldingSchema,
 } from '@moneypulse/shared';
 import type {
   CreateInvestmentAccountInput,
   UpdateInvestmentAccountInput,
   AddSnapshotInput,
+  AddHoldingInput,
   AuthTokenPayload,
 } from '@moneypulse/shared';
 
@@ -99,6 +101,27 @@ export class InvestmentsController {
     @Param('id') id: string,
   ) {
     const data = await this.investmentsService.getSnapshots(user.sub, id);
+    return { data };
+  }
+
+  /** POST /investments/:id/holdings — declare/edit a ticker holding (append-only). */
+  @Post(':id/holdings')
+  @HttpCode(201)
+  @ApiOperation({ summary: 'Declare investment holding (ticker + share count as-of a date)' })
+  async addHolding(
+    @CurrentUser() user: AuthTokenPayload,
+    @Param('id') id: string,
+    @Body(new ZodValidationPipe(addHoldingSchema)) body: AddHoldingInput,
+  ) {
+    const data = await this.investmentsService.addHolding(user.sub, id, body);
+    return { data };
+  }
+
+  /** GET /investments/:id/holdings — holding history, newest first. */
+  @Get(':id/holdings')
+  @ApiOperation({ summary: 'Get holding history for investment account' })
+  async getHoldings(@CurrentUser() user: AuthTokenPayload, @Param('id') id: string) {
+    const data = await this.investmentsService.getHoldings(user.sub, id);
     return { data };
   }
 }

--- a/apps/api/src/investments/investments.service.ts
+++ b/apps/api/src/investments/investments.service.ts
@@ -11,7 +11,12 @@ import type {
   CreateInvestmentAccountInput,
   UpdateInvestmentAccountInput,
   AddSnapshotInput,
+  AddHoldingInput,
 } from '@moneypulse/shared';
+
+/** Holdings older than this trigger a freshness insight + dataCaveat on derived
+ * facts (12.2 spec). Configurable via HOLDINGS_STALE_DAYS. */
+export const DEFAULT_HOLDINGS_STALE_DAYS = 90;
 
 @Injectable()
 export class InvestmentsService {
@@ -148,6 +153,62 @@ export class InvestmentsService {
         desc(schema.investmentSnapshots.createdAt),
       );
     return rows;
+  }
+
+  /**
+   * Declare/update a holding for an account. Edits APPEND a new row (history kept)
+   * rather than mutating an existing one — same pattern as addSnapshot above.
+   */
+  async addHolding(userId: string, accountId: string, input: AddHoldingInput) {
+    await this.assertOwnership(userId, accountId);
+    const rows = await this.db
+      .insert(schema.investmentHoldings)
+      .values({
+        investmentAccountId: accountId,
+        ticker: input.ticker,
+        shareCount: String(input.shareCount),
+        asOf: input.asOf,
+        notes: input.notes ?? null,
+      })
+      .returning();
+    return rows[0];
+  }
+
+  /**
+   * Latest holding per ticker for an account (most recent as_of, then created_at
+   * as tie-breaker), plus full history ordered newest-first.
+   */
+  async getHoldings(userId: string, accountId: string) {
+    await this.assertOwnership(userId, accountId);
+    const rows = await this.db
+      .select()
+      .from(schema.investmentHoldings)
+      .where(eq(schema.investmentHoldings.investmentAccountId, accountId))
+      .orderBy(desc(schema.investmentHoldings.asOf), desc(schema.investmentHoldings.createdAt));
+    return rows;
+  }
+
+  /**
+   * All currently-held tickers with their latest declared share count/as-of date
+   * across a user's accounts (one row per ticker per account).
+   */
+  async getCurrentHoldings(userId: string) {
+    const rows = await this.db.execute(sql`
+      SELECT DISTINCT ON (h.investment_account_id, h.ticker)
+        h.id, h.investment_account_id, h.ticker, h.share_count, h.as_of, h.notes
+      FROM ${schema.investmentHoldings} h
+      JOIN ${schema.investmentAccounts} ia ON ia.id = h.investment_account_id
+      WHERE ia.user_id = ${userId} AND ia.deleted_at IS NULL
+      ORDER BY h.investment_account_id, h.ticker, h.as_of DESC, h.created_at DESC
+    `);
+    return (rows.rows ?? rows).map((r: any) => ({
+      id: r.id,
+      investmentAccountId: r.investment_account_id,
+      ticker: r.ticker,
+      shareCount: r.share_count,
+      asOf: String(r.as_of).slice(0, 10),
+      notes: r.notes ?? null,
+    }));
   }
 
   /**

--- a/apps/api/src/jobs/alert-cron.processor.ts
+++ b/apps/api/src/jobs/alert-cron.processor.ts
@@ -14,6 +14,7 @@ import { AdvisorReviewService } from '../advisor/review/advisor-review.service';
 import { BillsService } from '../bills/bills.service';
 import { LoansService } from '../loans/loans.service';
 import { MarketDataService } from '../market-data/market-data.service';
+import { SecurityPricesService } from '../market-data/security-prices.service';
 
 const MARKET_DATA_JITTER_MAX_MS = 15 * 60_000; // spread load on the free EIA/FRED tiers
 
@@ -39,6 +40,7 @@ export class AlertCronProcessor extends WorkerHost {
     private readonly billsService: BillsService,
     private readonly loansService: LoansService,
     private readonly marketDataService: MarketDataService,
+    private readonly securityPricesService: SecurityPricesService,
   ) {
     super();
   }
@@ -127,6 +129,21 @@ export class AlertCronProcessor extends WorkerHost {
         this.logger.log(
           `Market data refresh: ${result.refreshed.length} refreshed, ` +
             `${result.skipped.length} skipped, ${result.failed.length} failed`,
+        );
+        break;
+      }
+
+      case 'security-prices-refresh': {
+        // Same jitter rationale as market-data-refresh (11.6) — Alpha Vantage's
+        // free tier is rate-limited, so avoid every daily run hitting it in the
+        // same second. Skipped in tests for the same reason as above.
+        if (process.env.NODE_ENV !== 'test') {
+          await sleep(Math.floor(Math.random() * MARKET_DATA_JITTER_MAX_MS));
+        }
+        const result = await this.securityPricesService.refreshAll();
+        this.logger.log(
+          `Security price refresh: ${result.refreshed.length} refreshed, ` +
+            `${result.failed.length} failed`,
         );
         break;
       }

--- a/apps/api/src/jobs/jobs.module.ts
+++ b/apps/api/src/jobs/jobs.module.ts
@@ -161,6 +161,15 @@ export class JobsModule implements OnModuleInit {
         { name: 'market-data-refresh' },
       ),
 
+      // Security price refresh (12.2) — daily 9:15 AM UTC, only for tickers actually
+      // held (never the whole market). Stooq primary, Alpha Vantage fallback for
+      // mutual-fund NAVs; jitter added in the processor per the 11.6 pattern.
+      this.alertsQueue.upsertJobScheduler(
+        'daily-security-prices-refresh',
+        { pattern: '15 9 * * *' },
+        { name: 'security-prices-refresh' },
+      ),
+
       // Market-joined insights (11.7) — monthly detectors run on the 2nd (after the
       // 1st-of-month market-data-adjacent digests) at staggered hours so they don't all
       // hammer the DB/notification pipeline at once; the weekly gas-dip note runs Mondays.

--- a/apps/api/src/market-data/__tests__/alphavantage.client.spec.ts
+++ b/apps/api/src/market-data/__tests__/alphavantage.client.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { AlphaVantageClient } from '../alphavantage.client';
+
+function makeConfig(overrides: Record<string, string> = {}) {
+  return { get: (key: string) => overrides[key] } as any;
+}
+
+// Recorded fixture — synthetic TIME_SERIES_DAILY response shape for a mutual-fund
+// NAV ticker (e.g. VTSAX) that Stooq's free feed doesn't cover. No live calls (12.2).
+const ALPHA_VANTAGE_FIXTURE = {
+  'Meta Data': { '2. Symbol': 'VTSAX' },
+  'Time Series (Daily)': {
+    '2026-07-01': { '1. open': '120.00', '4. close': '121.50' },
+    '2026-06-30': { '1. open': '119.50', '4. close': '120.10' },
+  },
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('AlphaVantageClient', () => {
+  it('is unconfigured without an API key and never calls out', async () => {
+    const client = new AlphaVantageClient(makeConfig());
+    expect(client.isConfigured).toBe(false);
+    global.fetch = vi.fn();
+    const point = await client.fetchLatestClose('VTSAX');
+    expect(point).toBeNull();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('parses the latest close from a recorded fixture', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ALPHA_VANTAGE_FIXTURE,
+    }) as any;
+    const client = new AlphaVantageClient(makeConfig({ ALPHAVANTAGE_API_KEY: 'test-key' }));
+    const point = await client.fetchLatestClose('VTSAX');
+    expect(point).toEqual({ date: '2026-07-01', closeCents: 12150, currency: 'USD' });
+  });
+
+  it('returns null (never throws) when the free-tier rate limit note is present', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ Note: 'Thank you for using Alpha Vantage! Our standard API rate limit is 25 requests per day.' }),
+    }) as any;
+    const client = new AlphaVantageClient(makeConfig({ ALPHAVANTAGE_API_KEY: 'test-key' }));
+    const point = await client.fetchLatestClose('VTSAX');
+    expect(point).toBeNull();
+  });
+
+  it('returns null (never throws) on a provider outage', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('network down')) as any;
+    const client = new AlphaVantageClient(makeConfig({ ALPHAVANTAGE_API_KEY: 'test-key' }));
+    const point = await client.fetchLatestClose('VTSAX');
+    expect(point).toBeNull();
+  });
+});

--- a/apps/api/src/market-data/__tests__/security-prices.service.spec.ts
+++ b/apps/api/src/market-data/__tests__/security-prices.service.spec.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi } from 'vitest';
+import { SecurityPricesService } from '../security-prices.service';
+
+function makeDb({
+  heldTickers = [] as string[],
+  latestRows = [] as any[],
+}: { heldTickers?: string[]; latestRows?: any[] } = {}) {
+  const upserts: Array<{ values: any; target: any; set: any }> = [];
+  const db = {
+    selectDistinct: vi.fn(() => ({
+      from: vi.fn().mockResolvedValue(heldTickers.map((ticker) => ({ ticker }))),
+    })),
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          orderBy: vi.fn(() => ({
+            limit: vi.fn().mockResolvedValue(latestRows),
+          })),
+        })),
+      })),
+    })),
+    insert: vi.fn(() => ({
+      values: (values: any) => ({
+        onConflictDoUpdate: (opts: { target: any; set: any }) => {
+          upserts.push({ values, target: opts.target, set: opts.set });
+          return Promise.resolve();
+        },
+      }),
+    })),
+  };
+  return { db, upserts };
+}
+
+function makeStooq(point: any) {
+  return { fetchLatestClose: vi.fn().mockResolvedValue(point) } as any;
+}
+function makeAlphaVantage(point: any) {
+  return { fetchLatestClose: vi.fn().mockResolvedValue(point) } as any;
+}
+
+describe('SecurityPricesService', () => {
+  it('fetches only currently-held tickers, never the whole market', async () => {
+    const { db } = makeDb({ heldTickers: ['VTI'] });
+    const stooq = makeStooq({ date: '2026-07-01', closeCents: 25310, currency: 'USD' });
+    const alphaVantage = makeAlphaVantage(null);
+    const service = new SecurityPricesService(db, stooq, alphaVantage);
+
+    const result = await service.refreshAll();
+
+    expect(result.refreshed).toEqual(['VTI']);
+    expect(stooq.fetchLatestClose).toHaveBeenCalledWith('VTI');
+  });
+
+  it('falls back to Alpha Vantage when Stooq has no data (e.g. mutual-fund NAV)', async () => {
+    const { db, upserts } = makeDb({ heldTickers: ['VTSAX'] });
+    const stooq = makeStooq(null);
+    const alphaVantage = makeAlphaVantage({
+      date: '2026-07-01',
+      closeCents: 12150,
+      currency: 'USD',
+    });
+    const service = new SecurityPricesService(db, stooq, alphaVantage);
+
+    const result = await service.refreshAll();
+
+    expect(result.refreshed).toEqual(['VTSAX']);
+    expect(alphaVantage.fetchLatestClose).toHaveBeenCalledWith('VTSAX');
+    expect(upserts[0].values.source).toBe('alphavantage');
+    expect(upserts[0].values.closeCents).toBe(12150);
+  });
+
+  it('records a failure (no crash) when both providers are down — a provider outage', async () => {
+    const { db } = makeDb({ heldTickers: ['VTI'] });
+    const stooq = makeStooq(null);
+    const alphaVantage = makeAlphaVantage(null);
+    const service = new SecurityPricesService(db, stooq, alphaVantage);
+
+    const result = await service.refreshAll();
+
+    expect(result.refreshed).toEqual([]);
+    expect(result.failed).toEqual(['VTI']);
+  });
+
+  it('serves the last known price with its real date when nothing fresh is available', async () => {
+    const { db } = makeDb({
+      latestRows: [
+        {
+          ticker: 'VTI',
+          priceDate: '2026-06-15',
+          closeCents: 24800,
+          currency: 'USD',
+          source: 'stooq',
+          fetchedAt: new Date('2026-06-15T21:00:00Z'),
+        },
+      ],
+    });
+    const service = new SecurityPricesService(db, makeStooq(null), makeAlphaVantage(null));
+
+    const latest = await service.getLatest('VTI');
+
+    expect(latest.closeCents).toBe(24800);
+    expect(latest.priceDate).toBe('2026-06-15'); // real (stale) date visibly attached
+    expect(latest.source).toBe('stooq');
+  });
+
+  it('returns nulls (never a fabricated price) when no price has ever been recorded', async () => {
+    const { db } = makeDb({ latestRows: [] });
+    const service = new SecurityPricesService(db, makeStooq(null), makeAlphaVantage(null));
+
+    const latest = await service.getLatest('BRAND_NEW_TICKER');
+
+    expect(latest.closeCents).toBeNull();
+    expect(latest.priceDate).toBeNull();
+  });
+});

--- a/apps/api/src/market-data/__tests__/stooq.client.spec.ts
+++ b/apps/api/src/market-data/__tests__/stooq.client.spec.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { StooqClient, parseStooqCsv } from '../stooq.client';
+
+// Recorded fixture — a trimmed real-shaped Stooq CSV response for a synthetic
+// EOD close. No live network calls in tests (12.2 spec).
+const STOOQ_VTI_FIXTURE = `Date,Open,High,Low,Close,Volume
+2026-06-29,250.10,251.00,249.80,250.55,3200000
+2026-06-30,250.60,252.20,250.10,251.90,3100000
+2026-07-01,251.95,253.40,251.50,253.10,3050000
+`;
+
+const STOOQ_UNKNOWN_TICKER = 'N/D\n';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('parseStooqCsv', () => {
+  it('parses the latest row as the close', () => {
+    const point = parseStooqCsv(STOOQ_VTI_FIXTURE);
+    expect(point).toEqual({ date: '2026-07-01', closeCents: 25310, currency: 'USD' });
+  });
+
+  it('returns null for an unknown ticker (Stooq "N/D" body)', () => {
+    expect(parseStooqCsv(STOOQ_UNKNOWN_TICKER)).toBeNull();
+  });
+
+  it('returns null for an empty body', () => {
+    expect(parseStooqCsv('')).toBeNull();
+  });
+});
+
+describe('StooqClient', () => {
+  it('fetches and parses the latest close using a recorded fixture', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => STOOQ_VTI_FIXTURE,
+    }) as any;
+    const client = new StooqClient();
+    const point = await client.fetchLatestClose('VTI');
+    expect(point).toEqual({ date: '2026-07-01', closeCents: 25310, currency: 'USD' });
+  });
+
+  it('returns null (never throws) on a provider outage', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('network down')) as any;
+    const client = new StooqClient();
+    const point = await client.fetchLatestClose('VTI');
+    expect(point).toBeNull();
+  });
+
+  it('returns null on a non-2xx response', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 }) as any;
+    const client = new StooqClient();
+    const point = await client.fetchLatestClose('VTI');
+    expect(point).toBeNull();
+  });
+});

--- a/apps/api/src/market-data/alphavantage.client.ts
+++ b/apps/api/src/market-data/alphavantage.client.ts
@@ -1,0 +1,78 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import type { SecurityPricePoint } from './stooq.client';
+
+const ALPHA_VANTAGE_BASE_URL = 'https://www.alphavantage.co/query';
+
+/**
+ * Client for Alpha Vantage's free-tier `TIME_SERIES_DAILY` endpoint
+ * (https://www.alphavantage.co/documentation/). Secondary/fallback provider —
+ * covers mutual-fund NAVs (e.g. VTSAX) that Stooq's free feed doesn't. Requires
+ * `ALPHAVANTAGE_API_KEY`; free tier is rate-limited (5 req/min, 25/day as of
+ * writing) so callers must only fetch tickers actually held.
+ */
+@Injectable()
+export class AlphaVantageClient {
+  private readonly logger = new Logger(AlphaVantageClient.name);
+  private readonly apiKey: string | undefined;
+  private readonly timeoutMs = 15_000;
+
+  constructor(private readonly config: ConfigService) {
+    this.apiKey = this.config.get<string>('ALPHAVANTAGE_API_KEY') || undefined;
+  }
+
+  get isConfigured(): boolean {
+    return Boolean(this.apiKey);
+  }
+
+  /**
+   * Fetch the most recent daily close for a ticker. Never throws — an outage, bad
+   * key, or rate-limit response must never break a caller; returns null on any
+   * failure so the service falls back to the last stored price.
+   */
+  async fetchLatestClose(ticker: string): Promise<SecurityPricePoint | null> {
+    if (!this.apiKey) {
+      this.logger.warn(`ALPHAVANTAGE_API_KEY not set — skipping ${ticker}`);
+      return null;
+    }
+    const url = new URL(ALPHA_VANTAGE_BASE_URL);
+    url.searchParams.set('function', 'TIME_SERIES_DAILY');
+    url.searchParams.set('symbol', ticker);
+    url.searchParams.set('outputsize', 'compact');
+    url.searchParams.set('apikey', this.apiKey);
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const res = await fetch(url.toString(), { signal: controller.signal });
+      if (!res.ok) {
+        this.logger.error(`Alpha Vantage ${ticker} returned ${res.status}`);
+        return null;
+      }
+      const body = (await res.json()) as {
+        'Time Series (Daily)'?: Record<string, { '4. close': string }>;
+        Note?: string; // rate-limit message
+        'Error Message'?: string;
+      };
+      if (body.Note || body['Error Message']) {
+        this.logger.error(
+          `Alpha Vantage ${ticker}: ${body.Note ?? body['Error Message']}`,
+        );
+        return null;
+      }
+      const series = body['Time Series (Daily)'];
+      if (!series) return null;
+      const dates = Object.keys(series).sort().reverse();
+      const latestDate = dates[0];
+      if (!latestDate) return null;
+      const close = Number(series[latestDate]['4. close']);
+      if (!Number.isFinite(close)) return null;
+      return { date: latestDate, closeCents: Math.round(close * 100), currency: 'USD' };
+    } catch (err: any) {
+      this.logger.error(`Alpha Vantage ${ticker} fetch failed: ${err.message}`);
+      return null;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/apps/api/src/market-data/market-data.module.ts
+++ b/apps/api/src/market-data/market-data.module.ts
@@ -3,10 +3,20 @@ import { MarketDataService } from './market-data.service';
 import { MarketDataController } from './market-data.controller';
 import { EiaClient } from './eia.client';
 import { FredClient } from './fred.client';
+import { StooqClient } from './stooq.client';
+import { AlphaVantageClient } from './alphavantage.client';
+import { SecurityPricesService } from './security-prices.service';
 
 @Module({
   controllers: [MarketDataController],
-  providers: [MarketDataService, EiaClient, FredClient],
-  exports: [MarketDataService],
+  providers: [
+    MarketDataService,
+    EiaClient,
+    FredClient,
+    StooqClient,
+    AlphaVantageClient,
+    SecurityPricesService,
+  ],
+  exports: [MarketDataService, SecurityPricesService],
 })
 export class MarketDataModule {}

--- a/apps/api/src/market-data/security-prices.service.ts
+++ b/apps/api/src/market-data/security-prices.service.ts
@@ -1,0 +1,123 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { DATABASE_CONNECTION } from '../db/db.module';
+import { securityPrices, investmentHoldings } from '../db/schema';
+import { eq, desc } from 'drizzle-orm';
+import { StooqClient } from './stooq.client';
+import { AlphaVantageClient } from './alphavantage.client';
+
+export interface LatestSecurityPrice {
+  ticker: string;
+  closeCents: number | null;
+  priceDate: string | null;
+  currency: string;
+  source: string | null;
+  fetchedAt: string | null;
+}
+
+@Injectable()
+export class SecurityPricesService {
+  private readonly logger = new Logger(SecurityPricesService.name);
+
+  constructor(
+    @Inject(DATABASE_CONNECTION) private readonly db: any,
+    private readonly stooq: StooqClient,
+    private readonly alphaVantage: AlphaVantageClient,
+  ) {}
+
+  /** Distinct tickers currently held by any user — the only ones we ever fetch. */
+  async heldTickers(): Promise<string[]> {
+    const rows = await this.db
+      .selectDistinct({ ticker: investmentHoldings.ticker })
+      .from(investmentHoldings);
+    return rows.map((r: any) => r.ticker as string);
+  }
+
+  /**
+   * Refresh EOD closes for every currently-held ticker: Stooq first, Alpha Vantage
+   * as fallback (needed for mutual-fund NAVs Stooq doesn't cover). An outage on one
+   * ticker/provider must never break the others, and never overwrites good history
+   * with nothing — on total failure the last stored price simply stays latest.
+   */
+  async refreshAll(): Promise<{ refreshed: string[]; failed: string[] }> {
+    const tickers = await this.heldTickers();
+    const refreshed: string[] = [];
+    const failed: string[] = [];
+
+    for (const ticker of tickers) {
+      try {
+        const wrote = await this.refreshOne(ticker);
+        if (wrote) refreshed.push(ticker);
+        else failed.push(ticker); // both providers came back empty (outage / unknown ticker)
+      } catch (err: any) {
+        this.logger.error(`security price refresh failed for ${ticker}: ${err.message}`);
+        failed.push(ticker);
+      }
+    }
+    return { refreshed, failed };
+  }
+
+  private async refreshOne(ticker: string): Promise<boolean> {
+    let point = await this.stooq.fetchLatestClose(ticker);
+    let source = 'stooq';
+    if (!point) {
+      point = await this.alphaVantage.fetchLatestClose(ticker);
+      source = 'alphavantage';
+    }
+    if (!point) return false;
+
+    await this.db
+      .insert(securityPrices)
+      .values({
+        ticker,
+        priceDate: point.date,
+        closeCents: point.closeCents,
+        currency: point.currency,
+        source,
+        fetchedAt: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: [securityPrices.ticker, securityPrices.priceDate],
+        set: { closeCents: point.closeCents, source, fetchedAt: new Date() },
+      });
+    return true;
+  }
+
+  /**
+   * Latest known close for a ticker regardless of how stale it is — a provider
+   * outage must serve the last known price with its real date attached, never a
+   * silent/wrong "current" claim.
+   */
+  async getLatest(ticker: string): Promise<LatestSecurityPrice> {
+    const rows = await this.db
+      .select()
+      .from(securityPrices)
+      .where(eq(securityPrices.ticker, ticker))
+      .orderBy(desc(securityPrices.priceDate))
+      .limit(1);
+    const row = rows[0];
+    if (!row) {
+      return {
+        ticker,
+        closeCents: null,
+        priceDate: null,
+        currency: 'USD',
+        source: null,
+        fetchedAt: null,
+      };
+    }
+    return {
+      ticker,
+      closeCents: row.closeCents,
+      priceDate: String(row.priceDate),
+      currency: row.currency,
+      source: row.source,
+      fetchedAt: row.fetchedAt ? new Date(row.fetchedAt).toISOString() : null,
+    };
+  }
+
+  async getLatestForTickers(tickers: string[]): Promise<Map<string, LatestSecurityPrice>> {
+    const uniq = Array.from(new Set(tickers));
+    const entries = await Promise.all(uniq.map(async (t) => [t, await this.getLatest(t)] as const));
+    return new Map(entries);
+  }
+}

--- a/apps/api/src/market-data/stooq.client.ts
+++ b/apps/api/src/market-data/stooq.client.ts
@@ -1,0 +1,70 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+/** One EOD close for a ticker. */
+export interface SecurityPricePoint {
+  date: string; // "YYYY-MM-DD"
+  closeCents: number;
+  currency: string;
+}
+
+const STOOQ_BASE_URL = 'https://stooq.com/q/d/l/';
+
+/**
+ * Client for Stooq's free, keyless EOD CSV endpoint (https://stooq.com/db/h/).
+ * Primary provider for stocks/ETFs — no API key, no rate-limit account to manage.
+ * Does NOT cover mutual-fund NAVs (e.g. VTSAX) — see AlphaVantageClient for those.
+ */
+@Injectable()
+export class StooqClient {
+  private readonly logger = new Logger(StooqClient.name);
+  private readonly timeoutMs = 15_000;
+
+  /**
+   * Fetch the most recent EOD close for a ticker. Never throws — an outage or
+   * unknown ticker must never break a caller; returns null on any failure so the
+   * service falls back to the last stored price.
+   */
+  async fetchLatestClose(ticker: string): Promise<SecurityPricePoint | null> {
+    const url = new URL(STOOQ_BASE_URL);
+    // Stooq expects lower-case US tickers suffixed ".us" for US-listed equities/ETFs.
+    url.searchParams.set('s', `${ticker.toLowerCase()}.us`);
+    url.searchParams.set('i', 'd');
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const res = await fetch(url.toString(), { signal: controller.signal });
+      if (!res.ok) {
+        this.logger.error(`Stooq ${ticker} returned ${res.status}`);
+        return null;
+      }
+      const text = await res.text();
+      return parseStooqCsv(text);
+    } catch (err: any) {
+      this.logger.error(`Stooq ${ticker} fetch failed: ${err.message}`);
+      return null;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+/**
+ * Parse Stooq's CSV response (`Date,Open,High,Low,Close,Volume`, header row first,
+ * ascending date order). Returns the latest row's close, or null for an unknown
+ * ticker (Stooq responds with the literal body `N/D`).
+ */
+export function parseStooqCsv(csv: string): SecurityPricePoint | null {
+  const lines = csv.trim().split('\n').filter(Boolean);
+  if (lines.length < 2) return null; // header only, or "N/D"
+  const last = lines[lines.length - 1].split(',');
+  if (last.length < 5) return null;
+  const [date, , , , closeStr] = last;
+  const close = Number(closeStr);
+  if (!date || !Number.isFinite(close)) return null;
+  return {
+    date,
+    closeCents: Math.round(close * 100),
+    currency: 'USD',
+  };
+}

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -26,6 +26,8 @@ import { registerGetSavingsRate } from './tools/get-savings-rate.js';
 import { registerGetCashRunway } from './tools/get-cash-runway.js';
 import { registerGetSubscriptionTotal } from './tools/get-subscription-total.js';
 import { registerGetYoyComparison } from './tools/get-yoy-comparison.js';
+import { registerGetPortfolioValue } from './tools/get-portfolio-value.js';
+import { registerGetAllocation } from './tools/get-allocation.js';
 import { close } from './db.js';
 import http from 'node:http';
 
@@ -59,6 +61,8 @@ registerGetSavingsRate(server);
 registerGetCashRunway(server);
 registerGetSubscriptionTotal(server);
 registerGetYoyComparison(server);
+registerGetPortfolioValue(server);
+registerGetAllocation(server);
 
 const mode = process.argv.includes('--sse') ? 'sse' : 'stdio';
 

--- a/apps/mcp-server/src/tools/__tests__/get-allocation.spec.ts
+++ b/apps/mcp-server/src/tools/__tests__/get-allocation.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const queryMock = vi.fn();
+const getUserIdMock = vi.fn().mockResolvedValue('user-1');
+
+vi.mock('../../db.js', () => ({
+  query: (...args: any[]) => queryMock(...args),
+  getUserId: () => getUserIdMock(),
+}));
+
+const { registerGetAllocation } = await import('../get-allocation.js');
+
+function makeServer() {
+  let handler: (params: any) => Promise<any>;
+  const server = {
+    tool: (_name: string, _desc: string, _schema: any, fn: any) => {
+      handler = fn;
+    },
+  } as any;
+  registerGetAllocation(server);
+  return (params: any = {}) => handler(params);
+}
+
+describe('get_allocation', () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+  });
+
+  it('matches a hand-calculated expectation for a synthetic multi-holding portfolio', async () => {
+    // Synthetic two-holding portfolio: 100 x $200 = $20,000 (ticker A) and
+    // 50 x $400 = $20,000 (ticker B) -> 50%/50% split, hand-calculated.
+    queryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM investment_holdings')) {
+        return [
+          { ticker: 'AAA', share_count: '100', as_of: '2026-07-01' },
+          { ticker: 'BBB', share_count: '50', as_of: '2026-07-01' },
+        ];
+      }
+      if (sql.includes('FROM security_prices')) {
+        return [
+          { ticker: 'AAA', price_date: '2026-07-01', close_cents: 20000 },
+          { ticker: 'BBB', price_date: '2026-07-01', close_cents: 40000 },
+        ];
+      }
+      return [];
+    });
+
+    const call = makeServer();
+    const result = await call({});
+    const text = result.content[0].text;
+
+    expect(text).toContain('AAA: 50.00%');
+    expect(text).toContain('BBB: 50.00%');
+    expect(text).toContain('#120'); // no target-allocation drift yet — TODO references the issue
+  });
+
+  it('surfaces a dataCaveat when holdings are stale', async () => {
+    queryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM investment_holdings')) {
+        return [{ ticker: 'AAA', share_count: '100', as_of: '2020-01-01' }];
+      }
+      if (sql.includes('FROM security_prices')) {
+        return [{ ticker: 'AAA', price_date: '2020-01-01', close_cents: 20000 }];
+      }
+      return [];
+    });
+
+    const call = makeServer();
+    const result = await call({});
+    expect(result.content[0].text).toContain('dataCaveat');
+  });
+});

--- a/apps/mcp-server/src/tools/__tests__/get-portfolio-value.spec.ts
+++ b/apps/mcp-server/src/tools/__tests__/get-portfolio-value.spec.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const queryMock = vi.fn();
+const getUserIdMock = vi.fn().mockResolvedValue('user-1');
+
+vi.mock('../../db.js', () => ({
+  query: (...args: any[]) => queryMock(...args),
+  getUserId: () => getUserIdMock(),
+}));
+
+// Import after mocking so the tool picks up the mocked db module.
+const { registerGetPortfolioValue } = await import('../get-portfolio-value.js');
+
+function makeServer() {
+  let handler: (params: any) => Promise<any>;
+  const server = {
+    tool: (_name: string, _desc: string, _schema: any, fn: any) => {
+      handler = fn;
+    },
+  } as any;
+  registerGetPortfolioValue(server);
+  return (params: any = {}) => handler(params);
+}
+
+describe('get_portfolio_value', () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+  });
+
+  it('sums shares x latest close within one EOD close of the hand-calculated expectation', async () => {
+    // 100 shares of a synthetic VTI-like ticker declared as-of 2026-07-01, with a
+    // recorded EOD close near that date — matches the 12.2 acceptance scenario.
+    queryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM investment_holdings')) {
+        return [
+          {
+            investment_account_id: 'acc-1',
+            nickname: 'Brokerage',
+            ticker: 'VTI',
+            share_count: '100',
+            as_of: '2026-07-01',
+          },
+        ];
+      }
+      if (sql.includes('FROM security_prices')) {
+        return [{ ticker: 'VTI', price_date: '2026-07-01', close_cents: 25000, source: 'stooq' }];
+      }
+      return [];
+    });
+
+    const call = makeServer();
+    const result = await call({});
+    const text = result.content[0].text;
+
+    expect(text).toContain('Total portfolio value: $25000.00'); // 100 shares x $250.00
+    expect(text).toContain('2026-07-01'); // price date surfaced
+    expect(text).not.toContain('dataCaveat');
+  });
+
+  it('serves the last known price with its visible date during a provider outage — never a silent current claim', async () => {
+    queryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM investment_holdings')) {
+        return [
+          {
+            investment_account_id: 'acc-1',
+            nickname: 'Brokerage',
+            ticker: 'VTI',
+            share_count: '100',
+            as_of: '2026-07-15',
+          },
+        ];
+      }
+      if (sql.includes('FROM security_prices')) {
+        // Stale price — last refresh succeeded weeks ago, then the provider went down.
+        return [{ ticker: 'VTI', price_date: '2026-06-20', close_cents: 24000, source: 'stooq' }];
+      }
+      return [];
+    });
+
+    const call = makeServer();
+    const result = await call({});
+    const text = result.content[0].text;
+
+    expect(text).toContain('close on 2026-06-20'); // real (stale) date visibly attached
+    expect(text).toContain('Total portfolio value: $24000.00');
+  });
+
+  it('surfaces a dataCaveat when holdings are older than the staleness threshold', async () => {
+    queryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM investment_holdings')) {
+        return [
+          {
+            investment_account_id: 'acc-1',
+            nickname: 'Brokerage',
+            ticker: 'VTI',
+            share_count: '100',
+            as_of: '2020-01-01', // far older than the 90-day default threshold
+          },
+        ];
+      }
+      if (sql.includes('FROM security_prices')) {
+        return [{ ticker: 'VTI', price_date: '2020-01-01', close_cents: 20000, source: 'stooq' }];
+      }
+      return [];
+    });
+
+    const call = makeServer();
+    const result = await call({});
+    const text = result.content[0].text;
+
+    expect(text).toContain('dataCaveat');
+    expect(text).toContain('older than');
+  });
+
+  it('reports no holdings declared when the user has none', async () => {
+    queryMock.mockResolvedValue([]);
+    const call = makeServer();
+    const result = await call({});
+    expect(result.content[0].text).toContain('No investment holdings declared yet.');
+  });
+});

--- a/apps/mcp-server/src/tools/get-allocation.ts
+++ b/apps/mcp-server/src/tools/get-allocation.ts
@@ -1,0 +1,116 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { query, getUserId } from '../db.js';
+
+const HOLDINGS_STALE_DAYS = Number(process.env.HOLDINGS_STALE_DAYS) || 90;
+
+interface HoldingRow {
+  ticker: string;
+  share_count: string;
+  as_of: string;
+}
+
+interface PriceRow {
+  ticker: string;
+  price_date: string;
+  close_cents: number;
+}
+
+/**
+ * Portfolio allocation: percent of total market value by ticker.
+ *
+ * TODO(#120): once suitability-settings/target-allocation lands, add per-asset-class
+ * target percentages here and surface drift (actual - target) per class. That
+ * feature doesn't exist in this codebase yet, so this tool only computes actual
+ * percentages for now.
+ */
+export function registerGetAllocation(server: McpServer) {
+  server.tool(
+    'get_allocation',
+    'Portfolio allocation: percent of total market value held in each ticker. Answers "how diversified am I" and "what percent of my portfolio is X".',
+    {},
+    async () => {
+      const userId = await getUserId();
+
+      const holdings = await query<HoldingRow>(
+        `SELECT DISTINCT ON (h.investment_account_id, h.ticker)
+           h.ticker, h.share_count::text AS share_count, h.as_of::text AS as_of
+         FROM investment_holdings h
+         JOIN investment_accounts ia ON ia.id = h.investment_account_id
+         WHERE ia.user_id = $1 AND ia.deleted_at IS NULL
+         ORDER BY h.investment_account_id, h.ticker, h.as_of DESC, h.created_at DESC`,
+        [userId],
+      );
+
+      if (holdings.length === 0) {
+        return {
+          content: [{ type: 'text' as const, text: 'No investment holdings declared yet.' }],
+        };
+      }
+
+      const tickers = Array.from(new Set(holdings.map((h) => h.ticker)));
+      const prices = await query<PriceRow>(
+        `SELECT DISTINCT ON (ticker) ticker, price_date::text AS price_date, close_cents
+         FROM security_prices
+         WHERE ticker = ANY($1)
+         ORDER BY ticker, price_date DESC`,
+        [tickers],
+      );
+      const priceByTicker = new Map(prices.map((p) => [p.ticker, p]));
+
+      // Sum market value per ticker (a ticker can appear across multiple accounts).
+      const valueByTicker = new Map<string, number>();
+      let staleFound = false;
+      let missingPriceFound = false;
+      const now = Date.now();
+
+      for (const h of holdings) {
+        if (now - new Date(h.as_of).getTime() > HOLDINGS_STALE_DAYS * 24 * 3600_000) {
+          staleFound = true;
+        }
+        const price = priceByTicker.get(h.ticker);
+        if (!price) {
+          missingPriceFound = true;
+          continue;
+        }
+        const value = Number(h.share_count) * price.close_cents;
+        valueByTicker.set(h.ticker, (valueByTicker.get(h.ticker) ?? 0) + value);
+      }
+
+      const totalCents = Array.from(valueByTicker.values()).reduce((a, b) => a + b, 0);
+      if (totalCents === 0) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: 'No priced holdings yet — cannot compute allocation.',
+            },
+          ],
+        };
+      }
+
+      const lines: string[] = [];
+      const sorted = Array.from(valueByTicker.entries()).sort((a, b) => b[1] - a[1]);
+      for (const [ticker, valueCents] of sorted) {
+        const pct = (valueCents / totalCents) * 100;
+        lines.push(`${ticker}: ${pct.toFixed(2)}% ($${(valueCents / 100).toFixed(2)})`);
+      }
+      lines.push(
+        '(Allocation by asset class with target-vs-actual drift is not yet available — ' +
+          'see issue #120 for the suitability-settings/target-allocation feature this depends on.)',
+      );
+
+      if (staleFound) {
+        lines.push(
+          `dataCaveat: one or more holdings are older than ${HOLDINGS_STALE_DAYS} days — allocation may not reflect current reality.`,
+        );
+      }
+      if (missingPriceFound) {
+        lines.push(
+          `dataCaveat: no price data yet for one or more held tickers — those holdings are excluded from this breakdown.`,
+        );
+      }
+
+      return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
+    },
+  );
+}

--- a/apps/mcp-server/src/tools/get-portfolio-value.ts
+++ b/apps/mcp-server/src/tools/get-portfolio-value.ts
@@ -1,0 +1,111 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { query, getUserId } from '../db.js';
+
+/** Holdings older than this trigger a dataCaveat on any fact derived from them
+ * (12.2 spec). Mirrors DEFAULT_HOLDINGS_STALE_DAYS in the API's investments module. */
+const HOLDINGS_STALE_DAYS = Number(process.env.HOLDINGS_STALE_DAYS) || 90;
+
+interface HoldingRow {
+  investment_account_id: string;
+  nickname: string;
+  ticker: string;
+  share_count: string;
+  as_of: string;
+}
+
+interface PriceRow {
+  ticker: string;
+  price_date: string;
+  close_cents: number;
+  source: string;
+}
+
+/**
+ * Portfolio market value: shares × latest close per holding, summed. Both the
+ * price date and the holdings as-of date are always surfaced next to each other —
+ * never silently mixing a stale price with fresh holdings or vice versa.
+ */
+export function registerGetPortfolioValue(server: McpServer) {
+  server.tool(
+    'get_portfolio_value',
+    'Total investment portfolio market value (shares x latest EOD close, per holding and account), with the price date and holdings as-of date both shown. Answers "what is my portfolio worth".',
+    {},
+    async () => {
+      const userId = await getUserId();
+
+      const holdings = await query<HoldingRow>(
+        `SELECT DISTINCT ON (h.investment_account_id, h.ticker)
+           h.investment_account_id, ia.nickname, h.ticker, h.share_count::text AS share_count,
+           h.as_of::text AS as_of
+         FROM investment_holdings h
+         JOIN investment_accounts ia ON ia.id = h.investment_account_id
+         WHERE ia.user_id = $1 AND ia.deleted_at IS NULL
+         ORDER BY h.investment_account_id, h.ticker, h.as_of DESC, h.created_at DESC`,
+        [userId],
+      );
+
+      if (holdings.length === 0) {
+        return {
+          content: [
+            { type: 'text' as const, text: 'No investment holdings declared yet.' },
+          ],
+        };
+      }
+
+      const tickers = Array.from(new Set(holdings.map((h) => h.ticker)));
+      const prices = await query<PriceRow>(
+        `SELECT DISTINCT ON (ticker) ticker, price_date::text AS price_date,
+                close_cents, source
+         FROM security_prices
+         WHERE ticker = ANY($1)
+         ORDER BY ticker, price_date DESC`,
+        [tickers],
+      );
+      const priceByTicker = new Map(prices.map((p) => [p.ticker, p]));
+
+      const now = Date.now();
+      let totalCents = 0;
+      let staleFound = false;
+      let missingPriceFound = false;
+      const lines: string[] = [];
+
+      for (const h of holdings) {
+        const price = priceByTicker.get(h.ticker);
+        const isStale =
+          now - new Date(h.as_of).getTime() > HOLDINGS_STALE_DAYS * 24 * 3600_000;
+        if (isStale) staleFound = true;
+
+        if (!price) {
+          missingPriceFound = true;
+          lines.push(
+            `${h.ticker} (${h.nickname}): ${h.share_count} shares as of ${h.as_of} — no price data yet`,
+          );
+          continue;
+        }
+        const marketValueCents = Math.round(Number(h.share_count) * price.close_cents);
+        totalCents += marketValueCents;
+        lines.push(
+          `${h.ticker} (${h.nickname}): ${h.share_count} shares as of ${h.as_of} x ` +
+            `$${(price.close_cents / 100).toFixed(2)} close on ${price.price_date} (${price.source}) ` +
+            `= $${(marketValueCents / 100).toFixed(2)}`,
+        );
+      }
+
+      lines.push(`Total portfolio value: $${(totalCents / 100).toFixed(2)}`);
+
+      if (staleFound) {
+        lines.push(
+          `dataCaveat: one or more holdings are older than ${HOLDINGS_STALE_DAYS} days ` +
+            `(declared share counts may no longer reflect reality) — please refresh them.`,
+        );
+      }
+      if (missingPriceFound) {
+        lines.push(
+          `dataCaveat: no price data yet for one or more held tickers — those holdings are excluded from the total above.`,
+        );
+      }
+
+      return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
+    },
+  );
+}

--- a/db/migrations/0026_investment_holdings_security_prices.sql
+++ b/db/migrations/0026_investment_holdings_security_prices.sql
@@ -1,0 +1,35 @@
+-- 12.2 Holdings & security prices: user-declared ticker/share-count holdings and
+-- autonomous EOD price history (Stooq primary, Alpha Vantage fallback for mutual-fund
+-- NAVs). Both append-only, same history-kept pattern as investment_snapshots.
+
+CREATE TABLE IF NOT EXISTS "investment_holdings" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "investment_account_id" uuid NOT NULL REFERENCES "investment_accounts"("id"),
+  "ticker" varchar(20) NOT NULL,
+  "share_count" numeric(20, 6) NOT NULL,
+  "as_of" date NOT NULL,
+  "notes" varchar(500),
+  "created_at" timestamp WITH TIME ZONE NOT NULL DEFAULT now(),
+  "updated_at" timestamp WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "idx_investment_holdings_account"
+  ON "investment_holdings" ("investment_account_id", "ticker", "as_of" DESC);
+
+-- Global (not user-scoped) — same public-time-series shape as market_metrics.
+-- Only tickers actually held are fetched (see SecurityPricesService).
+CREATE TABLE IF NOT EXISTS "security_prices" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "ticker" varchar(20) NOT NULL,
+  "price_date" date NOT NULL,
+  "close_cents" integer NOT NULL,
+  "currency" varchar(8) NOT NULL DEFAULT 'USD',
+  "source" varchar(16) NOT NULL,
+  "fetched_at" timestamp WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_security_prices_ticker_date"
+  ON "security_prices" ("ticker", "price_date");
+
+CREATE INDEX IF NOT EXISTS "idx_security_prices_ticker_latest"
+  ON "security_prices" ("ticker", "price_date" DESC);

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1784560300000,
       "tag": "0025_recommendation_layer",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1784560400000,
+      "tag": "0026_investment_holdings_security_prices",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -439,3 +439,25 @@ export interface InvestmentSnapshot {
   balanceCents: number;
   createdAt: string;
 }
+
+/** User-declared ticker + share count as-of a date. Append-only: an edit is a new row. */
+export interface InvestmentHolding {
+  id: string;
+  investmentAccountId: string;
+  ticker: string;
+  shareCount: string;
+  asOf: string;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** One EOD close price for a ticker, from an autonomous market-data refresh. */
+export interface SecurityPrice {
+  ticker: string;
+  priceDate: string;
+  closeCents: number;
+  currency: string;
+  source: string;
+  fetchedAt: string;
+}

--- a/packages/shared/src/validation/index.ts
+++ b/packages/shared/src/validation/index.ts
@@ -341,6 +341,24 @@ export type CreateInvestmentAccountInput = z.infer<typeof createInvestmentAccoun
 export type UpdateInvestmentAccountInput = z.infer<typeof updateInvestmentAccountSchema>;
 export type AddSnapshotInput = z.infer<typeof addSnapshotSchema>;
 
+// ── Investment Holdings (12.2) ───────────────────────────────
+// User-declared ticker + share count as-of a date. Edits APPEND a new row
+// (history kept) — same append-only pattern as investment snapshots above.
+
+export const addHoldingSchema = z.object({
+  ticker: z
+    .string()
+    .trim()
+    .min(1)
+    .max(20)
+    .transform((s) => s.toUpperCase()),
+  shareCount: z.number().positive(),
+  asOf: z.iso.date(),
+  notes: z.string().max(500).optional(),
+});
+
+export type AddHoldingInput = z.infer<typeof addHoldingSchema>;
+
 // ── Loans (mortgage / auto payoff tracker) ───────────────────
 
 export const createLoanSchema = z.object({


### PR DESCRIPTION
Committed successfully. Summary of the work:

## Summary

Implemented issue #118 (12.2 Holdings & security prices) backend, following the established #104 market-data module pattern:

**Schema (migration 0026):**
- `investment_holdings` — user-declared ticker/share-count, append-only history (edits insert a new row, same pattern as `investment_snapshots`)
- `security_prices` — global EOD closes, unique on `(ticker, price_date)`

**Price adapters:** `StooqClient` (primary, free/keyless CSV feed) and `AlphaVantageClient` (fallback for mutual-fund NAVs like VTSAX, needs `ALPHAVANTAGE_API_KEY`, respects rate-limit responses). `SecurityPricesService` fetches only tickers actually held, tries Stooq then Alpha Vantage, and on total outage simply leaves the last stored price as latest — never fabricates or silently mixes stale data. Wired into the daily cron alongside the existing market-data refresh, with the same jitter convention.

**Holdings CRUD:** added to the existing `InvestmentsService`/`InvestmentsController` (`POST`/`GET /investments/:id/holdings`), owner-scoped like the existing snapshot endpoints.

**MCP tools:** `get_portfolio_value` and `get_allocation`, added to the advisor tool allowlist. Both always surface the price date next to the holdings as-of date, and emit a visible `dataCaveat` when holdings exceed `HOLDINGS_STALE_DAYS` (default 90) or when a held ticker has no price yet. `get_allocation` computes percent-by-ticker only, with a TODO referencing #120 for target/drift comparison since that suitability-settings feature isn't in the codebase yet.

**Tests:** all use recorded fixtures (synthetic prices/tickers, no live calls) covering: portfolio-value math against a hand-calculated expectation, outage → last-known-price-with-real-date, allocation percentages against a hand-calculated multi-holding split, and the stale-holdings dataCaveat. Full `apps/api` (655) and `apps/mcp-server` (134) suites pass, and both packages build cleanly via `tsc`/`nest build

_(summary truncated)_

---
### Test evidence
**25 new test case(s) added** (heuristic count):
```
 .../advisor/__tests__/mcp-client.service.spec.ts   |   2 +
 .../__tests__/investments.service.spec.ts          |  52 +++++++++
 .../__tests__/alphavantage.client.spec.ts          |  58 ++++++++++
 .../__tests__/security-prices.service.spec.ts      | 115 +++++++++++++++++++
 .../src/market-data/__tests__/stooq.client.spec.ts |  57 ++++++++++
 .../src/tools/__tests__/get-allocation.spec.ts     |  72 ++++++++++++
 .../tools/__tests__/get-portfolio-value.spec.ts    | 121 ++++++++++++++++++++
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- n/a (no check configured) `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
pi:test: [22m[39m[11.10 NN categorization accuracy] held-out=4 predicted=3 correct=3 precision=100%
@moneypulse/api:test: 
@moneypulse/api:test:  [32m✓[39m src/embeddings/__tests__/embedding-categorizer.service.spec.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 8[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/analytics/__tests__/budget-plan.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 4[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/categorization/__tests__/learning.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/transactions/__tests__/business-date.spec.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 5[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/expected-cycle-date.spec.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/next-loan-due-date.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m77 passed[39m[22m[90m (77)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m655 passed[39m[22m[90m (655)[39m
@moneypulse/api:test: [2m   Start at [22m 00:26:53
@moneypulse/api:test: [2m   Duration [22m 10.87s[2m (transform 3.26s, setup 0ms, import 56.48s, tests 1.93s, environment 7ms)[22m
@moneypulse/api:test: 

 Tasks:    3 successful, 3 total
Cached:    1 cached, 3 total
  Time:    11.436s
```
</details>

### Review
**Review verdict:** approve

Findings (advisory — did not block landing):
- [low/advisory] apps/api/src/db/schema.ts:700 — Drizzle schema declares only a non-unique index on security_prices(ticker, price_date), while migration 0026 adds the uq_security_prices_ticker_date unique index that the onConflictDoUpdate upsert relies on. Runtime is correct (migration is authoritative), but the schema/migration drift risks a regenerated migration dropping the constraint the upsert needs.
- [low/advisory] apps/api/src/investments/investments.service.ts:19 — DEFAULT_HOLDINGS_STALE_DAYS is exported but the staleness logic actually lives in the MCP tools (HOLDINGS_STALE_DAYS); the API constant appears unused.
- [low/advisory] packages/shared/src/validation/index.ts:348 — addHoldingSchema does not constrain ticker character set (only trim/min/max/uppercase); arbitrary characters could be stored. Safe today because URL encoding neutralizes it, but a format guard (e.g. /^[A-Z0-9.\-]+$/) would be more robust.
- [low/advisory] db/migrations/0026_investment_holdings_security_prices.sql:15 — investment_holdings index column direction differs between drizzle schema (as_of asc) and migration (as_of DESC) — cosmetic drift only.

---
Dispatched via coxd (`MyMoney-12-2-holdings-security-price-1784678979`) · cost $3.473 · 🤖 coxd