### PR TITLE
Add the missing Investments-page UI for declaring/editing holdings (fo

### DIFF
--- a/apps/api/src/investments/__tests__/investments.service.spec.ts
+++ b/apps/api/src/investments/__tests__/investments.service.spec.ts
@@ -174,6 +174,93 @@ describe('InvestmentsService', () => {
     });
   });
 
+  describe('getPortfolioValue', () => {
+    it('returns zero total with no holdings when the user has none', async () => {
+      mockDb.execute.mockResolvedValue({ rows: [] });
+      const result = await service.getPortfolioValue(userId);
+      expect(result).toEqual({
+        totalCents: 0,
+        holdings: [],
+        staleFound: false,
+        missingPriceFound: false,
+        staleDays: 90,
+      });
+    });
+
+    it('computes market value as shares x latest close and flags stale/missing-price holdings', async () => {
+      const recentDate = new Date().toISOString().slice(0, 10);
+      const staleDate = '2020-01-01';
+      mockDb.execute
+        // getCurrentHoldings query
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              investment_account_id: accountId,
+              ticker: 'AAA',
+              share_count: '10',
+              as_of: recentDate,
+              notes: null,
+            },
+            {
+              investment_account_id: accountId,
+              ticker: 'BBB',
+              share_count: '5',
+              as_of: staleDate,
+              notes: null,
+            },
+          ],
+        })
+        // security_prices query — only AAA has a price
+        .mockResolvedValueOnce({
+          rows: [{ ticker: 'AAA', price_date: recentDate, close_cents: 1000, source: 'test' }],
+        });
+
+      const result = await service.getPortfolioValue(userId, 90);
+      expect(result.totalCents).toBe(10 * 1000);
+      expect(result.staleFound).toBe(true);
+      expect(result.missingPriceFound).toBe(true);
+      const bbb = result.holdings.find((h: any) => h.ticker === 'BBB');
+      expect(bbb.marketValueCents).toBeNull();
+      expect(bbb.isStale).toBe(true);
+    });
+  });
+
+  describe('getAllocation', () => {
+    it('computes percent of total value per ticker, excluding unpriced holdings', async () => {
+      const recentDate = new Date().toISOString().slice(0, 10);
+      mockDb.execute
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              investment_account_id: accountId,
+              ticker: 'AAA',
+              share_count: '10',
+              as_of: recentDate,
+              notes: null,
+            },
+            {
+              investment_account_id: accountId,
+              ticker: 'CCC',
+              share_count: '30',
+              as_of: recentDate,
+              notes: null,
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          rows: [
+            { ticker: 'AAA', price_date: recentDate, close_cents: 1000, source: 'test' },
+            { ticker: 'CCC', price_date: recentDate, close_cents: 1000, source: 'test' },
+          ],
+        });
+
+      const result = await service.getAllocation(userId);
+      expect(result.totalCents).toBe(40000);
+      const ccc = result.allocations.find((a) => a.ticker === 'CCC');
+      expect(ccc?.pct).toBeCloseTo(75);
+    });
+  });
+
   describe('getHoldings', () => {
     it('throws ForbiddenException when reading another user\'s holdings', async () => {
       mockDb.limit.mockResolvedValue([{ ...baseAccount, userId: otherId }]);

--- a/apps/api/src/investments/investments.controller.ts
+++ b/apps/api/src/investments/investments.controller.ts
@@ -42,6 +42,26 @@ export class InvestmentsController {
     return { data };
   }
 
+  /**
+   * GET /investments/portfolio/value — total portfolio market value (shares x
+   * latest EOD close) across all of the user's declared holdings.
+   * Registered before the `:id` routes so "portfolio" is never matched as an id.
+   */
+  @Get('portfolio/value')
+  @ApiOperation({ summary: 'Get total portfolio market value across all holdings' })
+  async getPortfolioValue(@CurrentUser() user: AuthTokenPayload) {
+    const data = await this.investmentsService.getPortfolioValue(user.sub);
+    return { data };
+  }
+
+  /** GET /investments/portfolio/allocation — percent of portfolio value by ticker. */
+  @Get('portfolio/allocation')
+  @ApiOperation({ summary: 'Get portfolio allocation (percent of value by ticker)' })
+  async getAllocation(@CurrentUser() user: AuthTokenPayload) {
+    const data = await this.investmentsService.getAllocation(user.sub);
+    return { data };
+  }
+
   /** POST /investments — create an investment account. */
   @Post()
   @HttpCode(201)

--- a/apps/api/src/investments/investments.service.ts
+++ b/apps/api/src/investments/investments.service.ts
@@ -212,6 +212,97 @@ export class InvestmentsService {
   }
 
   /**
+   * Portfolio market value: shares x latest EOD close, per holding, summed to a
+   * total. Mirrors the `get_portfolio_value` MCP tool's computation (same
+   * "latest holding per ticker per account" + "latest price per ticker" joins),
+   * but returns structured JSON instead of prose text so the web app can render
+   * it without a REST->MCP hop (MCP tools aren't directly callable from the web
+   * app in this codebase).
+   */
+  async getPortfolioValue(userId: string, staleDays = DEFAULT_HOLDINGS_STALE_DAYS) {
+    const holdings = await this.getCurrentHoldings(userId);
+    if (holdings.length === 0) {
+      return { totalCents: 0, holdings: [], staleFound: false, missingPriceFound: false, staleDays };
+    }
+
+    const tickers = Array.from(new Set(holdings.map((h: any) => h.ticker)));
+    const priceRows = await this.db.execute(sql`
+      SELECT DISTINCT ON (ticker) ticker, price_date::text AS price_date, close_cents, source
+      FROM ${schema.securityPrices}
+      WHERE ticker = ANY(${tickers})
+      ORDER BY ticker, price_date DESC
+    `);
+    const prices = (priceRows.rows ?? priceRows) as any[];
+    const priceByTicker = new Map(prices.map((p) => [p.ticker, p]));
+
+    const now = Date.now();
+    let totalCents = 0;
+    let staleFound = false;
+    let missingPriceFound = false;
+
+    const result = holdings.map((h: any) => {
+      const isStale = now - new Date(h.asOf).getTime() > staleDays * 24 * 3600_000;
+      if (isStale) staleFound = true;
+      const price = priceByTicker.get(h.ticker);
+      if (!price) {
+        missingPriceFound = true;
+        return {
+          investmentAccountId: h.investmentAccountId,
+          ticker: h.ticker,
+          shareCount: h.shareCount,
+          asOf: h.asOf,
+          isStale,
+          priceDate: null,
+          closeCents: null,
+          marketValueCents: null,
+        };
+      }
+      const marketValueCents = Math.round(Number(h.shareCount) * Number(price.close_cents));
+      totalCents += marketValueCents;
+      return {
+        investmentAccountId: h.investmentAccountId,
+        ticker: h.ticker,
+        shareCount: h.shareCount,
+        asOf: h.asOf,
+        isStale,
+        priceDate: String(price.price_date).slice(0, 10),
+        closeCents: Number(price.close_cents),
+        marketValueCents,
+      };
+    });
+
+    return { totalCents, holdings: result, staleFound, missingPriceFound, staleDays };
+  }
+
+  /**
+   * Portfolio allocation: percent of total market value by ticker. Mirrors the
+   * `get_allocation` MCP tool's computation — see getPortfolioValue for why this
+   * is a structured-JSON REST wrapper rather than an MCP call from the web app.
+   */
+  async getAllocation(userId: string, staleDays = DEFAULT_HOLDINGS_STALE_DAYS) {
+    const { totalCents, holdings, staleFound, missingPriceFound } = await this.getPortfolioValue(
+      userId,
+      staleDays,
+    );
+
+    const valueByTicker = new Map<string, number>();
+    for (const h of holdings) {
+      if (h.marketValueCents == null) continue;
+      valueByTicker.set(h.ticker, (valueByTicker.get(h.ticker) ?? 0) + h.marketValueCents);
+    }
+
+    const allocations = Array.from(valueByTicker.entries())
+      .map(([ticker, valueCents]) => ({
+        ticker,
+        valueCents,
+        pct: totalCents > 0 ? (valueCents / totalCents) * 100 : 0,
+      }))
+      .sort((a, b) => b.valueCents - a.valueCents);
+
+    return { totalCents, allocations, staleFound, missingPriceFound, staleDays };
+  }
+
+  /**
    * Verify account exists, is not deleted, and belongs to userId.
    */
   private async assertOwnership(userId: string, accountId: string) {

--- a/apps/web/src/__tests__/investment-holdings.spec.tsx
+++ b/apps/web/src/__tests__/investment-holdings.spec.tsx
@@ -1,0 +1,150 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import InvestmentsPage from '@/app/(protected)/investments/page';
+
+// ── Synthetic fixtures (no real financial data) ──────────────
+
+const account = {
+  id: 'acct-synthetic-1',
+  userId: 'user-synthetic-1',
+  institution: 'Synthetic Brokerage',
+  accountType: 'brokerage',
+  nickname: 'Test Brokerage',
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  deletedAt: null,
+  latestBalanceCents: 500000,
+  latestSnapshotDate: '2026-07-01',
+};
+
+const holdingFresh = {
+  id: 'hold-1',
+  investmentAccountId: account.id,
+  ticker: 'ZZZ',
+  shareCount: '10',
+  asOf: '2026-07-15',
+  notes: 'synthetic test holding',
+  createdAt: '2026-07-15T00:00:00Z',
+  updatedAt: '2026-07-15T00:00:00Z',
+};
+
+const holdingOlder = {
+  id: 'hold-0',
+  investmentAccountId: account.id,
+  ticker: 'ZZZ',
+  shareCount: '5',
+  asOf: '2026-06-01',
+  notes: null,
+  createdAt: '2026-06-01T00:00:00Z',
+  updatedAt: '2026-06-01T00:00:00Z',
+};
+
+const mockAddHoldingMutate = vi.fn();
+
+vi.mock('@/lib/hooks/useInvestments', () => ({
+  useInvestments: () => ({ data: [account], isLoading: false }),
+  useCreateInvestment: () => ({ mutate: vi.fn(), isPending: false }),
+  useDeleteInvestment: () => ({ mutate: vi.fn(), isPending: false }),
+  useAddSnapshot: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock('@/lib/hooks/useHoldings', () => ({
+  useHoldings: () => ({ data: [holdingFresh, holdingOlder], isLoading: false }),
+  useAddHolding: () => ({ mutate: mockAddHoldingMutate, isPending: false }),
+  usePortfolioValue: () => ({
+    data: {
+      totalCents: 123400,
+      holdings: [
+        {
+          investmentAccountId: account.id,
+          ticker: 'ZZZ',
+          shareCount: '10',
+          asOf: '2026-07-15',
+          isStale: false,
+          priceDate: '2026-07-20',
+          closeCents: 12340,
+          marketValueCents: 123400,
+        },
+      ],
+      staleFound: true,
+      missingPriceFound: false,
+      staleDays: 90,
+    },
+    isLoading: false,
+  }),
+  useAllocation: () => ({
+    data: {
+      totalCents: 123400,
+      allocations: [{ ticker: 'ZZZ', valueCents: 123400, pct: 100 }],
+      staleFound: true,
+      missingPriceFound: false,
+      staleDays: 90,
+    },
+    isLoading: false,
+  }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+function renderWithQuery(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
+
+beforeEach(() => {
+  mockAddHoldingMutate.mockClear();
+});
+
+describe('Investments page — holdings UI', () => {
+  it('shows portfolio value and allocation with a staleness caveat', () => {
+    renderWithQuery(<InvestmentsPage />);
+    expect(screen.getByText('Portfolio value (declared holdings)')).toBeInTheDocument();
+    expect(screen.getByText('$1,234.00')).toBeInTheDocument();
+    expect(screen.getByText('ZZZ')).toBeInTheDocument();
+    expect(screen.getByText('100.0%')).toBeInTheDocument();
+    expect(screen.getByText(/older than 90 days/)).toBeInTheDocument();
+  });
+
+  it('expands to show holdings history newest-first for an account', () => {
+    renderWithQuery(<InvestmentsPage />);
+    fireEvent.click(screen.getByText('Show holdings'));
+    // Both history rows render (append-only history, not just current value)
+    expect(screen.getByText('10 shares')).toBeInTheDocument();
+    expect(screen.getByText('5 shares')).toBeInTheDocument();
+    expect(screen.getByText('synthetic test holding')).toBeInTheDocument();
+  });
+
+  it('opens the declare-holding form and submits ticker/shares/as-of date', async () => {
+    renderWithQuery(<InvestmentsPage />);
+    fireEvent.click(screen.getByRole('button', { name: 'Holding' }));
+
+    const tickerInput = screen.getByPlaceholderText('e.g. VTI');
+    fireEvent.change(tickerInput, { target: { value: 'abc' } });
+    const sharesInput = screen.getByPlaceholderText('0');
+    fireEvent.change(sharesInput, { target: { value: '42' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Holding' }));
+
+    await waitFor(() => expect(mockAddHoldingMutate).toHaveBeenCalledTimes(1));
+    const [payload] = mockAddHoldingMutate.mock.calls[0];
+    expect(payload.ticker).toBe('abc');
+    expect(payload.shareCount).toBe(42);
+    expect(payload.asOf).toBeTruthy();
+  });
+
+  it('rejects a non-positive share count without calling the mutation', async () => {
+    renderWithQuery(<InvestmentsPage />);
+    fireEvent.click(screen.getByRole('button', { name: 'Holding' }));
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. VTI'), { target: { value: 'abc' } });
+    fireEvent.change(screen.getByPlaceholderText('0'), { target: { value: '0' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save Holding' }));
+
+    expect(await screen.findByText('Enter a positive share count')).toBeInTheDocument();
+    expect(mockAddHoldingMutate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/(protected)/investments/page.tsx
+++ b/apps/web/src/app/(protected)/investments/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { TrendingUp, Plus, RefreshCw, Trash2, X } from 'lucide-react';
+import { TrendingUp, Plus, RefreshCw, Trash2, X, ChevronDown, ChevronUp, AlertTriangle } from 'lucide-react';
 import { toast } from 'sonner';
 import {
   useInvestments,
@@ -9,7 +9,13 @@ import {
   useDeleteInvestment,
   useAddSnapshot,
 } from '@/lib/hooks/useInvestments';
-import { formatCents } from '@/lib/format';
+import {
+  useHoldings,
+  useAddHolding,
+  usePortfolioValue,
+  useAllocation,
+} from '@/lib/hooks/useHoldings';
+import { formatCents, formatDate } from '@/lib/format';
 import type { InvestmentAccount } from '@moneypulse/shared';
 
 const ACCOUNT_TYPES = [
@@ -233,18 +239,261 @@ function UpdateValueModal({
   );
 }
 
+// ── Add Holding Modal ────────────────────────────────────────
+
+function AddHoldingModal({
+  account,
+  onClose,
+}: {
+  account: InvestmentAccount;
+  onClose: () => void;
+}) {
+  const addHolding = useAddHolding(account.id);
+  const [ticker, setTicker] = useState('');
+  const [shareCountStr, setShareCountStr] = useState('');
+  const [asOf, setAsOf] = useState(new Date().toLocaleDateString('en-CA'));
+  const [notes, setNotes] = useState('');
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  function validate() {
+    const e: Record<string, string> = {};
+    if (!ticker.trim()) e.ticker = 'Ticker is required';
+    const shares = Number(shareCountStr);
+    if (!shareCountStr || isNaN(shares) || shares <= 0) {
+      e.shareCount = 'Enter a positive share count';
+    }
+    if (!asOf) e.asOf = 'As-of date is required';
+    return e;
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const errs = validate();
+    setErrors(errs);
+    if (Object.keys(errs).length > 0) return;
+    addHolding.mutate(
+      {
+        ticker: ticker.trim(),
+        shareCount: Number(shareCountStr),
+        asOf,
+        notes: notes.trim() || undefined,
+      },
+      {
+        onSuccess: () => {
+          toast.success('Holding declared');
+          onClose();
+        },
+        onError: () => toast.error('Failed to declare holding'),
+      },
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div aria-hidden="true" className="absolute inset-0 bg-black/40" onClick={onClose} />
+      <div className="relative w-full max-w-sm rounded-2xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-xl">
+        <div className="mb-5 flex items-center justify-between">
+          <div>
+            <h2 className="text-base font-bold">Declare Holding</h2>
+            <p className="text-xs text-[var(--muted-foreground)]">{account.nickname}</p>
+          </div>
+          <button onClick={onClose} className="rounded-lg p-1.5 hover:bg-[var(--muted)] transition-colors">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} noValidate className="space-y-4">
+          <div>
+            <label className="mb-1.5 block text-sm font-semibold">Ticker *</label>
+            <input
+              type="text"
+              value={ticker}
+              onChange={(e) => setTicker(e.target.value)}
+              placeholder="e.g. VTI"
+              className="w-full rounded-xl border border-[var(--border)] bg-[var(--surface-container-low)] px-3 py-2.5 text-sm uppercase focus:border-[var(--primary)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)]/30 transition-all"
+            />
+            {errors.ticker && <p className="mt-1 text-xs text-red-500">{errors.ticker}</p>}
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-sm font-semibold">Share count *</label>
+            <input
+              type="number"
+              step="any"
+              min="0"
+              value={shareCountStr}
+              onChange={(e) => setShareCountStr(e.target.value)}
+              placeholder="0"
+              className="w-full rounded-xl border border-[var(--border)] bg-[var(--surface-container-low)] px-3 py-2.5 text-sm focus:border-[var(--primary)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)]/30 transition-all"
+            />
+            {errors.shareCount && <p className="mt-1 text-xs text-red-500">{errors.shareCount}</p>}
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-sm font-semibold">As of *</label>
+            <input
+              type="date"
+              value={asOf}
+              onChange={(e) => setAsOf(e.target.value)}
+              className="w-full rounded-xl border border-[var(--border)] bg-[var(--surface-container-low)] px-3 py-2.5 text-sm focus:border-[var(--primary)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)]/30 transition-all"
+            />
+            {errors.asOf && <p className="mt-1 text-xs text-red-500">{errors.asOf}</p>}
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-sm font-semibold">Notes (optional)</label>
+            <input
+              type="text"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="e.g. from brokerage statement"
+              maxLength={500}
+              className="w-full rounded-xl border border-[var(--border)] bg-[var(--surface-container-low)] px-3 py-2.5 text-sm focus:border-[var(--primary)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)]/30 transition-all"
+            />
+          </div>
+
+          <p className="text-[11px] text-[var(--muted-foreground)]">
+            Editing a holding appends a new entry rather than overwriting the old one, so you
+            can see how your declared shares changed over time.
+          </p>
+
+          <div className="flex gap-3 pt-1">
+            <button
+              type="submit"
+              disabled={addHolding.isPending}
+              className="flex-1 rounded-full bg-[var(--primary)] py-2.5 text-sm font-bold text-[var(--primary-foreground)] shadow-lg shadow-[var(--primary)]/20 transition-all hover:opacity-90 active:scale-[0.98] disabled:opacity-50"
+            >
+              {addHolding.isPending ? 'Saving…' : 'Save Holding'}
+            </button>
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-full border border-[var(--border)] px-5 py-2.5 text-sm font-semibold hover:bg-[var(--muted)] transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+// ── Holdings History ─────────────────────────────────────────
+
+function HoldingsHistory({ accountId }: { accountId: string }) {
+  const { data: holdings = [], isLoading } = useHoldings(accountId);
+
+  if (isLoading) {
+    return <p className="py-3 text-xs text-[var(--muted-foreground)]">Loading holdings…</p>;
+  }
+  if (holdings.length === 0) {
+    return (
+      <p className="py-3 text-xs text-[var(--muted-foreground)] italic">
+        No holdings declared yet for this account.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="mt-2 space-y-1.5">
+      {holdings.map((h) => (
+        <li
+          key={h.id}
+          className="flex items-center justify-between rounded-lg bg-[var(--muted)]/50 px-3 py-2 text-xs"
+        >
+          <div className="min-w-0">
+            <span className="font-bold">{h.ticker}</span>
+            <span className="ml-2 text-[var(--muted-foreground)]">{h.shareCount} shares</span>
+            {h.notes && (
+              <p className="mt-0.5 truncate text-[11px] text-[var(--muted-foreground)]">{h.notes}</p>
+            )}
+          </div>
+          <span className="shrink-0 text-[11px] text-[var(--muted-foreground)]">
+            as of {formatDate(h.asOf)}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+// ── Portfolio Summary (value + allocation) ──────────────────
+
+function PortfolioSummary() {
+  const { data: value, isLoading: valueLoading } = usePortfolioValue();
+  const { data: allocation, isLoading: allocationLoading } = useAllocation();
+
+  if (valueLoading || allocationLoading) return null;
+  if (!value || value.holdings.length === 0) return null;
+
+  return (
+    <div className="rounded-2xl border border-[var(--border)] bg-[var(--card)] px-6 py-5 shadow-sm">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]">
+            Portfolio value (declared holdings)
+          </p>
+          <p className="mt-1 text-3xl font-extrabold tabular-nums tracking-tight">
+            {formatCents(value.totalCents)}
+          </p>
+          <p className="mt-0.5 text-xs text-[var(--muted-foreground)]">
+            Shares x latest EOD close, across {value.holdings.length} holding
+            {value.holdings.length !== 1 ? 's' : ''}
+          </p>
+        </div>
+        {(value.staleFound || value.missingPriceFound) && (
+          <div className="flex shrink-0 items-start gap-1.5 rounded-lg border border-amber-300 bg-amber-50 px-2.5 py-1.5 text-[11px] text-amber-800 dark:border-amber-900/40 dark:bg-amber-950/20 dark:text-amber-300">
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <span>
+              {value.staleFound &&
+                `One or more holdings are older than ${value.staleDays} days. `}
+              {value.missingPriceFound && 'No price data yet for one or more tickers.'}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {allocation && allocation.allocations.length > 0 && (
+        <div className="mt-4 space-y-1.5">
+          <p className="text-xs font-semibold uppercase tracking-wider text-[var(--muted-foreground)]">
+            Allocation
+          </p>
+          {allocation.allocations.map((a) => (
+            <div key={a.ticker} className="flex items-center gap-3 text-xs">
+              <span className="w-16 shrink-0 font-bold">{a.ticker}</span>
+              <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-[var(--muted)]">
+                <div
+                  className="h-full rounded-full bg-[var(--primary)]"
+                  style={{ width: `${Math.min(100, a.pct)}%` }}
+                />
+              </div>
+              <span className="w-14 shrink-0 text-right tabular-nums text-[var(--muted-foreground)]">
+                {a.pct.toFixed(1)}%
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ── Account Card ─────────────────────────────────────────────
 
 function AccountCard({
   account,
   onUpdateValue,
   onDelete,
+  onAddHolding,
 }: {
   account: InvestmentAccount;
   onUpdateValue: () => void;
   onDelete: () => void;
+  onAddHolding: () => void;
 }) {
   const typeLabel = ACCOUNT_TYPES.find((t) => t.value === account.accountType)?.label ?? account.accountType;
+  const [showHoldings, setShowHoldings] = useState(false);
 
   return (
     <div className="flex flex-col rounded-2xl border border-[var(--border)] bg-[var(--card)] p-5 shadow-sm transition-shadow hover:shadow-md">
@@ -277,13 +526,38 @@ function AccountCard({
         )}
       </div>
 
+      <div className="mt-4 flex gap-2">
+        <button
+          onClick={onUpdateValue}
+          className="flex flex-1 items-center justify-center gap-2 rounded-xl border border-[var(--border)] py-2 text-xs font-semibold transition-colors hover:bg-[var(--muted)]"
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+          Update value
+        </button>
+        <button
+          onClick={onAddHolding}
+          className="flex flex-1 items-center justify-center gap-2 rounded-xl border border-[var(--border)] py-2 text-xs font-semibold transition-colors hover:bg-[var(--muted)]"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Holding
+        </button>
+      </div>
+
       <button
-        onClick={onUpdateValue}
-        className="mt-4 flex w-full items-center justify-center gap-2 rounded-xl border border-[var(--border)] py-2 text-xs font-semibold transition-colors hover:bg-[var(--muted)]"
+        onClick={() => setShowHoldings((v) => !v)}
+        className="mt-2 flex w-full items-center justify-center gap-1 rounded-xl py-1.5 text-[11px] font-semibold text-[var(--muted-foreground)] transition-colors hover:bg-[var(--muted)]"
       >
-        <RefreshCw className="h-3.5 w-3.5" />
-        Update value
+        {showHoldings ? (
+          <>
+            Hide holdings <ChevronUp className="h-3 w-3" />
+          </>
+        ) : (
+          <>
+            Show holdings <ChevronDown className="h-3 w-3" />
+          </>
+        )}
       </button>
+      {showHoldings && <HoldingsHistory accountId={account.id} />}
     </div>
   );
 }
@@ -295,6 +569,7 @@ export default function InvestmentsPage() {
   const deleteAccount = useDeleteInvestment();
   const [showAddModal, setShowAddModal] = useState(false);
   const [updatingAccount, setUpdatingAccount] = useState<InvestmentAccount | null>(null);
+  const [addingHoldingAccount, setAddingHoldingAccount] = useState<InvestmentAccount | null>(null);
 
   const totalCents = accounts.reduce(
     (sum, a) => sum + (a.latestBalanceCents ?? 0),
@@ -343,6 +618,9 @@ export default function InvestmentsPage() {
         </div>
       )}
 
+      {/* Portfolio value + allocation from declared holdings */}
+      <PortfolioSummary />
+
       {/* Modeling help */}
       <div className="rounded-xl border border-blue-200 bg-blue-50 px-5 py-4 text-xs text-blue-800 dark:border-blue-900/40 dark:bg-blue-950/20 dark:text-blue-300">
         <p className="font-semibold mb-1">How to track investment accounts</p>
@@ -372,6 +650,7 @@ export default function InvestmentsPage() {
               account={account}
               onUpdateValue={() => setUpdatingAccount(account)}
               onDelete={() => handleDelete(account)}
+              onAddHolding={() => setAddingHoldingAccount(account)}
             />
           ))}
         </div>
@@ -382,6 +661,12 @@ export default function InvestmentsPage() {
         <UpdateValueModal
           account={updatingAccount}
           onClose={() => setUpdatingAccount(null)}
+        />
+      )}
+      {addingHoldingAccount && (
+        <AddHoldingModal
+          account={addingHoldingAccount}
+          onClose={() => setAddingHoldingAccount(null)}
         />
       )}
     </div>

--- a/apps/web/src/lib/hooks/useHoldings.ts
+++ b/apps/web/src/lib/hooks/useHoldings.ts
@@ -1,0 +1,60 @@
+'use client';
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { api } from '../api';
+import type {
+  InvestmentHolding,
+  AddHoldingInput,
+  PortfolioValue,
+  Allocation,
+} from '@moneypulse/shared';
+
+const KEYS = {
+  holdings: (accountId: string) => ['investments', accountId, 'holdings'] as const,
+  portfolioValue: ['investments', 'portfolio', 'value'] as const,
+  allocation: ['investments', 'portfolio', 'allocation'] as const,
+};
+
+/** Holding history for a single investment account, newest as-of first. */
+export function useHoldings(accountId: string) {
+  return useQuery({
+    queryKey: KEYS.holdings(accountId),
+    queryFn: () => api.get<{ data: InvestmentHolding[] }>(`/investments/${accountId}/holdings`),
+    select: (res) => res.data,
+    enabled: Boolean(accountId),
+  });
+}
+
+/** Declare a new holding (ticker + share count as-of a date). Append-only: this
+ * always inserts a new row rather than editing an existing one. */
+export function useAddHolding(accountId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: AddHoldingInput) =>
+      api.post<{ data: InvestmentHolding }>(`/investments/${accountId}/holdings`, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: KEYS.holdings(accountId) });
+      qc.invalidateQueries({ queryKey: KEYS.portfolioValue });
+      qc.invalidateQueries({ queryKey: KEYS.allocation });
+    },
+  });
+}
+
+/** Total portfolio market value (shares x latest EOD close) across all declared
+ * holdings, with a per-holding breakdown. */
+export function usePortfolioValue() {
+  return useQuery({
+    queryKey: KEYS.portfolioValue,
+    queryFn: () => api.get<{ data: PortfolioValue }>('/investments/portfolio/value'),
+    select: (res) => res.data,
+  });
+}
+
+/** Portfolio allocation: percent of total market value held in each ticker. */
+export function useAllocation() {
+  return useQuery({
+    queryKey: KEYS.allocation,
+    queryFn: () => api.get<{ data: Allocation }>('/investments/portfolio/allocation'),
+    select: (res) => res.data,
+  });
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -461,3 +461,44 @@ export interface SecurityPrice {
   source: string;
   fetchedAt: string;
 }
+
+/** One priced (or unpriced) holding line in a portfolio value breakdown. */
+export interface PortfolioValueHolding {
+  investmentAccountId: string;
+  ticker: string;
+  shareCount: string;
+  asOf: string;
+  /** True when this holding's as-of date is older than staleDays. */
+  isStale: boolean;
+  priceDate: string | null;
+  closeCents: number | null;
+  /** Null when no price data is available yet for this ticker. */
+  marketValueCents: number | null;
+}
+
+/** Total portfolio market value + per-holding breakdown (shares x latest EOD close). */
+export interface PortfolioValue {
+  totalCents: number;
+  holdings: PortfolioValueHolding[];
+  /** True if any holding is older than staleDays — declared shares may be stale. */
+  staleFound: boolean;
+  /** True if any held ticker has no price data yet (excluded from totalCents). */
+  missingPriceFound: boolean;
+  staleDays: number;
+}
+
+/** One ticker's share of total portfolio market value. */
+export interface AllocationEntry {
+  ticker: string;
+  valueCents: number;
+  pct: number;
+}
+
+/** Portfolio allocation: percent of total market value held in each ticker. */
+export interface Allocation {
+  totalCents: number;
+  allocations: AllocationEntry[];
+  staleFound: boolean;
+  missingPriceFound: boolean;
+  staleDays: number;
+}


### PR DESCRIPTION
Committed successfully.

## Summary

Closes the follow-up gap from #118 (PR #145): the holdings API existed but had no UI.

**Web (new UI):**
- `useHoldings.ts` hook (following the `useInvestments.ts` convention) wrapping `POST/GET /investments/:id/holdings` and the two new portfolio endpoints below.
- On the existing Investments page, each account card now has a "Holding" button (declare ticker/shares/as-of/notes) and a "Show holdings" toggle that renders the full append-only history, newest-first — so users see how declared shares changed over time, not just the current value.
- A page-level "Portfolio value / Allocation" card showing total market value (shares × latest EOD close) and per-ticker allocation bars, with a visible amber staleness/missing-price badge when applicable (mirrors the `dataCaveat` concept from the #118 backend).

**API (small, additive):**
- MCP tools aren't callable directly from the web app in this codebase, and there was no existing REST wrapper exposing `get_portfolio_value`/`get_allocation`'s computation as JSON — so added `GET /investments/portfolio/value` and `GET /investments/portfolio/allocation` on the existing, already-authenticated `InvestmentsController`, following the same plain-REST-wrapper pattern used elsewhere (e.g. `analytics.controller`) for computed facts. These reuse the same "latest holding per ticker per account" + "latest price per ticker" query logic as the MCP tools, just returning structured JSON instead of prose. No existing endpoint or behavior was touched.

**Tests (synthetic data only):** new API service specs for `getPortfolioValue`/`getAllocation` (empty state, stale/missing-price flags, allocation percentages) and a web test suite for the page covering: portfolio summary + staleness caveat rendering, expanding holdings history, submitting a new holding, and share-count validation. Full `investments` API suite and full web suite pass; `tsc --noEmit` is clean for both the API and the new/changed web files (pr

_(summary truncated)_

---
### Test evidence
**7 new test case(s) added** (heuristic count):
```
 .../__tests__/investments.service.spec.ts          |  87 ++++++
 .../web/src/__tests__/investment-holdings.spec.tsx | 150 +++++++++++
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- n/a (no check configured) `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
2m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/sync/__tests__/signing.service.spec.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 13[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/expected-cycle-date.spec.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/sync/__tests__/sync-payload.util.spec.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 10[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/audit/audit.service.spec.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 8[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/sync-delivery.processor.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 4[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/next-loan-due-date.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/categorization/__tests__/learning.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m77 passed[39m[22m[90m (77)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m658 passed[39m[22m[90m (658)[39m
@moneypulse/api:test: [2m   Start at [22m 01:11:50
@moneypulse/api:test: [2m   Duration [22m 11.02s[2m (transform 4.10s, setup 0ms, import 59.20s, tests 2.01s, environment 5ms)[22m
@moneypulse/api:test: 

 Tasks:    3 successful, 3 total
Cached:    0 cached, 3 total
  Time:    12.219s
```
</details>

### Review
**Review verdict:** approve

Findings (advisory — did not block landing):
- [low/advisory] apps/api/src/investments/investments.service.ts:300 — getAllocation re-runs getPortfolioValue, duplicating the holdings+prices DB queries already executed by the separate /portfolio/value request; the two endpoints could also return momentarily inconsistent snapshots. Minor efficiency/consistency nit, not blocking.
- [low/advisory] apps/api/src/investments/investments.controller.ts:51 — Correctness of the getPortfolioValue/getAllocation routes depends on them being declared before any @Get(':id') handler (Nest matches by declaration order). The comment claims this but it could not be verified from the diff; confirm the ':id' GET route is declared after these.

---
Dispatched via coxd (`MyMoney-add-the-missing-investments-1784682363`) · cost $2.321 · 🤖 coxd