### PR TITLE
12.6 Investment Coach agent — contribution + allocation drift, tested 

### DIFF
--- a/apps/api/src/recommendations/__tests__/contribution-planner.spec.ts
+++ b/apps/api/src/recommendations/__tests__/contribution-planner.spec.ts
@@ -1,0 +1,135 @@
+import {
+  ContributionPlanner,
+  ContributionPlannerContext,
+  InvestmentCoachSettingsLike,
+} from '../contribution-planner';
+
+const ASOF = '2026-07-01';
+
+function baseContext(overrides: Partial<ContributionPlannerContext> = {}): ContributionPlannerContext {
+  return {
+    asOfDate: ASOF,
+    avgMonthlyExpenseCents: 400_000, // $4,000/mo
+    currentEmergencyFundCents: 2_400_000, // $24,000 (6mo of $4,000)
+    trailingMonthlySurplusCents: 150_000, // $1,500/mo surplus
+    monthlyGoalContributionCents: 0,
+    totalPortfolioValueCents: 10_000_00 * 100, // $1,000,000 in cents scaled below by fixture
+    currentAllocationByAssetClass: [],
+    ...overrides,
+  };
+}
+
+function baseSettings(overrides: Partial<InvestmentCoachSettingsLike> = {}): InvestmentCoachSettingsLike {
+  return {
+    version: 3,
+    emergencyFundTargetMonths: 6,
+    riskTolerance: 'moderate',
+    targetAllocation: [
+      { assetClass: 'us_equity', targetPercent: 60 },
+      { assetClass: 'intl_equity', targetPercent: 20 },
+      { assetClass: 'bonds', targetPercent: 20 },
+    ],
+    dcaDayOfMonth: 15,
+    dcaAmountCents: 0,
+    ...overrides,
+  };
+}
+
+describe('ContributionPlanner', () => {
+  it('gates on missing suitability settings (reuses requireSuitability directly) — zero recommendations', () => {
+    const planner = new ContributionPlanner();
+    const settings = baseSettings({ riskTolerance: null });
+    const result = planner.plan(settings, baseContext());
+
+    expect(result.status).toBe('missing_setting');
+    if (result.status === 'missing_setting') {
+      expect(result.missing).toContain('risk_tolerance');
+      expect(result.message).toMatch(/missing/i);
+    }
+  });
+
+  it('gates on completely absent settings row too', () => {
+    const planner = new ContributionPlanner();
+    const result = planner.plan(null, baseContext());
+    expect(result.status).toBe('missing_setting');
+  });
+
+  it('outputs "fund the buffer first" with the exact dollar gap when emergency fund is underfunded, no investment recommendation', () => {
+    const planner = new ContributionPlanner();
+    const settings = baseSettings();
+    // Only $10,000 saved against a $24,000 (6mo x $4,000) target.
+    const context = baseContext({ currentEmergencyFundCents: 1_000_000 });
+    const result = planner.plan(settings, context);
+
+    expect(result.status).toBe('fund_buffer_first');
+    if (result.status === 'fund_buffer_first') {
+      expect(result.emergencyFundTargetCents).toBe(2_400_000);
+      expect(result.gapCents).toBe(2_400_000 - 1_000_000);
+      expect(result.evidence.length).toBeGreaterThan(0);
+      expect(result.assumptions.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('reports no_surplus when investable surplus is <= 0 after goals + DCA, even with a funded buffer', () => {
+    const planner = new ContributionPlanner();
+    const settings = baseSettings({ dcaAmountCents: 200_000 });
+    const context = baseContext({ trailingMonthlySurplusCents: 150_000, monthlyGoalContributionCents: 0 });
+    const result = planner.plan(settings, context);
+
+    expect(result.status).toBe('no_surplus');
+    if (result.status === 'no_surplus') {
+      expect(result.investableSurplusCents).toBe(150_000 - 200_000);
+    }
+  });
+
+  it('picks the most-underweight asset class and the correct dollar amount (hand-verifiable)', () => {
+    const planner = new ContributionPlanner();
+    const settings = baseSettings();
+    const totalPortfolioValueCents = 100_000_00; // $100,000
+    const context = baseContext({
+      totalPortfolioValueCents,
+      // us_equity 70% (overweight vs 60% target), intl_equity 10% (underweight vs 20%),
+      // bonds 20% (on target) -> intl_equity is most underweight by 10pp.
+      currentAllocationByAssetClass: [
+        { assetClass: 'us_equity', valueCents: 70_000_00 },
+        { assetClass: 'intl_equity', valueCents: 10_000_00 },
+        { assetClass: 'bonds', valueCents: 20_000_00 },
+      ],
+      trailingMonthlySurplusCents: 150_000,
+      monthlyGoalContributionCents: 0,
+    });
+    const result = planner.plan(settings, context);
+
+    expect(result.status).toBe('recommend');
+    if (result.status === 'recommend') {
+      expect(result.destinationAssetClass).toBe('intl_equity');
+      expect(result.contributionCents).toBe(150_000); // full investable surplus, hand-verified
+      expect(result.driftPercentPoints).toBeCloseTo(10, 5);
+      expect(result.currentPercent).toBeCloseTo(10, 5);
+      expect(result.targetPercent).toBe(20);
+      expect(result.dcaDayOfMonth).toBe(15);
+      // Never suggests selling: no such field/verb exists on the 'recommend' result at all.
+      expect((result as any).sell).toBeUndefined();
+    }
+  });
+
+  it('never endorses a fund/ticker name — destination is an asset class only', () => {
+    const planner = new ContributionPlanner();
+    const settings = baseSettings();
+    const context = baseContext({
+      totalPortfolioValueCents: 100_000_00,
+      currentAllocationByAssetClass: [
+        { assetClass: 'us_equity', valueCents: 60_000_00 },
+        { assetClass: 'intl_equity', valueCents: 20_000_00 },
+        { assetClass: 'bonds', valueCents: 10_000_00 },
+      ],
+    });
+    const result = planner.plan(settings, context);
+    expect(result.status).toBe('recommend');
+    if (result.status === 'recommend') {
+      expect(result.destinationAssetClass).toBe('bonds');
+      expect(typeof result.destinationAssetClass).toBe('string');
+      expect(result.destinationAssetClass).not.toMatch(/[A-Z]{2,5}$/); // not a ticker-like symbol
+    }
+  });
+});

--- a/apps/api/src/recommendations/__tests__/investment-coach-narration.spec.ts
+++ b/apps/api/src/recommendations/__tests__/investment-coach-narration.spec.ts
@@ -1,0 +1,94 @@
+import { ContributionPlanResult } from '../contribution-planner';
+import {
+  buildInvestmentCoachNarration,
+  buildTimingRefusalNarration,
+  containsPredictiveClaim,
+  looksLikeMarketTimingQuestion,
+  INVESTMENT_COACH_DISCLAIMER,
+  PREDICTIVE_CLAIM_PATTERNS,
+} from '../investment-coach-narration';
+
+const recommendResult: ContributionPlanResult = {
+  status: 'recommend',
+  destinationAssetClass: 'intl_equity',
+  contributionCents: 150_000,
+  driftPercentPoints: 10,
+  currentPercent: 10,
+  targetPercent: 20,
+  dcaDayOfMonth: 15,
+  dcaAmountCents: 0,
+  impact: { minCentsPerYear: 1_800_000, maxCentsPerYear: 1_800_000, basis: 'annualized' },
+  evidence: [{ source: 'tool', ref: 'get_allocation', value: '10.0', unit: 'percent', observedAt: '2026-07-01' }],
+  assumptions: ['test assumption'],
+  confidenceBand: 'medium',
+  calculationVersion: 'contribution-planner-v1',
+  policyVersion: 3,
+};
+
+describe('containsPredictiveClaim / looksLikeMarketTimingQuestion (word/phrase-based, not eyeballed)', () => {
+  it('flags common predictive phrasing', () => {
+    expect(containsPredictiveClaim('The market will rise next quarter.')).toBe(true);
+    expect(containsPredictiveClaim('Stocks will fall soon.')).toBe(true);
+    expect(containsPredictiveClaim('This is a good time to buy.')).toBe(true);
+    expect(containsPredictiveClaim('We expect the market to recover.')).toBe(true);
+    expect(containsPredictiveClaim('Now is the time to invest more.')).toBe(true);
+  });
+
+  it('does not flag neutral policy language', () => {
+    expect(containsPredictiveClaim(buildTimingRefusalNarration(recommendResult))).toBe(false);
+    expect(containsPredictiveClaim('Stick to your DCA schedule and current allocation drift.')).toBe(false);
+  });
+
+  it('detects timing-style questions', () => {
+    expect(looksLikeMarketTimingQuestion('Is now a good time to buy?')).toBe(true);
+    expect(looksLikeMarketTimingQuestion('Should I wait for a dip?')).toBe(true);
+    expect(looksLikeMarketTimingQuestion('What is my current allocation?')).toBe(false);
+  });
+});
+
+describe('12.6 timing-refusal contract (acceptance-critical)', () => {
+  it('explicitly refuses/reframes AND contains zero predictive claims, for a "good time to buy" question', () => {
+    const userQuestion = 'Is now a good time to buy, or should I wait for a dip?';
+    expect(looksLikeMarketTimingQuestion(userQuestion)).toBe(true);
+
+    const reply = buildTimingRefusalNarration(recommendResult);
+
+    // (a) explicit refusal/reframing language present.
+    expect(reply).toMatch(/can't predict/i);
+    expect(reply).toMatch(/time-in-market/i);
+    expect(reply).toMatch(/DCA schedule/i);
+    expect(reply).toMatch(/allocation/i);
+
+    // (b) no predictive market-direction claims anywhere in the reply — a real
+    // phrase-based assertion against every pattern, not eyeballing the text.
+    for (const pattern of PREDICTIVE_CLAIM_PATTERNS) {
+      expect(reply).not.toMatch(pattern);
+    }
+    expect(containsPredictiveClaim(reply)).toBe(false);
+
+    // Standing disclaimer present on this output too.
+    expect(reply).toContain(INVESTMENT_COACH_DISCLAIMER);
+  });
+
+  it('still refuses even when no plan/recommendation is available (missing settings)', () => {
+    const missing: ContributionPlanResult = {
+      status: 'missing_setting',
+      missing: ['risk_tolerance'],
+      message: 'missing: risk_tolerance',
+    };
+    const reply = buildTimingRefusalNarration(missing);
+    expect(reply).toMatch(/can't predict/i);
+    expect(containsPredictiveClaim(reply)).toBe(false);
+  });
+});
+
+describe('buildInvestmentCoachNarration', () => {
+  it('always includes the standing disclaimer', () => {
+    expect(buildInvestmentCoachNarration(recommendResult)).toContain(INVESTMENT_COACH_DISCLAIMER);
+  });
+
+  it('never contains lastFour/account-number style tokens', () => {
+    const text = buildInvestmentCoachNarration(recommendResult);
+    expect(text.toLowerCase()).not.toMatch(/last_?four/);
+  });
+});

--- a/apps/api/src/recommendations/contribution-planner.ts
+++ b/apps/api/src/recommendations/contribution-planner.ts
@@ -1,0 +1,267 @@
+import { EvidenceItem, ExpectedImpact, ConfidenceBand } from './recommendation-evidence';
+import { requireSuitability, SuitabilitySettingsLike, SuitabilityField } from '../suitability-settings/suitability-gate';
+
+/**
+ * 12.6 — Investment Coach's deterministic core. Pure, LLM-free, and exhaustively
+ * unit-tested: given a snapshot of a user's emergency-fund status, trailing savings
+ * surplus, and allocation drift vs their target allocation (12.4), decide either
+ * "fund the buffer first" or "contribute $X to <most-underweight asset class>".
+ *
+ * This module NEVER produces a sell/rebalance-by-selling recommendation and NEVER
+ * invents its own timing logic (that's the user's existing DCA policy, 12.4) or its
+ * own market-direction opinion (see investment-coach-narration.ts's timing-refusal
+ * contract). It also never endorses a specific fund/ticker beyond what the caller
+ * passes in as already-held or explicitly ticker-mapped by the user.
+ *
+ * IMPORTANT (see recommendation-evidence.ts): every input here MUST already be
+ * sanitized of account numbers/lastFour before it reaches this module.
+ */
+
+export const CONTRIBUTION_PLANNER_CALCULATION_VERSION = 'contribution-planner-v1';
+
+export interface AssetClassAllocation {
+  assetClass: string;
+  valueCents: number;
+}
+
+export interface TargetAllocationEntry {
+  assetClass: string;
+  targetPercent: number;
+}
+
+export interface ContributionPlannerContext {
+  asOfDate: string;
+  /** Trailing-3mo avg monthly expenses, in cents — same basis as the emergency-fund
+   * target and the 12.5 Cash Manager buffer math (not reinvented here). */
+  avgMonthlyExpenseCents: number;
+  /** Sum of liquid (checking/savings) balances counted toward the emergency fund. */
+  currentEmergencyFundCents: number;
+  /** get_savings_rate's most recent month: incomeCents - expenseCents. May be negative. */
+  trailingMonthlySurplusCents: number;
+  /** Sum of any recurring goal contributions already committed out of the surplus.
+   * Defaults to 0 — goals are not yet a shipped feature in this codebase. */
+  monthlyGoalContributionCents?: number;
+  totalPortfolioValueCents: number;
+  currentAllocationByAssetClass: AssetClassAllocation[];
+}
+
+export type ContributionPlanResult =
+  | {
+      status: 'missing_setting';
+      missing: SuitabilityField[];
+      message: string;
+    }
+  | {
+      status: 'fund_buffer_first';
+      emergencyFundTargetCents: number;
+      currentEmergencyFundCents: number;
+      gapCents: number;
+      evidence: EvidenceItem[];
+      assumptions: string[];
+      confidenceBand: ConfidenceBand;
+      calculationVersion: string;
+      policyVersion: number;
+    }
+  | {
+      status: 'no_surplus';
+      investableSurplusCents: number;
+      evidence: EvidenceItem[];
+      assumptions: string[];
+      confidenceBand: ConfidenceBand;
+      calculationVersion: string;
+      policyVersion: number;
+    }
+  | {
+      status: 'recommend';
+      destinationAssetClass: string;
+      contributionCents: number;
+      driftPercentPoints: number;
+      currentPercent: number;
+      targetPercent: number;
+      dcaDayOfMonth: number | null;
+      dcaAmountCents: number | null;
+      impact: ExpectedImpact;
+      evidence: EvidenceItem[];
+      assumptions: string[];
+      confidenceBand: ConfidenceBand;
+      calculationVersion: string;
+      policyVersion: number;
+    };
+
+function dollars(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+/** `SuitabilitySettingsLike` (12.4) doesn't carry `dcaAmountCents` since the gate
+ * itself only checks *presence* of `dcaDayOfMonth`; this agent also needs the
+ * scheduled DCA amount to compute investable surplus, so it extends the shape
+ * locally rather than widening the shared gate's contract. */
+export interface InvestmentCoachSettingsLike extends SuitabilitySettingsLike {
+  dcaAmountCents?: number | null;
+  /** {TICKER: assetClass, ...} — 12.4's ticker→asset-class mapping, needed here to
+   * attribute held tickers' market value to a target-allocation asset class. */
+  tickerAssetClassMap?: Record<string, string> | null;
+}
+
+const REQUIRED_FIELDS: SuitabilityField[] = [
+  'emergency_fund_target_months',
+  'risk_tolerance',
+  'target_allocation',
+  'dca_day_of_month',
+];
+
+/**
+ * Single entry point: reuses 12.4's `requireSuitability` gate directly (never
+ * reimplements it), then runs the deterministic contribution plan.
+ */
+export class ContributionPlanner {
+  plan(settings: InvestmentCoachSettingsLike | null | undefined, context: ContributionPlannerContext): ContributionPlanResult {
+    const gate = requireSuitability(settings, REQUIRED_FIELDS);
+    if (!gate.ok) {
+      return { status: 'missing_setting', missing: gate.missing, message: gate.message };
+    }
+
+    const emergencyFundTargetMonths = settings!.emergencyFundTargetMonths ?? 0;
+    const emergencyFundTargetCents = Math.round(context.avgMonthlyExpenseCents * emergencyFundTargetMonths);
+    const gapCents = Math.max(0, emergencyFundTargetCents - context.currentEmergencyFundCents);
+
+    const baseEvidence: EvidenceItem[] = [
+      {
+        source: 'tool',
+        ref: 'get_account_balances',
+        value: dollars(context.currentEmergencyFundCents),
+        unit: 'usd',
+        observedAt: context.asOfDate,
+      },
+      {
+        source: 'calculator',
+        ref: 'emergency_fund_target',
+        value: dollars(emergencyFundTargetCents),
+        unit: 'usd',
+        observedAt: context.asOfDate,
+      },
+    ];
+
+    if (gapCents > 0) {
+      return {
+        status: 'fund_buffer_first',
+        emergencyFundTargetCents,
+        currentEmergencyFundCents: context.currentEmergencyFundCents,
+        gapCents,
+        evidence: baseEvidence,
+        assumptions: [
+          `Emergency-fund target = ${emergencyFundTargetMonths} month(s) of avg expenses (suitability policy v${gate.policyVersion}).`,
+          'No investment recommendation is made until the emergency buffer is fully funded.',
+        ],
+        confidenceBand: 'high',
+        calculationVersion: CONTRIBUTION_PLANNER_CALCULATION_VERSION,
+        policyVersion: gate.policyVersion,
+      };
+    }
+
+    const monthlyGoalContributionCents = context.monthlyGoalContributionCents ?? 0;
+    const dcaAmountCents = settings!.dcaAmountCents ?? 0;
+    const investableSurplusCents =
+      context.trailingMonthlySurplusCents - monthlyGoalContributionCents - dcaAmountCents;
+
+    const surplusEvidence: EvidenceItem[] = [
+      ...baseEvidence,
+      {
+        source: 'tool',
+        ref: 'get_savings_rate',
+        value: dollars(context.trailingMonthlySurplusCents),
+        unit: 'usd',
+        observedAt: context.asOfDate,
+      },
+    ];
+
+    if (investableSurplusCents <= 0) {
+      return {
+        status: 'no_surplus',
+        investableSurplusCents,
+        evidence: surplusEvidence,
+        assumptions: [
+          `Investable surplus = trailing monthly surplus (${dollars(context.trailingMonthlySurplusCents)}) - goal contributions (${dollars(monthlyGoalContributionCents)}) - scheduled DCA (${dollars(dcaAmountCents)}).`,
+          'Nothing left over this month — no new-contribution recommendation.',
+        ],
+        confidenceBand: 'medium',
+        calculationVersion: CONTRIBUTION_PLANNER_CALCULATION_VERSION,
+        policyVersion: gate.policyVersion,
+      };
+    }
+
+    const target = (settings!.targetAllocation ?? []) as TargetAllocationEntry[];
+    const totalCents = context.totalPortfolioValueCents;
+    const currentByClass = new Map(context.currentAllocationByAssetClass.map((a) => [a.assetClass, a.valueCents]));
+
+    let best: { assetClass: string; drift: number; currentPercent: number; targetPercent: number } | null = null;
+    for (const t of target) {
+      const currentPercent = totalCents > 0 ? ((currentByClass.get(t.assetClass) ?? 0) / totalCents) * 100 : 0;
+      const drift = t.targetPercent - currentPercent; // positive = underweight
+      if (!best || drift > best.drift) {
+        best = { assetClass: t.assetClass, drift, currentPercent, targetPercent: t.targetPercent };
+      }
+    }
+
+    if (!best) {
+      // No target allocation entries at all — shouldn't happen (gate requires
+      // target_allocation to be non-empty), but fail closed rather than guess.
+      return {
+        status: 'no_surplus',
+        investableSurplusCents,
+        evidence: surplusEvidence,
+        assumptions: ['No target allocation classes found — cannot pick a contribution destination.'],
+        confidenceBand: 'low',
+        calculationVersion: CONTRIBUTION_PLANNER_CALCULATION_VERSION,
+        policyVersion: gate.policyVersion,
+      };
+    }
+
+    const allocationEvidence: EvidenceItem[] = [
+      ...surplusEvidence,
+      {
+        source: 'tool',
+        ref: 'get_portfolio_value',
+        value: dollars(totalCents),
+        unit: 'usd',
+        observedAt: context.asOfDate,
+      },
+      {
+        source: 'tool',
+        ref: 'get_allocation',
+        value: best.currentPercent.toFixed(1),
+        unit: 'percent',
+        observedAt: context.asOfDate,
+      },
+    ];
+
+    const impact: ExpectedImpact = {
+      minCentsPerYear: investableSurplusCents * 12,
+      maxCentsPerYear: investableSurplusCents * 12,
+      basis:
+        'Annualized at the current monthly contribution rate; not a return projection — no market performance is assumed.',
+    };
+
+    return {
+      status: 'recommend',
+      destinationAssetClass: best.assetClass,
+      contributionCents: investableSurplusCents,
+      driftPercentPoints: Math.round(best.drift * 10) / 10,
+      currentPercent: Math.round(best.currentPercent * 10) / 10,
+      targetPercent: best.targetPercent,
+      dcaDayOfMonth: settings!.dcaDayOfMonth ?? null,
+      dcaAmountCents: settings!.dcaAmountCents ?? null,
+      impact,
+      evidence: allocationEvidence,
+      assumptions: [
+        `Investable surplus = trailing monthly surplus (${dollars(context.trailingMonthlySurplusCents)}) - goal contributions (${dollars(monthlyGoalContributionCents)}) - scheduled DCA (${dollars(dcaAmountCents)}).`,
+        `Destination = most-underweight asset class vs target allocation (suitability policy v${gate.policyVersion}) — directs NEW contributions only, never a sale of existing holdings.`,
+        'Timing follows your existing DCA schedule; this agent does not predict market direction (see timing-refusal contract).',
+        'No specific new fund/ticker is endorsed — only asset classes; use a fund you already hold or have mapped to this class.',
+      ],
+      confidenceBand: 'medium',
+      calculationVersion: CONTRIBUTION_PLANNER_CALCULATION_VERSION,
+      policyVersion: gate.policyVersion,
+    };
+  }
+}

--- a/apps/api/src/recommendations/investment-coach-narration.ts
+++ b/apps/api/src/recommendations/investment-coach-narration.ts
@@ -1,0 +1,127 @@
+import { ContributionPlanResult } from './contribution-planner';
+
+/**
+ * 12.6 — Investment Coach narration. Pure, LLM-free rendering straight off a
+ * `ContributionPlanResult` (same numeric-spot-check-safe pattern as 12.5's
+ * `cash-manager-narration.ts`): every dollar figure traces back to `evidence`.
+ *
+ * Only dollar amounts, asset-class names, and percentages appear here — never an
+ * account number, lastFour, or routing number (see recommendation-evidence.ts).
+ */
+
+function dollars(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+/** Standing disclaimer — must appear on every piece of output this agent produces
+ * (recommendation narration AND timing-refusal replies alike). */
+export const INVESTMENT_COACH_DISCLAIMER =
+  'This is not personalized investment, legal, or tax advice. MoneyPulse never buys, sells, moves, or ' +
+  'schedules any trade or transfer on your behalf — consider consulting a licensed financial advisor before acting.';
+
+export function buildInvestmentCoachNarration(result: ContributionPlanResult): string {
+  let body: string;
+  switch (result.status) {
+    case 'missing_setting':
+      body = `I can't give you an investment recommendation yet — missing setting(s): ${result.missing.join(', ')}. Add these in Settings first.`;
+      break;
+    case 'fund_buffer_first':
+      body =
+        `Let's fund your emergency buffer first. You have ${dollars(result.currentEmergencyFundCents)} toward a ` +
+        `${dollars(result.emergencyFundTargetCents)} target — a gap of ${dollars(result.gapCents)}. ` +
+        `No investment recommendation until this buffer is fully funded.`;
+      break;
+    case 'no_surplus':
+      body =
+        `There's no investable surplus this month (${dollars(result.investableSurplusCents)} after goal contributions ` +
+        `and your scheduled DCA) — nothing new to contribute right now.`;
+      break;
+    case 'recommend':
+      body =
+        `Contribute ~${dollars(result.contributionCents)} this month to ${result.destinationAssetClass} ` +
+        `(currently ${result.currentPercent.toFixed(1)}% vs your ${result.targetPercent.toFixed(1)}% target, ` +
+        `${result.driftPercentPoints.toFixed(1)}pp underweight). This directs new money only — we do not ` +
+        `recommend selling any existing holding. Timing follows your existing DCA schedule` +
+        (result.dcaDayOfMonth ? ` (day ${result.dcaDayOfMonth} of the month)` : '') +
+        `; time-in-market beats timing-the-market, so this isn't tied to any market prediction.`;
+      break;
+  }
+  return `${body}\n\n${INVESTMENT_COACH_DISCLAIMER}`;
+}
+
+/** Phrases that would constitute a market-direction PREDICTION — must never appear
+ * in this agent's output, tested with a real word/phrase-based assertion (not just
+ * eyeballing the text). Case-insensitive. */
+export const PREDICTIVE_CLAIM_PATTERNS: RegExp[] = [
+  /will\s+rise/i,
+  /will\s+fall/i,
+  /will\s+(go\s+)?(up|down)/i,
+  /good\s+time\s+to\s+buy/i,
+  /good\s+time\s+to\s+invest/i,
+  /expect\s+the\s+market\s+to/i,
+  /market\s+is\s+about\s+to/i,
+  /prices?\s+(are|is)\s+going\s+to/i,
+  /now\s+is\s+the\s+time/i,
+];
+
+export function containsPredictiveClaim(text: string): boolean {
+  return PREDICTIVE_CLAIM_PATTERNS.some((p) => p.test(text));
+}
+
+/** Loose detector for a market-timing-style question from advisor chat (e.g. "is now
+ * a good time to buy?" / "should I wait for a dip?"). Used by the on-demand trigger
+ * to route to the refusal reply instead of (or in addition to) the plan narration. */
+const TIMING_QUESTION_PATTERNS: RegExp[] = [
+  /good\s+time\s+to\s+(buy|invest)/i,
+  /wait\s+for\s+a\s+dip/i,
+  /wait\s+for\s+the\s+market/i,
+  /time\s+the\s+market/i,
+  /should\s+i\s+(buy|invest)\s+now/i,
+  /is\s+now\s+a\s+good\s+time/i,
+];
+
+export function looksLikeMarketTimingQuestion(message: string): boolean {
+  return TIMING_QUESTION_PATTERNS.some((p) => p.test(message));
+}
+
+/**
+ * 12.6's timing-refusal contract: given a question like "is now a good time to buy?"
+ * or "should I wait for a dip?", the agent must EXPLICITLY decline to predict market
+ * direction/timing and instead reframe around policy — time-in-market over
+ * timing-the-market, the user's existing DCA schedule, and their current allocation
+ * drift. It must never contain a predictive claim (see `containsPredictiveClaim`).
+ *
+ * `result` is an already-computed `ContributionPlanResult` so the reframing can cite
+ * the user's actual drift/DCA facts rather than invent generic advice — but even when
+ * no plan is available (e.g. missing settings), the refusal language itself is always
+ * present.
+ */
+export function buildTimingRefusalNarration(result: ContributionPlanResult): string {
+  const refusal =
+    "I can't predict market direction or tell you whether now is a good or bad time to buy — no one can " +
+    'do that reliably. What I can tell you is that time-in-market has historically mattered far more than ' +
+    'timing-the-market, which is why your plan sticks to a regular contribution schedule regardless of ' +
+    'short-term moves.';
+
+  let policyNote: string;
+  if (result.status === 'recommend') {
+    policyNote =
+      `Your current plan: contribute on your existing DCA schedule` +
+      (result.dcaDayOfMonth ? ` (day ${result.dcaDayOfMonth} of the month)` : '') +
+      ` and direct new money toward ${result.destinationAssetClass}, which is currently ` +
+      `${result.driftPercentPoints.toFixed(1)}pp underweight vs your target allocation. Sticking to that ` +
+      `schedule — rather than trying to guess a good entry point — is the recommendation.`;
+  } else if (result.status === 'fund_buffer_first') {
+    policyNote =
+      `Right now your plan is to finish funding your emergency buffer (${dollars(result.gapCents)} to go) before ` +
+      `any new investment — that timeline doesn't depend on market conditions either.`;
+  } else if (result.status === 'no_surplus') {
+    policyNote =
+      "There's no investable surplus this month, so there's nothing to time either way — the next scheduled " +
+      'contribution will follow your existing DCA policy once surplus is available.';
+  } else {
+    policyNote = 'Once your suitability settings are complete, this reframes around your DCA schedule and allocation drift instead of market timing.';
+  }
+
+  return `${refusal} ${policyNote}\n\n${INVESTMENT_COACH_DISCLAIMER}`;
+}

--- a/apps/api/src/recommendations/investment-coach.manifest.ts
+++ b/apps/api/src/recommendations/investment-coach.manifest.ts
@@ -1,0 +1,27 @@
+import { defineAgentManifest } from './agent-manifest';
+
+/**
+ * 12.6 — Investment Coach agent manifest.
+ *
+ * `get_cash_runway` stands in for the "safe-to-spend" signal (#102's engine is not
+ * itself exposed as a standalone MCP tool today — see `analytics/brief.service.ts`'s
+ * `computeSafeToSpend`); it gives the coach the same trailing-runway aggregate the
+ * Cash Manager already uses, without adding a new tool to `AGGREGATE_TOOL_ALLOWLIST`.
+ * `get_earned_apy` and any row-level tool are deliberately excluded — this agent
+ * consumes only the aggregate portfolio/allocation/savings-rate/market-context tools.
+ */
+export const INVESTMENT_COACH_AGENT_MANIFEST = defineAgentManifest({
+  id: 'investment-coach',
+  version: '1.0.0',
+  schedule: 'monthly (after month-end facts settle) + on-demand from advisor chat',
+  toolAllowlist: [
+    'get_portfolio_value',
+    'get_allocation',
+    'get_savings_rate',
+    'get_cash_runway',
+    'get_market_context',
+  ],
+  privacyClass: 'aggregates_cloud_ok',
+  outputTypes: ['recommendation'],
+  featureFlag: 'agent_investment_coach',
+});

--- a/apps/api/src/recommendations/investment-coach.service.ts
+++ b/apps/api/src/recommendations/investment-coach.service.ts
@@ -1,0 +1,199 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { and, eq, isNull, sql } from 'drizzle-orm';
+import { DATABASE_CONNECTION } from '../db/db.module';
+import * as schema from '../db/schema';
+import { NotificationsService } from '../notifications/notifications.service';
+import { RecommendationSuppressionService } from './recommendation-suppression.service';
+import { AnalyticsService } from '../analytics/analytics.service';
+import { InvestmentsService } from '../investments/investments.service';
+import { ContributionPlanner, InvestmentCoachSettingsLike } from './contribution-planner';
+import { buildInvestmentCoachNarration } from './investment-coach-narration';
+import { INVESTMENT_COACH_AGENT_MANIFEST } from './investment-coach.manifest';
+
+const INVESTMENT_COACH_NOTIFICATION_TYPE = 'investment_coach_contribution';
+
+/**
+ * 12.6 — Investment Coach agent. Gathers sanitized (no lastFour/account-number)
+ * inputs, runs them through the deterministic `ContributionPlanner`, applies 12.1's
+ * decision-aware suppression, and persists a `recommendation` notification when the
+ * plan clears the "worth telling the user" bar (i.e. it isn't a no-op no_surplus
+ * result). Only a `status === 'recommend'` (or `fund_buffer_first`) result is worth
+ * a notification — `no_surplus`/`missing_setting` are surfaced on-demand only (advisor
+ * chat), never as a monthly nag, since there's nothing new to say.
+ */
+@Injectable()
+export class InvestmentCoachService {
+  private readonly logger = new Logger(InvestmentCoachService.name);
+
+  constructor(
+    @Inject(DATABASE_CONNECTION) private readonly db: any,
+    private readonly notificationsService: NotificationsService,
+    private readonly suppressionService: RecommendationSuppressionService,
+    private readonly analyticsService: AnalyticsService,
+    private readonly investmentsService: InvestmentsService,
+  ) {}
+
+  private async activeUsers(): Promise<Array<{ id: string }>> {
+    return this.db.select({ id: schema.users.id }).from(schema.users).where(isNull(schema.users.deletedAt));
+  }
+
+  async runForAllUsers(): Promise<void> {
+    for (const user of await this.activeUsers()) {
+      try {
+        await this.runForUser(user.id);
+      } catch (err: any) {
+        this.logger.error(`Investment Coach run failed for user ${user.id}: ${err.message}`, err.stack);
+      }
+    }
+  }
+
+  private async latestSuitabilitySettings(userId: string): Promise<InvestmentCoachSettingsLike | null> {
+    const rows = await this.db
+      .select()
+      .from(schema.suitabilitySettings)
+      .where(eq(schema.suitabilitySettings.userId, userId))
+      .orderBy(sql`version DESC`)
+      .limit(1);
+    if (rows.length === 0) return null;
+    const r = rows[0];
+    return {
+      version: r.version,
+      emergencyFundTargetMonths: r.emergencyFundTargetMonths,
+      liquidityHorizonMonths: r.liquidityHorizonMonths,
+      riskTolerance: r.riskTolerance,
+      taxState: r.taxState,
+      monthlyInvestingTargetCents: r.monthlyInvestingTargetCents,
+      targetAllocation: r.targetAllocation ?? [],
+      dcaDayOfMonth: r.dcaDayOfMonth,
+      dcaAmountCents: r.dcaAmountCents,
+      tickerAssetClassMap: r.tickerAssetClassMap ?? {},
+    };
+  }
+
+  /** Sum of liquid (checking/savings) balances — same basis 12.5's Cash Manager uses
+   * for its buffer math, reused here for the emergency-fund gate. */
+  private async currentEmergencyFundCents(userId: string): Promise<number> {
+    const accounts = await this.db
+      .select({ id: schema.accounts.id })
+      .from(schema.accounts)
+      .where(
+        and(
+          eq(schema.accounts.userId, userId),
+          isNull(schema.accounts.deletedAt),
+          sql`${schema.accounts.accountType} IN ('checking', 'savings')`,
+        ),
+      );
+    if (accounts.length === 0) return 0;
+    const accountIds = accounts.map((a: any) => a.id);
+
+    const balanceRows = await this.db.execute(sql`
+      SELECT DISTINCT ON (account_id) account_id, balance_cents
+      FROM ${schema.accountBalanceSnapshots}
+      WHERE account_id = ANY(${accountIds})
+      ORDER BY account_id, snapshot_date DESC
+    `);
+    return (balanceRows.rows ?? balanceRows).reduce((sum: number, r: any) => sum + Number(r.balance_cents), 0);
+  }
+
+  private async avgMonthlyExpenseCents(userId: string): Promise<number> {
+    const expenseRows = await this.db.execute(sql`
+      SELECT COALESCE(SUM(amount_cents), 0)::bigint AS total_cents
+      FROM ${schema.transactions}
+      WHERE user_id = ${userId}
+        AND is_credit = false
+        AND is_split_parent = false
+        AND parent_transaction_id IS NULL
+        AND deleted_at IS NULL
+        AND date >= NOW() - INTERVAL '3 months'
+    `);
+    return Math.round(Number((expenseRows.rows ?? expenseRows)[0]?.total_cents ?? 0) / 3);
+  }
+
+  async runForUser(
+    userId: string,
+  ): Promise<{ ran: boolean; suppressed: boolean; recommended: boolean }> {
+    const manifest = INVESTMENT_COACH_AGENT_MANIFEST;
+    const settings = await this.latestSuitabilitySettings(userId);
+
+    const [avgMonthlyExpenseCents, currentEmergencyFundCents, savingsRate, portfolio, allocation] =
+      await Promise.all([
+        this.avgMonthlyExpenseCents(userId),
+        this.currentEmergencyFundCents(userId),
+        this.analyticsService.savingsRate(userId, { months: 1 }),
+        this.investmentsService.getPortfolioValue(userId),
+        this.investmentsService.getAllocation(userId),
+      ]);
+
+    const trailingMonthlySurplusCents = savingsRate.current
+      ? savingsRate.current.incomeCents - savingsRate.current.expenseCents
+      : 0;
+
+    const tickerAssetClassMap: Record<string, string> = settings?.tickerAssetClassMap ?? {};
+    const currentAllocationByAssetClass = new Map<string, number>();
+    for (const a of allocation.allocations) {
+      const assetClass = tickerAssetClassMap[a.ticker];
+      if (!assetClass) continue; // unmapped ticker — cannot attribute to a target class, skip rather than guess
+      currentAllocationByAssetClass.set(assetClass, (currentAllocationByAssetClass.get(assetClass) ?? 0) + a.valueCents);
+    }
+
+    const planner = new ContributionPlanner();
+    const result = planner.plan(settings, {
+      asOfDate: new Date().toISOString().slice(0, 10),
+      avgMonthlyExpenseCents,
+      currentEmergencyFundCents,
+      trailingMonthlySurplusCents,
+      monthlyGoalContributionCents: 0, // goals feature not yet shipped in this codebase
+      totalPortfolioValueCents: portfolio.totalCents,
+      currentAllocationByAssetClass: Array.from(currentAllocationByAssetClass.entries()).map(
+        ([assetClass, valueCents]) => ({ assetClass, valueCents }),
+      ),
+    });
+
+    if (result.status !== 'recommend' && result.status !== 'fund_buffer_first') {
+      return { ran: true, suppressed: false, recommended: false };
+    }
+
+    const suppression = await this.suppressionService.checkAndSuppress(
+      userId,
+      INVESTMENT_COACH_NOTIFICATION_TYPE,
+      'calculationVersion' in result ? result.calculationVersion : 'contribution-planner-v1',
+      result.status === 'recommend' ? { contributionCents: result.contributionCents } : { gapCents: result.gapCents },
+      result.status === 'recommend'
+        ? { contributionCents: Math.max(10_000, result.contributionCents * 0.1) }
+        : { gapCents: 10_000 },
+    );
+    if (suppression.suppressed) {
+      return { ran: true, suppressed: true, recommended: false };
+    }
+
+    const message = buildInvestmentCoachNarration(result);
+    const now = new Date();
+    const periodKey = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+    const dedupeKey = `investment_coach_${userId}_${periodKey}`;
+
+    await this.notificationsService.createAndDispatch({
+      userId,
+      type: INVESTMENT_COACH_NOTIFICATION_TYPE,
+      source: 'advisor',
+      severity: 'insight',
+      title: result.status === 'recommend' ? 'Your monthly contribution plan' : 'Fund your emergency buffer first',
+      message,
+      dedupeKey,
+      kind: 'recommendation',
+      actionSummary:
+        result.status === 'recommend'
+          ? `Contribute ~$${(result.contributionCents / 100).toFixed(2)} to ${result.destinationAssetClass}`
+          : `Save ~$${(result.gapCents / 100).toFixed(2)} more toward your emergency buffer`,
+      expectedImpact: result.status === 'recommend' ? result.impact : { minCentsPerYear: 0, maxCentsPerYear: 0, basis: 'No investment impact until the emergency buffer is funded.' },
+      evidence: result.evidence,
+      assumptions: result.assumptions,
+      confidenceBand: result.confidenceBand,
+      calculationVersion: result.calculationVersion,
+      producer: { id: manifest.id, version: manifest.version },
+      expiresAt: new Date(now.getTime() + 30 * 24 * 3600_000),
+      metadata: { dedupeKey },
+    });
+
+    return { ran: true, suppressed: false, recommended: result.status === 'recommend' };
+  }
+}

--- a/apps/api/src/recommendations/recommendations.module.ts
+++ b/apps/api/src/recommendations/recommendations.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { AnalyticsModule } from '../analytics/analytics.module';
+import { InvestmentsModule } from '../investments/investments.module';
 import { AgentRunnerService } from './agent-runner.service';
 import { RecommendationSuppressionService } from './recommendation-suppression.service';
 import { CashManagerService } from './cash-manager.service';
+import { InvestmentCoachService } from './investment-coach.service';
 
 /**
  * 12.1 — the recommendation layer's runtime pieces: the agent manifest runner
@@ -11,10 +14,11 @@ import { CashManagerService } from './cash-manager.service';
  * consumed directly by `NotificationsService`, not a provider.
  *
  * 12.5 adds the first real agent, `CashManagerService`, on top of that scaffold.
+ * 12.6 adds the second, `InvestmentCoachService`.
  */
 @Module({
-  imports: [NotificationsModule],
-  providers: [AgentRunnerService, RecommendationSuppressionService, CashManagerService],
-  exports: [AgentRunnerService, RecommendationSuppressionService, CashManagerService],
+  imports: [NotificationsModule, AnalyticsModule, InvestmentsModule],
+  providers: [AgentRunnerService, RecommendationSuppressionService, CashManagerService, InvestmentCoachService],
+  exports: [AgentRunnerService, RecommendationSuppressionService, CashManagerService, InvestmentCoachService],
 })
 export class RecommendationsModule {}


### PR DESCRIPTION
Committed successfully.

## Summary

Implemented #122 (Investment Coach agent, 12.6 of the Phase 12 advisory spec):

- **`contribution-planner.ts`** — the deterministic `ContributionPlanner`, unit-tested independent of any LLM. It reuses 12.4's `requireSuitability` gate directly (never reimplements it), gates on the emergency-fund target, computes investable surplus (trailing savings-rate surplus − goal contributions − scheduled DCA), and picks the most-underweight asset class vs the user's target allocation for new contributions only — no sell/rebalance-by-selling logic, no new fund/ticker endorsement.
- **`investment-coach-narration.ts`** — narration builder plus the acceptance-critical timing-refusal contract: `buildTimingRefusalNarration` explicitly declines to predict market direction and reframes around DCA policy/allocation drift, verified with a real phrase-based predictive-claim blocklist (not just eyeballed text). A standing disclaimer is appended to all output.
- **`investment-coach.manifest.ts`** — agent manifest restricted to the existing aggregate-only tool allowlist (`get_portfolio_value`, `get_allocation`, `get_savings_rate`, `get_cash_runway`, `get_market_context`).
- **`investment-coach.service.ts`** — wires the above into a real agent following the same shape as the 12.5 Cash Manager service, reusing `AnalyticsService.savingsRate` and `InvestmentsService` allocation/portfolio queries, and 12.1's decision-aware suppression.
- Tests cover all four required acceptance scenarios with synthetic fixtures: underfunded emergency fund → "fund the buffer first" with exact gap, drifted allocation → correct asset class + dollar amount (hand-verified), the timing-refusal contract (both refusal-language presence and absence of predictive phrases), and missing `risk_tolerance` → gated "missing setting" output with zero recommendations.

Verified no `lastFour`/`last_four` account-credential leakage in any new file (only rule-reference comments), and confirmed no

_(summary truncated)_

---
### Test evidence
**13 new test case(s) added** (heuristic count):
```
 .../__tests__/contribution-planner.spec.ts         | 135 +++++++++++
 .../__tests__/investment-coach-narration.spec.ts   |  94 ++++++++
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- n/a (no check configured) `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
[32m 6[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/sync/__tests__/signing.service.spec.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 5[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/sync/__tests__/sync-payload.util.spec.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 16[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/expected-cycle-date.spec.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/audit/audit.service.spec.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 9[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/sync-delivery.processor.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 4[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/next-loan-due-date.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/categorization/__tests__/learning.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m85 passed[39m[22m[90m (85)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m696 passed[39m[22m[90m (696)[39m
@moneypulse/api:test: [2m   Start at [22m 02:56:35
@moneypulse/api:test: [2m   Duration [22m 9.13s[2m (transform 2.86s, setup 0ms, import 47.96s, tests 1.74s, environment 5ms)[22m
@moneypulse/api:test: 

 Tasks:    2 successful, 2 total
Cached:    1 cached, 2 total
  Time:    9.627s
```
</details>

### Review
**Review verdict:** approve

Findings (advisory — did not block landing):
- [low/advisory] apps/api/src/recommendations/investment-coach.service.ts:156 — Drift denominator uses full portfolio.totalCents while the numerator only sums mapped-ticker values; unmapped holdings/cash understate every class's currentPercent and can shift the chosen destination asset class (does not affect the contributed dollar amount).
- [low/advisory] apps/api/src/recommendations/investment-coach.service.ts:128 — avgMonthlyExpenseCents always divides the trailing 3-month sum by 3, understating the average when fewer than 3 months of transaction history exist.

---
Dispatched via coxd (`MyMoney-12-6-investment-coach-agent-1784688591`) · cost $2.462 · 🤖 coxd