### PR TITLE
12.4 Suitability settings & investment policy (target allocation, DCA,

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -28,6 +28,7 @@ import { InvestmentsModule } from './investments/investments.module';
 import { AdvisorModule } from './advisor/advisor.module';
 import { MarketDataModule } from './market-data/market-data.module';
 import { RateWatchlistModule } from './rate-watchlist/rate-watchlist.module';
+import { SuitabilitySettingsModule } from './suitability-settings/suitability-settings.module';
 
 @Module({
   imports: [
@@ -77,6 +78,7 @@ import { RateWatchlistModule } from './rate-watchlist/rate-watchlist.module';
     AdvisorModule,
     MarketDataModule,
     RateWatchlistModule,
+    SuitabilitySettingsModule,
     HealthModule,
   ],
   providers: [

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -62,6 +62,11 @@ export const watchlistProductTypeEnum = pgEnum('watchlist_product_type', [
   'mmf',
   'treasury',
 ]);
+export const riskToleranceEnum = pgEnum('risk_tolerance', [
+  'conservative',
+  'moderate',
+  'aggressive',
+]);
 export const notificationSeverityEnum = pgEnum('notification_severity', [
   'info',
   'insight',
@@ -1148,4 +1153,37 @@ export const rateWatchlist = pgTable(
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [index('idx_rate_watchlist_user').on(table.userId)],
+);
+
+// ── Suitability Settings & Investment Policy (12.4) ──────────
+// VERSIONED — an "update" always inserts a new row with an incremented `version`
+// rather than mutating the previous one, so a past recommendation can cite the exact
+// policy version that was in effect when it was made (same idea as calculation_version
+// on the recommendation-evidence contract). `version` is per-user, starting at 1.
+export const suitabilitySettings = pgTable(
+  'suitability_settings',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id),
+    version: integer('version').notNull(),
+    emergencyFundTargetMonths: integer('emergency_fund_target_months').notNull().default(6),
+    liquidityHorizonMonths: integer('liquidity_horizon_months'),
+    riskTolerance: riskToleranceEnum('risk_tolerance'),
+    taxState: varchar('tax_state', { length: 2 }),
+    monthlyInvestingTargetCents: integer('monthly_investing_target_cents'),
+    // [{assetClass: string, targetPercent: number}, ...] — percentages need not be
+    // validated to sum to 100 here (service layer's concern); stored as entered.
+    targetAllocation: jsonb('target_allocation').notNull().default([]),
+    // {TICKER: assetClass, ...} mapping for currently-held tickers.
+    tickerAssetClassMap: jsonb('ticker_asset_class_map').notNull().default({}),
+    dcaDayOfMonth: integer('dca_day_of_month'),
+    dcaAmountCents: integer('dca_amount_cents'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('uq_suitability_settings_user_version').on(table.userId, table.version),
+    index('idx_suitability_settings_user_created').on(table.userId, table.createdAt.desc()),
+  ],
 );

--- a/apps/api/src/suitability-settings/__tests__/suitability-gate.spec.ts
+++ b/apps/api/src/suitability-settings/__tests__/suitability-gate.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { requireSuitability } from '../suitability-gate';
+
+describe('requireSuitability — the 12.4 gate', () => {
+  it('refuses and names exactly the missing setting when risk_tolerance is absent', () => {
+    const settings = {
+      version: 3,
+      emergencyFundTargetMonths: 6,
+      riskTolerance: null, // the one under test
+    };
+
+    const result = requireSuitability(settings, ['emergency_fund_target_months', 'risk_tolerance']);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.missing).toEqual(['risk_tolerance']);
+      expect(result.message).toBe('missing: risk_tolerance');
+    }
+  });
+
+  it('refuses with all required fields listed when settings were never saved at all', () => {
+    const result = requireSuitability(null, ['emergency_fund_target_months', 'risk_tolerance']);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.missing).toEqual(['emergency_fund_target_months', 'risk_tolerance']);
+      expect(result.message).toContain('missing: emergency_fund_target_months, risk_tolerance');
+    }
+  });
+
+  it('allows the recommendation and cites the policy version when everything required is present', () => {
+    const settings = {
+      version: 4,
+      emergencyFundTargetMonths: 6,
+      riskTolerance: 'moderate',
+      targetAllocation: [{ assetClass: 'us_equity', targetPercent: 70 }],
+    };
+
+    const result = requireSuitability(settings, [
+      'emergency_fund_target_months',
+      'risk_tolerance',
+      'target_allocation',
+    ]);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.policyVersion).toBe(4);
+    }
+  });
+
+  it('treats an empty target_allocation list as missing (not merely present-but-empty)', () => {
+    const settings = {
+      version: 1,
+      emergencyFundTargetMonths: 6,
+      riskTolerance: 'moderate',
+      targetAllocation: [],
+    };
+
+    const result = requireSuitability(settings, ['target_allocation']);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.missing).toEqual(['target_allocation']);
+  });
+});

--- a/apps/api/src/suitability-settings/__tests__/suitability-settings.service.spec.ts
+++ b/apps/api/src/suitability-settings/__tests__/suitability-settings.service.spec.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Same fake-db pattern as rate-watchlist.service.spec.ts — mock drizzle-orm's
+// eq/desc to plain predicate/identity helpers so the in-memory fake below can
+// evaluate them, keeping this a true unit test of the service's own versioning
+// logic rather than drizzle's SQL builder.
+vi.mock('drizzle-orm', () => ({
+  eq: (col: any, val: any) => (row: any) => row[col] === val,
+  desc: (col: any) => col,
+}));
+
+vi.mock('../../db/schema', () => ({
+  suitabilitySettings: {
+    id: 'id',
+    userId: 'userId',
+    version: 'version',
+  },
+}));
+
+const { SuitabilitySettingsService } = await import('../suitability-settings.service');
+
+function asResult(arr: any[]) {
+  const result: any = [...arr];
+  result.orderBy = () => result;
+  result.limit = (n: number) => asResult(result.slice(0, n));
+  return result;
+}
+
+function makeFakeDb(seed: any[] = []) {
+  const rows: any[] = [...seed];
+  return {
+    _rows: () => rows,
+    select: () => ({
+      from: () => ({
+        where: (predFn: (r: any) => boolean) => {
+          const filtered = rows.filter(predFn).sort((a, b) => b.version - a.version);
+          return asResult(filtered);
+        },
+      }),
+    }),
+    insert: () => ({
+      values: (v: any) => {
+        const row = { id: `id-${rows.length + 1}`, createdAt: new Date(), ...v };
+        rows.push(row);
+        return { returning: () => [row] };
+      },
+    }),
+  };
+}
+
+const baseInput = {
+  emergencyFundTargetMonths: 6,
+  liquidityHorizonMonths: null,
+  riskTolerance: null,
+  taxState: null,
+  monthlyInvestingTargetCents: null,
+  targetAllocation: [],
+  tickerAssetClassMap: {},
+  dcaDayOfMonth: null,
+  dcaAmountCents: null,
+} as any;
+
+describe('SuitabilitySettingsService — versioning', () => {
+  it('creates version 1 on first save', async () => {
+    const db = makeFakeDb();
+    const service = new SuitabilitySettingsService(db as any);
+
+    const row = await service.createVersion('user-1', baseInput);
+
+    expect(row.version).toBe(1);
+    expect(db._rows()).toHaveLength(1);
+  });
+
+  it('updating a setting inserts a new version WITHOUT overwriting the old row', async () => {
+    const db = makeFakeDb();
+    const service = new SuitabilitySettingsService(db as any);
+
+    const v1 = await service.createVersion('user-1', {
+      ...baseInput,
+      riskTolerance: 'conservative',
+    });
+    const v2 = await service.createVersion('user-1', {
+      ...baseInput,
+      riskTolerance: 'aggressive',
+    });
+
+    expect(v1.version).toBe(1);
+    expect(v2.version).toBe(2);
+
+    // Both rows persist — the old version's record is untouched.
+    expect(db._rows()).toHaveLength(2);
+    const oldRow = db._rows().find((r: any) => r.version === 1);
+    expect(oldRow.riskTolerance).toBe('conservative');
+
+    // getCurrent reflects only the latest version.
+    const current = await service.getCurrent('user-1');
+    expect(current?.version).toBe(2);
+    expect(current?.riskTolerance).toBe('aggressive');
+
+    // Full history still has both, most recent first.
+    const history = await service.getHistory('user-1');
+    expect(history.map((h) => h.version)).toEqual([2, 1]);
+  });
+
+  it('versions are scoped per-user', async () => {
+    const db = makeFakeDb();
+    const service = new SuitabilitySettingsService(db as any);
+
+    await service.createVersion('user-1', baseInput);
+    const otherUserFirst = await service.createVersion('user-2', baseInput);
+
+    expect(otherUserFirst.version).toBe(1);
+  });
+});

--- a/apps/api/src/suitability-settings/suitability-gate.ts
+++ b/apps/api/src/suitability-settings/suitability-gate.ts
@@ -1,0 +1,100 @@
+/**
+ * 12.4 — the suitability gate.
+ *
+ * Any FUTURE suitability-dependent recommendation logic (which vehicle to use, how
+ * much to invest — e.g. the Investment Coach, #122) must call `requireSuitability`
+ * before proposing a recommendation. It never guesses a missing setting: it returns
+ * a result stating exactly which field(s) are absent so the caller can produce a
+ * "missing setting" output instead of fabricating advice (Phase 12 principle #4).
+ *
+ * This module has no DB/Nest dependency on purpose — it is a pure function over a
+ * plain settings object so #122 (and its tests) can call it without standing up the
+ * full service/DI graph.
+ */
+
+export type SuitabilityField =
+  | 'emergency_fund_target_months'
+  | 'risk_tolerance'
+  | 'tax_state'
+  | 'target_allocation'
+  | 'liquidity_horizon_months'
+  | 'monthly_investing_target_cents'
+  | 'dca_day_of_month';
+
+/** Loose shape so this works against both the Drizzle-shaped service row and plain
+ *  test fixtures — mirrors the RecommendationEvidenceFields pattern from 12.1. */
+export interface SuitabilitySettingsLike {
+  version?: number;
+  emergencyFundTargetMonths?: number | null;
+  liquidityHorizonMonths?: number | null;
+  riskTolerance?: string | null;
+  taxState?: string | null;
+  monthlyInvestingTargetCents?: number | null;
+  targetAllocation?: Array<{ assetClass: string; targetPercent: number }> | null;
+  dcaDayOfMonth?: number | null;
+}
+
+export type SuitabilityGateResult =
+  | { ok: true; policyVersion: number }
+  | { ok: false; missing: SuitabilityField[]; message: string };
+
+/**
+ * `settings` is null when the user has never saved any suitability settings at all.
+ * `required` lets a caller ask only for the fields it actually needs (e.g. the
+ * Investment Coach's "which vehicle" question needs risk_tolerance + target
+ * allocation but not the DCA fields) — defaults to the fields every suitability
+ * question needs at minimum: emergency-fund target and risk tolerance.
+ */
+export function requireSuitability(
+  settings: SuitabilitySettingsLike | null | undefined,
+  required: SuitabilityField[] = ['emergency_fund_target_months', 'risk_tolerance'],
+): SuitabilityGateResult {
+  if (!settings) {
+    return {
+      ok: false,
+      missing: [...required],
+      message: `missing: ${required.join(', ')} (no suitability settings have been saved yet)`,
+    };
+  }
+
+  const missing: SuitabilityField[] = [];
+  for (const field of required) {
+    if (!isPresent(settings, field)) missing.push(field);
+  }
+
+  if (missing.length > 0) {
+    return { ok: false, missing, message: `missing: ${missing.join(', ')}` };
+  }
+
+  return { ok: true, policyVersion: settings.version ?? 0 };
+}
+
+function isPresent(settings: SuitabilitySettingsLike, field: SuitabilityField): boolean {
+  switch (field) {
+    case 'emergency_fund_target_months':
+      return (
+        settings.emergencyFundTargetMonths !== null &&
+        settings.emergencyFundTargetMonths !== undefined
+      );
+    case 'risk_tolerance':
+      return !!settings.riskTolerance;
+    case 'tax_state':
+      return !!settings.taxState;
+    case 'target_allocation':
+      return Array.isArray(settings.targetAllocation) && settings.targetAllocation.length > 0;
+    case 'liquidity_horizon_months':
+      return (
+        settings.liquidityHorizonMonths !== null && settings.liquidityHorizonMonths !== undefined
+      );
+    case 'monthly_investing_target_cents':
+      // Nullable-by-design (null = "let the coach propose from surplus") — presence
+      // means the field has been explicitly saved at all, i.e. a settings row exists.
+      // Callers that truly require a user-fixed amount should check the value
+      // themselves; this gate only confirms the settings object was saved.
+      return true;
+    case 'dca_day_of_month':
+      return settings.dcaDayOfMonth !== null && settings.dcaDayOfMonth !== undefined;
+    default:
+      return false;
+  }
+}

--- a/apps/api/src/suitability-settings/suitability-settings.controller.ts
+++ b/apps/api/src/suitability-settings/suitability-settings.controller.ts
@@ -1,0 +1,38 @@
+import { Controller, Get, Put, Body, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { SuitabilitySettingsService } from './suitability-settings.service';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
+import { suitabilitySettingsInputSchema } from '@moneypulse/shared';
+import type { AuthTokenPayload, SuitabilitySettingsInput } from '@moneypulse/shared';
+
+@ApiTags('Suitability Settings')
+@Controller('suitability-settings')
+@UseGuards(JwtAuthGuard)
+export class SuitabilitySettingsController {
+  constructor(private readonly service: SuitabilitySettingsService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Current (latest-version) suitability settings for the user' })
+  async getCurrent(@CurrentUser() user: AuthTokenPayload) {
+    return { data: await this.service.getCurrent(user.sub) };
+  }
+
+  @Get('history')
+  @ApiOperation({ summary: 'Full version history of suitability settings, newest first' })
+  async getHistory(@CurrentUser() user: AuthTokenPayload) {
+    return { data: await this.service.getHistory(user.sub) };
+  }
+
+  @Put()
+  @ApiOperation({
+    summary: 'Save suitability settings — always creates a new version, never overwrites',
+  })
+  async save(
+    @CurrentUser() user: AuthTokenPayload,
+    @Body(new ZodValidationPipe(suitabilitySettingsInputSchema)) body: SuitabilitySettingsInput,
+  ) {
+    return { data: await this.service.createVersion(user.sub, body) };
+  }
+}

--- a/apps/api/src/suitability-settings/suitability-settings.module.ts
+++ b/apps/api/src/suitability-settings/suitability-settings.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { SuitabilitySettingsService } from './suitability-settings.service';
+import { SuitabilitySettingsController } from './suitability-settings.controller';
+
+@Module({
+  providers: [SuitabilitySettingsService],
+  controllers: [SuitabilitySettingsController],
+  exports: [SuitabilitySettingsService],
+})
+export class SuitabilitySettingsModule {}

--- a/apps/api/src/suitability-settings/suitability-settings.service.ts
+++ b/apps/api/src/suitability-settings/suitability-settings.service.ts
@@ -1,0 +1,100 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { eq, desc } from 'drizzle-orm';
+import { DATABASE_CONNECTION } from '../db/db.module';
+import { suitabilitySettings } from '../db/schema';
+import type { SuitabilitySettingsInput } from '@moneypulse/shared';
+
+export interface TargetAllocationEntry {
+  assetClass: string;
+  targetPercent: number;
+}
+
+export interface SuitabilitySettingsRow {
+  id: string;
+  version: number;
+  emergencyFundTargetMonths: number;
+  liquidityHorizonMonths: number | null;
+  riskTolerance: string | null;
+  taxState: string | null;
+  monthlyInvestingTargetCents: number | null;
+  targetAllocation: TargetAllocationEntry[];
+  tickerAssetClassMap: Record<string, string>;
+  dcaDayOfMonth: number | null;
+  dcaAmountCents: number | null;
+  createdAt: Date;
+}
+
+@Injectable()
+export class SuitabilitySettingsService {
+  constructor(@Inject(DATABASE_CONNECTION) private readonly db: any) {}
+
+  private toRow(r: any): SuitabilitySettingsRow {
+    return {
+      id: r.id,
+      version: r.version,
+      emergencyFundTargetMonths: r.emergencyFundTargetMonths,
+      liquidityHorizonMonths: r.liquidityHorizonMonths,
+      riskTolerance: r.riskTolerance,
+      taxState: r.taxState,
+      monthlyInvestingTargetCents: r.monthlyInvestingTargetCents,
+      targetAllocation: r.targetAllocation ?? [],
+      tickerAssetClassMap: r.tickerAssetClassMap ?? {},
+      dcaDayOfMonth: r.dcaDayOfMonth,
+      dcaAmountCents: r.dcaAmountCents,
+      createdAt: r.createdAt,
+    };
+  }
+
+  /** The latest (current) version for the user, or null if none has ever been set. */
+  async getCurrent(userId: string): Promise<SuitabilitySettingsRow | null> {
+    const rows = await this.db
+      .select()
+      .from(suitabilitySettings)
+      .where(eq(suitabilitySettings.userId, userId))
+      .orderBy(desc(suitabilitySettings.version))
+      .limit(1);
+    return rows[0] ? this.toRow(rows[0]) : null;
+  }
+
+  /** Full version history, most recent first — so a recommendation can look up which
+   *  version was in effect at a given point in time. */
+  async getHistory(userId: string): Promise<SuitabilitySettingsRow[]> {
+    const rows = await this.db
+      .select()
+      .from(suitabilitySettings)
+      .where(eq(suitabilitySettings.userId, userId))
+      .orderBy(desc(suitabilitySettings.version));
+    return rows.map((r: any) => this.toRow(r));
+  }
+
+  /**
+   * Insert a new version. Never mutates a prior row — this is the versioning
+   * contract (12.4): a recommendation can always cite the exact version that was in
+   * effect when it was made, and old versions remain queryable forever.
+   */
+  async createVersion(
+    userId: string,
+    input: SuitabilitySettingsInput,
+  ): Promise<SuitabilitySettingsRow> {
+    const current = await this.getCurrent(userId);
+    const nextVersion = (current?.version ?? 0) + 1;
+
+    const [row] = await this.db
+      .insert(suitabilitySettings)
+      .values({
+        userId,
+        version: nextVersion,
+        emergencyFundTargetMonths: input.emergencyFundTargetMonths,
+        liquidityHorizonMonths: input.liquidityHorizonMonths ?? null,
+        riskTolerance: input.riskTolerance ?? null,
+        taxState: input.taxState ?? null,
+        monthlyInvestingTargetCents: input.monthlyInvestingTargetCents ?? null,
+        targetAllocation: input.targetAllocation ?? [],
+        tickerAssetClassMap: input.tickerAssetClassMap ?? {},
+        dcaDayOfMonth: input.dcaDayOfMonth ?? null,
+        dcaAmountCents: input.dcaAmountCents ?? null,
+      })
+      .returning();
+    return this.toRow(row);
+  }
+}

--- a/apps/mcp-server/src/tools/__tests__/get-allocation.spec.ts
+++ b/apps/mcp-server/src/tools/__tests__/get-allocation.spec.ts
@@ -51,7 +51,78 @@ describe('get_allocation', () => {
 
     expect(text).toContain('AAA: 50.00%');
     expect(text).toContain('BBB: 50.00%');
-    expect(text).toContain('#120'); // no target-allocation drift yet — TODO references the issue
+    // No suitability settings saved -> refuses to guess a target rather than
+    // fabricating a comparison (12.4 gate).
+    expect(text).toContain('No target allocation on file');
+  });
+
+  it('computes target-vs-actual drift per asset class (12.4) against a synthetic policy fixture', async () => {
+    // Synthetic portfolio: AAA (us_equity) 100 x $200 = $20,000; BBB (bonds) 50 x
+    // $400 = $20,000 -> 50/50 actual. Target policy: us_equity 70%, bonds 30%.
+    // Hand-calc: us_equity drift = 50 - 70 = -20pp; bonds drift = 50 - 30 = +20pp.
+    queryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM investment_holdings')) {
+        return [
+          { ticker: 'AAA', share_count: '100', as_of: '2026-07-01' },
+          { ticker: 'BBB', share_count: '50', as_of: '2026-07-01' },
+        ];
+      }
+      if (sql.includes('FROM security_prices')) {
+        return [
+          { ticker: 'AAA', price_date: '2026-07-01', close_cents: 20000 },
+          { ticker: 'BBB', price_date: '2026-07-01', close_cents: 40000 },
+        ];
+      }
+      if (sql.includes('FROM suitability_settings')) {
+        return [
+          {
+            version: 3,
+            target_allocation: [
+              { assetClass: 'us_equity', targetPercent: 70 },
+              { assetClass: 'bonds', targetPercent: 30 },
+            ],
+            ticker_asset_class_map: { AAA: 'us_equity', BBB: 'bonds' },
+          },
+        ];
+      }
+      return [];
+    });
+
+    const call = makeServer();
+    const result = await call({});
+    const text = result.content[0].text;
+
+    expect(text).toContain('policy version 3');
+    expect(text).toContain('us_equity: target 70.0%, actual 50.0% (drift -20.0pp)');
+    expect(text).toContain('bonds: target 30.0%, actual 50.0% (drift +20.0pp)');
+  });
+
+  it('flags unmapped tickers with a dataCaveat instead of silently dropping them', async () => {
+    queryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM investment_holdings')) {
+        return [{ ticker: 'ZZZ', share_count: '10', as_of: '2026-07-01' }];
+      }
+      if (sql.includes('FROM security_prices')) {
+        return [{ ticker: 'ZZZ', price_date: '2026-07-01', close_cents: 100000 }];
+      }
+      if (sql.includes('FROM suitability_settings')) {
+        return [
+          {
+            version: 1,
+            target_allocation: [{ assetClass: 'us_equity', targetPercent: 100 }],
+            ticker_asset_class_map: {}, // ZZZ intentionally unmapped
+          },
+        ];
+      }
+      return [];
+    });
+
+    const call = makeServer();
+    const result = await call({});
+    const text = result.content[0].text;
+
+    expect(text).toContain('dataCaveat');
+    expect(text).toContain('no ticker→asset-class mapping');
   });
 
   it('surfaces a dataCaveat when holdings are stale', async () => {

--- a/apps/mcp-server/src/tools/get-allocation.ts
+++ b/apps/mcp-server/src/tools/get-allocation.ts
@@ -15,13 +15,18 @@ interface PriceRow {
   close_cents: number;
 }
 
+interface SuitabilitySettingsRow {
+  version: number;
+  target_allocation: Array<{ assetClass: string; targetPercent: number }> | null;
+  ticker_asset_class_map: Record<string, string> | null;
+}
+
 /**
- * Portfolio allocation: percent of total market value by ticker.
- *
- * TODO(#120): once suitability-settings/target-allocation lands, add per-asset-class
- * target percentages here and surface drift (actual - target) per class. That
- * feature doesn't exist in this codebase yet, so this tool only computes actual
- * percentages for now.
+ * Portfolio allocation: percent of total market value by ticker, plus (12.4) percent
+ * by asset class vs the user's target allocation with drift, when suitability
+ * settings with a target allocation have been saved. If no target allocation is on
+ * file, the tool still returns ticker-level actuals and says so explicitly rather
+ * than fabricating a comparison (fail-closed, per the Phase 12 suitability gate).
  */
 export function registerGetAllocation(server: McpServer) {
   server.tool(
@@ -94,10 +99,54 @@ export function registerGetAllocation(server: McpServer) {
         const pct = (valueCents / totalCents) * 100;
         lines.push(`${ticker}: ${pct.toFixed(2)}% ($${(valueCents / 100).toFixed(2)})`);
       }
-      lines.push(
-        '(Allocation by asset class with target-vs-actual drift is not yet available — ' +
-          'see issue #120 for the suitability-settings/target-allocation feature this depends on.)',
+      // 12.4: compare against the user's target allocation (latest saved version), if any.
+      const [policy] = await query<SuitabilitySettingsRow>(
+        `SELECT version, target_allocation, ticker_asset_class_map
+         FROM suitability_settings
+         WHERE user_id = $1
+         ORDER BY version DESC
+         LIMIT 1`,
+        [userId],
       );
+
+      const targets = policy?.target_allocation ?? [];
+      if (!policy || targets.length === 0) {
+        lines.push(
+          '(No target allocation on file — save one in Settings to see target-vs-actual drift. ' +
+            'Refusing to guess a target rather than fabricating a comparison.)',
+        );
+      } else {
+        const tickerToClass = policy.ticker_asset_class_map ?? {};
+        const valueByClass = new Map<string, number>();
+        let unmappedCents = 0;
+        for (const [ticker, valueCents] of valueByTicker.entries()) {
+          const assetClass = tickerToClass[ticker];
+          if (!assetClass) {
+            unmappedCents += valueCents;
+            continue;
+          }
+          valueByClass.set(assetClass, (valueByClass.get(assetClass) ?? 0) + valueCents);
+        }
+
+        lines.push('', `Target allocation (policy version ${policy.version}):`);
+        for (const { assetClass, targetPercent } of targets) {
+          const actualCents = valueByClass.get(assetClass) ?? 0;
+          const actualPercent = (actualCents / totalCents) * 100;
+          const driftPct = actualPercent - targetPercent;
+          const sign = driftPct >= 0 ? '+' : '';
+          lines.push(
+            `${assetClass}: target ${targetPercent.toFixed(1)}%, actual ${actualPercent.toFixed(
+              1,
+            )}% (drift ${sign}${driftPct.toFixed(1)}pp)`,
+          );
+        }
+        if (unmappedCents > 0) {
+          const unmappedPct = (unmappedCents / totalCents) * 100;
+          lines.push(
+            `dataCaveat: ${unmappedPct.toFixed(1)}% of holdings have no ticker→asset-class mapping in suitability settings and are excluded from the target comparison.`,
+          );
+        }
+      }
 
       if (staleFound) {
         lines.push(

--- a/apps/web/src/app/(protected)/settings/page.tsx
+++ b/apps/web/src/app/(protected)/settings/page.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '@/lib/auth';
 import { api } from '@/lib/api';
 import { ThemeToggle } from '@/components/ThemeToggle';
 import { AdvisorSettingsSection } from '@/components/AdvisorSettingsSection';
+import { SuitabilitySettingsSection } from '@/components/SuitabilitySettingsSection';
 import { useSendTestNotification } from '@/lib/hooks/useNotifications';
 
 export default function SettingsPage() {
@@ -332,6 +333,9 @@ export default function SettingsPage() {
 
       {/* AI Advisor (self-contained: own save/test) */}
       <AdvisorSettingsSection />
+
+      {/* Suitability settings & investment policy — feeds future advisory recommendations */}
+      <SuitabilitySettingsSection />
 
       {/* Paycheck Profiles — powers the 50/30/20 dashboard */}
       <section className="space-y-4 rounded-2xl bg-[var(--surface-container-low)] p-6">

--- a/apps/web/src/components/SuitabilitySettingsSection.tsx
+++ b/apps/web/src/components/SuitabilitySettingsSection.tsx
@@ -1,0 +1,323 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { ShieldCheck } from 'lucide-react';
+import { api } from '@/lib/api';
+
+type RiskTolerance = 'conservative' | 'moderate' | 'aggressive';
+
+interface TargetAllocationEntry {
+  assetClass: string;
+  targetPercent: number;
+}
+
+interface SuitabilitySettingsView {
+  version: number;
+  emergencyFundTargetMonths: number;
+  liquidityHorizonMonths: number | null;
+  riskTolerance: RiskTolerance | null;
+  taxState: string | null;
+  monthlyInvestingTargetCents: number | null;
+  targetAllocation: TargetAllocationEntry[];
+  tickerAssetClassMap: Record<string, string>;
+  dcaDayOfMonth: number | null;
+  dcaAmountCents: number | null;
+}
+
+const DEFAULTS = {
+  emergencyFundTargetMonths: 6,
+  liquidityHorizonMonths: '',
+  riskTolerance: '' as RiskTolerance | '',
+  taxState: '',
+  monthlyInvestingTargetCents: '',
+  dcaDayOfMonth: '',
+  dcaAmountCents: '',
+};
+
+/**
+ * 12.4 — suitability settings & investment policy. Every save creates a NEW
+ * version server-side (never overwrites); this UI always shows/edits the current
+ * (latest) version. These fields feed future automated recommendations (Investment
+ * Coach, #122) — the gate there refuses to guess a missing field rather than
+ * fabricating advice, so filling these in unlocks more specific recommendations.
+ */
+export function SuitabilitySettingsSection() {
+  const [current, setCurrent] = useState<SuitabilitySettingsView | null>(null);
+  const [form, setForm] = useState(DEFAULTS);
+  const [allocation, setAllocation] = useState<TargetAllocationEntry[]>([]);
+  const [tickerMap, setTickerMap] = useState<Record<string, string>>({});
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState('');
+
+  const load = () =>
+    api
+      .get<{ data: SuitabilitySettingsView | null }>('/suitability-settings')
+      .then(({ data }) => {
+        if (!data) return;
+        setCurrent(data);
+        setForm({
+          emergencyFundTargetMonths: data.emergencyFundTargetMonths,
+          liquidityHorizonMonths: data.liquidityHorizonMonths?.toString() ?? '',
+          riskTolerance: data.riskTolerance ?? '',
+          taxState: data.taxState ?? '',
+          monthlyInvestingTargetCents:
+            data.monthlyInvestingTargetCents != null
+              ? (data.monthlyInvestingTargetCents / 100).toString()
+              : '',
+          dcaDayOfMonth: data.dcaDayOfMonth?.toString() ?? '',
+          dcaAmountCents:
+            data.dcaAmountCents != null ? (data.dcaAmountCents / 100).toString() : '',
+        });
+        setAllocation(data.targetAllocation ?? []);
+        setTickerMap(data.tickerAssetClassMap ?? {});
+      })
+      .catch(() => {});
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  async function save() {
+    setBusy(true);
+    setMessage('');
+    try {
+      const { data } = await api.put<{ data: SuitabilitySettingsView }>(
+        '/suitability-settings',
+        {
+          emergencyFundTargetMonths: Number(form.emergencyFundTargetMonths) || 6,
+          liquidityHorizonMonths: form.liquidityHorizonMonths
+            ? Number(form.liquidityHorizonMonths)
+            : null,
+          riskTolerance: form.riskTolerance || null,
+          taxState: form.taxState || null,
+          monthlyInvestingTargetCents: form.monthlyInvestingTargetCents
+            ? Math.round(Number(form.monthlyInvestingTargetCents) * 100)
+            : null,
+          targetAllocation: allocation,
+          tickerAssetClassMap: tickerMap,
+          dcaDayOfMonth: form.dcaDayOfMonth ? Number(form.dcaDayOfMonth) : null,
+          dcaAmountCents: form.dcaAmountCents
+            ? Math.round(Number(form.dcaAmountCents) * 100)
+            : null,
+        },
+      );
+      setCurrent(data);
+      setMessage(`Saved as version ${data.version}.`);
+    } catch (err: any) {
+      setMessage(err.message || 'Failed to save suitability settings');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function updateAllocationRow(i: number, patch: Partial<TargetAllocationEntry>) {
+    setAllocation((rows) => rows.map((r, idx) => (idx === i ? { ...r, ...patch } : r)));
+  }
+
+  return (
+    <section className="space-y-4 rounded-2xl bg-[var(--surface-container-low)] p-6">
+      <div className="flex items-center gap-2">
+        <ShieldCheck className="h-5 w-5 text-[var(--primary)]" />
+        <h2 className="text-lg font-bold">Investment Policy &amp; Suitability</h2>
+      </div>
+      <p className="text-sm text-[var(--muted-foreground)]">
+        These answers let future automated recommendations (which account/vehicle to
+        use, how much to invest) be specific to your situation. If a field here is
+        left blank, a recommendation that needs it will say exactly what&apos;s
+        missing instead of guessing. Changes are versioned — this is version{' '}
+        {current?.version ?? '(none yet)'}; older versions stay on record so past
+        recommendations can be traced to the policy in effect at the time.
+      </p>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <label className="space-y-1 text-sm">
+          <span className="font-medium">
+            Emergency fund target (months of expenses)
+          </span>
+          <p className="text-xs text-[var(--muted-foreground)]">
+            Used to gate investing recommendations — the coach won&apos;t suggest
+            investing until this buffer is funded.
+          </p>
+          <input
+            type="number"
+            min={0}
+            className="w-full rounded-lg border border-[var(--border)] bg-transparent px-3 py-2"
+            value={form.emergencyFundTargetMonths}
+            onChange={(e) =>
+              setForm((f) => ({ ...f, emergencyFundTargetMonths: e.target.value as any }))
+            }
+          />
+        </label>
+
+        <label className="space-y-1 text-sm">
+          <span className="font-medium">Liquidity horizon (months)</span>
+          <p className="text-xs text-[var(--muted-foreground)]">
+            How soon you might need cash beyond the emergency fund (e.g. a house
+            down payment) — keeps that money out of anything illiquid.
+          </p>
+          <input
+            type="number"
+            min={0}
+            className="w-full rounded-lg border border-[var(--border)] bg-transparent px-3 py-2"
+            value={form.liquidityHorizonMonths}
+            onChange={(e) =>
+              setForm((f) => ({ ...f, liquidityHorizonMonths: e.target.value }))
+            }
+          />
+        </label>
+
+        <label className="space-y-1 text-sm">
+          <span className="font-medium">Risk tolerance</span>
+          <p className="text-xs text-[var(--muted-foreground)]">
+            Shapes which vehicles get recommended and how aggressively drift gets
+            corrected.
+          </p>
+          <select
+            className="w-full rounded-lg border border-[var(--border)] bg-transparent px-3 py-2"
+            value={form.riskTolerance}
+            onChange={(e) =>
+              setForm((f) => ({ ...f, riskTolerance: e.target.value as RiskTolerance | '' }))
+            }
+          >
+            <option value="">Not set</option>
+            <option value="conservative">Conservative</option>
+            <option value="moderate">Moderate</option>
+            <option value="aggressive">Aggressive</option>
+          </select>
+        </label>
+
+        <label className="space-y-1 text-sm">
+          <span className="font-medium">Tax state</span>
+          <p className="text-xs text-[var(--muted-foreground)]">
+            Two-letter state code — used to frame Treasury/muni state-tax exemption
+            in evidence.
+          </p>
+          <input
+            type="text"
+            maxLength={2}
+            placeholder="e.g. NY"
+            className="w-full rounded-lg border border-[var(--border)] bg-transparent px-3 py-2 uppercase"
+            value={form.taxState}
+            onChange={(e) =>
+              setForm((f) => ({ ...f, taxState: e.target.value.toUpperCase() }))
+            }
+          />
+        </label>
+
+        <label className="space-y-1 text-sm">
+          <span className="font-medium">Monthly investing target ($)</span>
+          <p className="text-xs text-[var(--muted-foreground)]">
+            Leave blank to let the future Investment Coach propose an amount from
+            your surplus instead of fixing one yourself.
+          </p>
+          <input
+            type="number"
+            min={0}
+            step="0.01"
+            className="w-full rounded-lg border border-[var(--border)] bg-transparent px-3 py-2"
+            value={form.monthlyInvestingTargetCents}
+            onChange={(e) =>
+              setForm((f) => ({ ...f, monthlyInvestingTargetCents: e.target.value }))
+            }
+          />
+        </label>
+
+        <label className="space-y-1 text-sm">
+          <span className="font-medium">DCA day of month</span>
+          <p className="text-xs text-[var(--muted-foreground)]">
+            The day recurring contributions land — informs (never executes) the
+            dollar-cost-averaging policy.
+          </p>
+          <input
+            type="number"
+            min={1}
+            max={28}
+            className="w-full rounded-lg border border-[var(--border)] bg-transparent px-3 py-2"
+            value={form.dcaDayOfMonth}
+            onChange={(e) => setForm((f) => ({ ...f, dcaDayOfMonth: e.target.value }))}
+          />
+        </label>
+
+        <label className="space-y-1 text-sm">
+          <span className="font-medium">DCA amount ($)</span>
+          <p className="text-xs text-[var(--muted-foreground)]">
+            Leave blank if contributions are irregular.
+          </p>
+          <input
+            type="number"
+            min={0}
+            step="0.01"
+            className="w-full rounded-lg border border-[var(--border)] bg-transparent px-3 py-2"
+            value={form.dcaAmountCents}
+            onChange={(e) => setForm((f) => ({ ...f, dcaAmountCents: e.target.value }))}
+          />
+        </label>
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-medium">Target allocation</span>
+          <button
+            type="button"
+            onClick={() => setAllocation((a) => [...a, { assetClass: '', targetPercent: 0 }])}
+            className="text-xs font-semibold text-[var(--primary)] hover:underline"
+          >
+            + Add asset class
+          </button>
+        </div>
+        <p className="text-xs text-[var(--muted-foreground)]">
+          e.g. US equity 70%, international 20%, bonds 10%. Drives allocation-drift
+          comparisons against your actual holdings.
+        </p>
+        {allocation.map((row, i) => (
+          <div key={i} className="flex items-center gap-2">
+            <input
+              type="text"
+              placeholder="asset class (e.g. us_equity)"
+              className="flex-1 rounded-lg border border-[var(--border)] bg-transparent px-3 py-2 text-sm"
+              value={row.assetClass}
+              onChange={(e) => updateAllocationRow(i, { assetClass: e.target.value })}
+            />
+            <input
+              type="number"
+              min={0}
+              max={100}
+              placeholder="%"
+              className="w-24 rounded-lg border border-[var(--border)] bg-transparent px-3 py-2 text-sm"
+              value={row.targetPercent}
+              onChange={(e) =>
+                updateAllocationRow(i, { targetPercent: Number(e.target.value) || 0 })
+              }
+            />
+            <button
+              type="button"
+              onClick={() => setAllocation((a) => a.filter((_, idx) => idx !== i))}
+              className="text-xs text-[var(--destructive)] hover:underline"
+            >
+              Remove
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {message && (
+        <p
+          className={`text-sm ${
+            message.toLowerCase().includes('fail') ? 'text-[var(--destructive)]' : 'text-[var(--primary)]'
+          }`}
+        >
+          {message}
+        </p>
+      )}
+
+      <button
+        type="button"
+        onClick={save}
+        disabled={busy}
+        className="rounded-full bg-[var(--primary)] px-6 py-2.5 text-sm font-bold text-[var(--primary-foreground)] shadow-lg shadow-[var(--primary)]/20 transition-all hover:opacity-90 active:scale-[0.98] disabled:opacity-50"
+      >
+        {busy ? 'Saving...' : 'Save Suitability Settings'}
+      </button>
+    </section>
+  );
+}

--- a/db/migrations/0028_suitability_settings.sql
+++ b/db/migrations/0028_suitability_settings.sql
@@ -1,0 +1,30 @@
+-- 12.4 Suitability settings & investment policy.
+-- Additive-only: new enum + new table. No backfill needed and no existing reads
+-- are affected. Versioned/append-only by design — see schema.ts comment.
+
+DO $$ BEGIN
+  CREATE TYPE "risk_tolerance" AS ENUM ('conservative', 'moderate', 'aggressive');
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "suitability_settings" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "user_id" uuid NOT NULL REFERENCES "users"("id"),
+  "version" integer NOT NULL,
+  "emergency_fund_target_months" integer NOT NULL DEFAULT 6,
+  "liquidity_horizon_months" integer,
+  "risk_tolerance" "risk_tolerance",
+  "tax_state" varchar(2),
+  "monthly_investing_target_cents" integer,
+  "target_allocation" jsonb NOT NULL DEFAULT '[]',
+  "ticker_asset_class_map" jsonb NOT NULL DEFAULT '{}',
+  "dca_day_of_month" integer,
+  "dca_amount_cents" integer,
+  "created_at" timestamp WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_suitability_settings_user_version"
+  ON "suitability_settings" ("user_id", "version");
+CREATE INDEX IF NOT EXISTS "idx_suitability_settings_user_created"
+  ON "suitability_settings" ("user_id", "created_at" DESC);

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1784560500000,
       "tag": "0027_treasury_rate_watchlist",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1784560600000,
+      "tag": "0028_suitability_settings",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/src/validation/index.ts
+++ b/packages/shared/src/validation/index.ts
@@ -393,6 +393,30 @@ export const updateRateWatchlistSchema = createRateWatchlistSchema.partial();
 export type CreateRateWatchlistInput = z.infer<typeof createRateWatchlistSchema>;
 export type UpdateRateWatchlistInput = z.infer<typeof updateRateWatchlistSchema>;
 
+// ── Suitability Settings & Investment Policy (12.4) ─────────────
+// Every successful write creates a new *version* (see schema.ts) — this is the input
+// shape for that write, not a partial patch of an existing row.
+
+export const targetAllocationEntrySchema = z.object({
+  assetClass: z.string().min(1).max(60),
+  targetPercent: z.number().min(0).max(100),
+});
+
+export const suitabilitySettingsInputSchema = z.object({
+  emergencyFundTargetMonths: z.int().min(0).max(60).default(6),
+  liquidityHorizonMonths: z.int().min(0).max(600).nullable().optional(),
+  riskTolerance: z.enum(['conservative', 'moderate', 'aggressive']).nullable().optional(),
+  taxState: z.string().length(2).nullable().optional(),
+  monthlyInvestingTargetCents: z.int().min(0).nullable().optional(),
+  targetAllocation: z.array(targetAllocationEntrySchema).default([]),
+  tickerAssetClassMap: z.record(z.string(), z.string()).default({}),
+  dcaDayOfMonth: z.int().min(1).max(28).nullable().optional(),
+  dcaAmountCents: z.int().min(0).nullable().optional(),
+});
+
+export type SuitabilitySettingsInput = z.infer<typeof suitabilitySettingsInputSchema>;
+export type TargetAllocationEntry = z.infer<typeof targetAllocationEntrySchema>;
+
 // ── Paycheck Profiles (11.11 — take-home pay modeling) ──────
 // Effective-dated: a new row is created whenever gross pay, withholdings, or
 // deductions change (raise, benefits election, etc). Rows are never mutated to


### PR DESCRIPTION
Committed successfully.

## Summary

Implemented 12.4 Suitability Settings & Investment Policy (#120):

- **Versioned settings model**: new `suitability_settings` table (`db/migrations/0028_suitability_settings.sql` + schema.ts) storing `emergency_fund_target_months`, `liquidity_horizon_months`, `risk_tolerance` enum, `tax_state`, `monthly_investing_target_cents`, target allocation (`[{assetClass, targetPercent}]`), ticker→asset-class map, and DCA policy fields. Every write inserts a new row with an incremented per-user `version` rather than mutating the previous one — proven by a unit test that updates a setting and asserts the old version's row is untouched.
- **Suitability gate**: `apps/api/src/suitability-settings/suitability-gate.ts` exports a pure `requireSuitability()` function (no DB/DI dependency) for the future Investment Coach (#122) to call before recommending. It returns `{ok:false, missing:['risk_tolerance'], message:'missing: risk_tolerance'}` rather than guessing — tested for the exact scenario in the issue, plus no-settings-saved and empty-target-allocation edge cases. On success it returns `policyVersion` so a recommendation can cite the exact policy version used.
- **API**: `SuitabilitySettingsService`/`Controller`/`Module` (GET current, GET history, PUT to save a new version), registered in `app.module.ts`, validated via a new Zod schema in `@moneypulse/shared`.
- **MCP wiring**: resolved #118's TODO in `get-allocation.ts` — it now looks up the latest suitability-settings policy, computes actual vs. target percent per asset class with drift, flags tickers missing from the ticker→asset-class map as a `dataCaveat`, and explicitly states "no target allocation on file" (refuses to guess) when none is saved. Extended the existing `get-allocation.spec.ts` with synthetic-fixture drift and unmapped-ticker tests (hand-verified deltas).
- **Settings UI**: new `SuitabilitySettingsSection` component on the Settings page with plain-language explanations per f

_(summary truncated)_

---
### Test evidence
**9 new test case(s) added** (heuristic count):
```
 .../__tests__/suitability-gate.spec.ts             |  64 ++++
 .../__tests__/suitability-settings.service.spec.ts | 114 ++++++++
 .../src/tools/__tests__/get-allocation.spec.ts     |  73 ++++-
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- n/a (no check configured) `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
[39m src/embeddings/__tests__/embedding-categorizer.service.spec.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/analytics/__tests__/budget-plan.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 7[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/suitability-settings/__tests__/suitability-gate.spec.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/expected-cycle-date.spec.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/categorization/__tests__/learning.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/transactions/__tests__/business-date.spec.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/next-loan-due-date.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m81 passed[39m[22m[90m (81)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m673 passed[39m[22m[90m (673)[39m
@moneypulse/api:test: [2m   Start at [22m 01:40:45
@moneypulse/api:test: [2m   Duration [22m 11.35s[2m (transform 3.12s, setup 0ms, import 61.33s, tests 2.83s, environment 5ms)[22m
@moneypulse/api:test: 

 Tasks:    4 successful, 4 total
Cached:    0 cached, 4 total
  Time:    12.625s
```
</details>

### Review
**Review verdict:** approve

Findings (advisory — did not block landing):
- [low/correctness] apps/api/src/suitability-settings/suitability-settings.service.ts:78 — createVersion() reads the current max version then inserts version+1 non-atomically. Two concurrent saves for the same user both read version N and both attempt to insert N+1; the uq_suitability_settings_user_version unique index correctly prevents duplicate/corrupt data, but one request fails with an unhandled unique-violation error (500) instead of retrying. No data desync, so advisory only.
- [low/advisory] apps/web/src/components/SuitabilitySettingsSection.tsx:105 — Save error path sets message from err.message, but the styled-as-error branch keys on the substring 'fail' (message.toLowerCase().includes('fail')); an API error whose message lacks the word 'fail' renders in the success (primary) color, misleading the user. Cosmetic only.

---
Dispatched via coxd (`MyMoney-12-4-suitability-settings-in-1784684025`) · cost $2.629 · 🤖 coxd