### PR TITLE
Account editing: name, type, and interest rate

### DIFF
--- a/apps/api/src/accounts/accounts.service.ts
+++ b/apps/api/src/accounts/accounts.service.ts
@@ -53,6 +53,7 @@ export class AccountsService {
         lastFour: encryptField(input.lastFour),
         startingBalanceCents: input.startingBalanceCents,
         creditLimitCents: input.creditLimitCents ?? null,
+        interestRateBps: input.interestRateBps ?? null,
       })
       .returning();
 

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -236,6 +236,8 @@ export const accounts = pgTable('accounts', {
   lastFour: varchar('last_four', { length: 255 }).notNull(),
   startingBalanceCents: integer('starting_balance_cents').notNull().default(0),
   creditLimitCents: integer('credit_limit_cents'),
+  /** Basis points (e.g. 450 = 4.50% APY). Only meaningful for interest-bearing types (savings, cash_sweep, brokerage). */
+  interestRateBps: integer('interest_rate_bps'),
   csvFormatConfig: jsonb('csv_format_config'),
   expectedImportCadenceDays: integer('expected_import_cadence_days'),
   isDormant: boolean('is_dormant').notNull().default(false),

--- a/apps/api/src/recommendations/__tests__/cash-manager.service.spec.ts
+++ b/apps/api/src/recommendations/__tests__/cash-manager.service.spec.ts
@@ -7,8 +7,8 @@ import { RecommendationSuppressionService } from '../recommendation-suppression.
 // even if a future edit accidentally widens the select().
 const SYNTHETIC_LAST_FOUR = '4242';
 const accountsRows = [
-  { id: 'acct-1', nickname: 'Everyday Checking', lastFour: SYNTHETIC_LAST_FOUR },
-  { id: 'acct-2', nickname: 'Online Savings', lastFour: '9911' },
+  { id: 'acct-1', nickname: 'Everyday Checking', lastFour: SYNTHETIC_LAST_FOUR, interestRateBps: null },
+  { id: 'acct-2', nickname: 'Online Savings', lastFour: '9911', interestRateBps: null },
 ];
 
 function buildMockDb(opts: {
@@ -19,6 +19,8 @@ function buildMockDb(opts: {
   avgCents: number;
   watchlist: any[];
   usersRow?: any[];
+  accountsRows?: any[];
+  balanceRows?: any[];
 }) {
   let selectCall = 0;
   const db: any = {
@@ -29,7 +31,7 @@ function buildMockDb(opts: {
         from: () => ({
           where: (): any => {
             // 1st select = accounts, 3rd = watchlist (2nd is suitabilitySettings, chained)
-            if (call === 1) return Promise.resolve(accountsRows);
+            if (call === 1) return Promise.resolve(opts.accountsRows ?? accountsRows);
             if (call === 3) return Promise.resolve(opts.watchlist);
             return {
               orderBy: () => ({
@@ -43,7 +45,9 @@ function buildMockDb(opts: {
     }),
     execute: vi
       .fn()
-      .mockResolvedValueOnce([{ balance_cents: opts.balanceCents }]) // liquid balance
+      .mockResolvedValueOnce(
+        opts.balanceRows ?? [{ balance_cents: opts.balanceCents }],
+      ) // liquid balance
       .mockResolvedValueOnce([{ total_cents: opts.expenseCents * 3 }]) // trailing-3mo expense total
       .mockResolvedValueOnce([{ total_cents: opts.interestCents }]) // interest credits
       .mockResolvedValueOnce([{ avg_cents: opts.avgCents }]), // avg balance basis
@@ -135,5 +139,47 @@ describe('CashManagerService — decision-memory suppression', () => {
     expect(result.suppressed).toBe(true);
     expect(result.recommended).toBe(false);
     expect(notifications.createAndDispatch).not.toHaveBeenCalled();
+  });
+});
+
+describe('CashManagerService — prefers account-level interest_rate_bps', () => {
+  it('uses the account-entered rate instead of the transaction heuristic when set', async () => {
+    // Savings account has a directly-entered 4.00% APY; the transaction-derived heuristic
+    // (interestCents/avgCents below) would compute a much lower ~25bps figure. The account's
+    // rate should win since it's a more direct signal.
+    const db = buildMockDb({
+      balanceCents: 22_000_00,
+      expenseCents: 200_000,
+      settings: [{ emergencyFundTargetMonths: 6, taxState: 'CA' }],
+      interestCents: 5_000, // would compute ~25bps if the heuristic were used
+      avgCents: 20_000_00,
+      accountsRows: [
+        { id: 'acct-2', nickname: 'Online Savings', lastFour: '9911', interestRateBps: 400 },
+      ],
+      balanceRows: [{ account_id: 'acct-2', balance_cents: 22_000_00 }],
+      watchlist: [
+        {
+          id: 'wl-1',
+          institution: 'Synthetic Bank',
+          productType: 'hysa',
+          apyBps: 700,
+          termMonths: null,
+          updatedAt: new Date('2026-07-10'),
+        },
+      ],
+    });
+    const notifications = buildNotifications();
+    const suppression = { checkAndSuppress: vi.fn().mockResolvedValue({ suppressed: false }) };
+
+    const svc = new CashManagerService(db, notifications as any, suppression as any);
+    await svc.runForUser('user-1');
+
+    // The spread between the 700bps watchlist candidate and the account's own 400bps rate
+    // (300bps) should drive the narration/evidence, not the heuristic's much wider spread
+    // (which would have used ~25bps as the current earned rate).
+    const payload = notifications.createAndDispatch.mock.calls[0]?.[0];
+    expect(payload).toBeDefined();
+    const serialized = JSON.stringify(payload);
+    expect(serialized).toContain('4.00');
   });
 });

--- a/apps/api/src/recommendations/cash-manager.service.ts
+++ b/apps/api/src/recommendations/cash-manager.service.ts
@@ -100,7 +100,11 @@ export class CashManagerService {
     // Select only the columns this agent needs — deliberately never `lastFour`/account
     // number/routing number (see recommendation-evidence.ts's no-credentials rule).
     const accounts = await this.db
-      .select({ id: schema.accounts.id, nickname: schema.accounts.nickname })
+      .select({
+        id: schema.accounts.id,
+        nickname: schema.accounts.nickname,
+        interestRateBps: schema.accounts.interestRateBps,
+      })
       .from(schema.accounts)
       .where(
         and(
@@ -118,8 +122,14 @@ export class CashManagerService {
       WHERE account_id = ANY(${accountIds})
       ORDER BY account_id, snapshot_date DESC
     `);
-    const liquidBalanceCents = (balanceRows.rows ?? balanceRows).reduce(
-      (sum: number, r: any) => sum + Number(r.balance_cents),
+    const balanceByAccountId = new Map<string, number>(
+      (balanceRows.rows ?? balanceRows).map((r: any) => [
+        String(r.account_id),
+        Number(r.balance_cents),
+      ]),
+    );
+    const liquidBalanceCents = Array.from(balanceByAccountId.values()).reduce(
+      (sum, cents) => sum + cents,
       0,
     );
 
@@ -146,10 +156,33 @@ export class CashManagerService {
     const emergencyFundTargetMonths = settingsRows[0]?.emergencyFundTargetMonths ?? 6;
     const idleCashBufferMonths = 1; // 11.7 default; overridden by user_settings when present, handled upstream
 
-    const { apyBps: currentEarnedApyBps, asOfDate: earnedApyAsOf } = await this.computeBlendedEarnedApyBps(
-      userId,
-      accountIds,
+    // Prefer the user-entered interest_rate_bps on each account (a direct signal) over the
+    // transaction-heuristic when at least one in-scope account has it set. Blend by current
+    // balance across the accounts that have a rate set; accounts without one are excluded from
+    // this direct-signal blend (their balances still count toward liquidBalanceCents above).
+    const today = new Date().toISOString().slice(0, 10);
+    const ratedAccounts = accounts.filter(
+      (a: any) => a.interestRateBps !== null && a.interestRateBps !== undefined,
     );
+    const ratedWeight = ratedAccounts.reduce(
+      (sum: number, a: any) => sum + (balanceByAccountId.get(a.id) ?? 0),
+      0,
+    );
+
+    let currentEarnedApyBps: number;
+    let earnedApyAsOf: string;
+    if (ratedAccounts.length > 0 && ratedWeight > 0) {
+      const weightedSum = ratedAccounts.reduce(
+        (sum: number, a: any) =>
+          sum + a.interestRateBps * (balanceByAccountId.get(a.id) ?? 0),
+        0,
+      );
+      currentEarnedApyBps = Math.round(weightedSum / ratedWeight);
+      earnedApyAsOf = today;
+    } else {
+      ({ apyBps: currentEarnedApyBps, asOfDate: earnedApyAsOf } =
+        await this.computeBlendedEarnedApyBps(userId, accountIds));
+    }
 
     const watchlistRows = await this.db
       .select()

--- a/apps/api/src/recommendations/cash-manager.service.ts
+++ b/apps/api/src/recommendations/cash-manager.service.ts
@@ -122,6 +122,11 @@ export class CashManagerService {
       WHERE account_id = ANY(${accountIds})
       ORDER BY account_id, snapshot_date DESC
     `);
+    // The query above is `DISTINCT ON (account_id)`, so Postgres guarantees at most one row
+    // per account_id (the most recent snapshot). Map construction is therefore safe — there is
+    // no later-row-wins ambiguity to worry about. If this query is ever changed to return
+    // multiple snapshot rows per account, this Map.set()-per-row approach would silently keep
+    // only the last-iterated row instead of summing; re-verify this invariant before doing so.
     const balanceByAccountId = new Map<string, number>(
       (balanceRows.rows ?? balanceRows).map((r: any) => [
         String(r.account_id),

--- a/apps/web/src/app/(protected)/accounts/page.tsx
+++ b/apps/web/src/app/(protected)/accounts/page.tsx
@@ -41,6 +41,7 @@ export default function AccountsPage() {
     lastFour: '',
     startingBalanceCents: 0,
     creditLimitCents: null as number | null,
+    interestRatePercent: '',
   });
 
   const accounts = accountsData?.data ?? [];
@@ -57,12 +58,17 @@ export default function AccountsPage() {
   /** Handle form submission to create a new account. */
   async function handleCreate(e: React.FormEvent) {
     e.preventDefault();
+    const isInterestBearing = INTEREST_BEARING_TYPES.includes(form.accountType);
     await createAccount.mutateAsync({
       ...form,
       startingBalanceCents: Math.round(form.startingBalanceCents * 100),
       creditLimitCents:
         form.accountType === 'credit_card' && form.creditLimitCents !== null
           ? Math.round(form.creditLimitCents * 100)
+          : null,
+      interestRateBps:
+        isInterestBearing && form.interestRatePercent.trim() !== ''
+          ? Math.round(parseFloat(form.interestRatePercent) * 100)
           : null,
     });
     setShowForm(false);
@@ -73,6 +79,7 @@ export default function AccountsPage() {
       lastFour: '',
       startingBalanceCents: 0,
       creditLimitCents: null,
+      interestRatePercent: '',
     });
   }
 
@@ -204,6 +211,20 @@ export default function AccountsPage() {
                   onChange={(e) =>
                     setForm({ ...form, creditLimitCents: e.target.value ? Number(e.target.value) : null })
                   }
+                  className="w-full rounded-xl border border-[var(--border)] bg-[var(--surface-container-low)] px-3 py-2.5 text-sm focus:border-[var(--primary)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)]/30 transition-all"
+                />
+              </div>
+            )}
+            {INTEREST_BEARING_TYPES.includes(form.accountType) && (
+              <div>
+                <label className="mb-1.5 block text-sm font-semibold">Interest Rate / APY (%)</label>
+                <input
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  value={form.interestRatePercent}
+                  onChange={(e) => setForm({ ...form, interestRatePercent: e.target.value })}
+                  placeholder="e.g. 4.50"
                   className="w-full rounded-xl border border-[var(--border)] bg-[var(--surface-container-low)] px-3 py-2.5 text-sm focus:border-[var(--primary)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)]/30 transition-all"
                 />
               </div>

--- a/apps/web/src/app/(protected)/accounts/page.tsx
+++ b/apps/web/src/app/(protected)/accounts/page.tsx
@@ -1,12 +1,21 @@
 'use client';
 
 import { useState } from 'react';
-import { Plus, Landmark, Trash2, Pencil } from 'lucide-react';
-import { useAccounts, useCreateAccount, useDeleteAccount, useReconcileAccount } from '@/lib/hooks/useAccounts';
+import { Plus, Landmark, Trash2, Pencil, Settings } from 'lucide-react';
+import {
+  useAccounts,
+  useCreateAccount,
+  useDeleteAccount,
+  useReconcileAccount,
+  useUpdateAccount,
+} from '@/lib/hooks/useAccounts';
 import { formatCents } from '@/lib/format';
 import { cn } from '@/lib/utils';
 import { BankLogo } from '@/components/BankLogo';
-import type { Institution, AccountType } from '@moneypulse/shared';
+import type { Account, Institution, AccountType } from '@moneypulse/shared';
+
+/** Account types that can carry an interest rate. */
+const INTEREST_BEARING_TYPES: AccountType[] = ['savings', 'cash_sweep', 'brokerage'];
 
 /** Accounts page — view, create, and manage bank accounts. */
 export default function AccountsPage() {
@@ -14,10 +23,17 @@ export default function AccountsPage() {
   const createAccount = useCreateAccount();
   const deleteAccount = useDeleteAccount();
   const reconcileAccount = useReconcileAccount();
+  const updateAccount = useUpdateAccount();
   const [showForm, setShowForm] = useState(false);
   const [reconcileTarget, setReconcileTarget] = useState<{ id: string; nickname: string; accountType: string } | null>(null);
   const [reconcileAmount, setReconcileAmount] = useState('');
   const [reconcileMsg, setReconcileMsg] = useState('');
+  const [editTarget, setEditTarget] = useState<Account | null>(null);
+  const [editForm, setEditForm] = useState({
+    nickname: '',
+    accountType: 'checking' as AccountType,
+    interestRatePercent: '',
+  });
   const [form, setForm] = useState({
     institution: 'boa' as Institution,
     accountType: 'checking' as AccountType,
@@ -58,6 +74,35 @@ export default function AccountsPage() {
       startingBalanceCents: 0,
       creditLimitCents: null,
     });
+  }
+
+  /** Open the edit modal, pre-filling from the selected account. */
+  function openEdit(account: Account) {
+    setEditTarget(account);
+    setEditForm({
+      nickname: account.nickname,
+      accountType: account.accountType,
+      interestRatePercent:
+        account.interestRateBps != null ? (account.interestRateBps / 100).toString() : '',
+    });
+  }
+
+  /** Handle form submission to update an existing account's nickname/type/interest rate. */
+  async function handleEditSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!editTarget) return;
+    const isInterestBearing = INTEREST_BEARING_TYPES.includes(editForm.accountType);
+    const interestRateBps =
+      isInterestBearing && editForm.interestRatePercent.trim() !== ''
+        ? Math.round(parseFloat(editForm.interestRatePercent) * 100)
+        : null;
+    await updateAccount.mutateAsync({
+      id: editTarget.id,
+      nickname: editForm.nickname,
+      accountType: editForm.accountType,
+      interestRateBps,
+    });
+    setEditTarget(null);
   }
 
   return (
@@ -224,6 +269,14 @@ export default function AccountsPage() {
                   </div>
                   <div className="flex items-center gap-1">
                     <button
+                      onClick={() => openEdit(account)}
+                      className="rounded-full p-1.5 text-[var(--muted-foreground)] hover:bg-[var(--muted)] hover:text-[var(--primary)] transition-colors"
+                      aria-label="Edit account"
+                      title="Edit nickname, type, or interest rate"
+                    >
+                      <Settings className="h-4 w-4" />
+                    </button>
+                    <button
                       onClick={() => {
                         setReconcileTarget({
                           id: account.id,
@@ -258,6 +311,11 @@ export default function AccountsPage() {
                 {account.creditLimitCents && (
                   <p className="mt-1 text-xs text-[var(--muted-foreground)]">
                     Limit: {formatCents(account.creditLimitCents)}
+                  </p>
+                )}
+                {account.interestRateBps != null && (
+                  <p className="mt-1 text-xs text-[var(--muted-foreground)]">
+                    APY: {(account.interestRateBps / 100).toFixed(2)}%
                   </p>
                 )}
                 {/* Bottom accent bar */}
@@ -338,6 +396,75 @@ export default function AccountsPage() {
               {reconcileMsg && (
                 <p className="text-sm text-green-600 dark:text-green-400">{reconcileMsg}</p>
               )}
+            </form>
+          </div>
+        </div>
+      )}
+      {/* Edit Modal */}
+      {editTarget && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="w-full max-w-md max-h-[90vh] overflow-y-auto rounded-xl border border-[var(--border)] bg-[var(--card)] p-6 shadow-xl">
+            <h2 className="text-lg font-semibold mb-4">Edit Account</h2>
+            <form onSubmit={handleEditSubmit} className="space-y-4">
+              <div>
+                <label className="mb-1.5 block text-sm font-semibold">Nickname</label>
+                <input
+                  type="text"
+                  required
+                  value={editForm.nickname}
+                  onChange={(e) => setEditForm({ ...editForm, nickname: e.target.value })}
+                  className="w-full rounded-xl border border-[var(--border)] bg-[var(--surface-container-low)] px-3 py-2.5 text-sm focus:border-[var(--primary)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)]/30 transition-all"
+                />
+              </div>
+              <div>
+                <label className="mb-1.5 block text-sm font-semibold">Account Type</label>
+                <select
+                  value={editForm.accountType}
+                  onChange={(e) =>
+                    setEditForm({ ...editForm, accountType: e.target.value as AccountType })
+                  }
+                  className="w-full rounded-xl border border-[var(--border)] bg-[var(--surface-container-low)] px-3 py-2.5 text-sm focus:border-[var(--primary)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)]/30 transition-all"
+                >
+                  <option value="checking">Checking</option>
+                  <option value="savings">Savings</option>
+                  <option value="credit_card">Credit Card</option>
+                  <option value="edu_529">529 Education Savings</option>
+                  <option value="brokerage">Brokerage / Index Fund</option>
+                  <option value="cash_sweep">Cash Sweep (interest-bearing)</option>
+                </select>
+              </div>
+              {INTEREST_BEARING_TYPES.includes(editForm.accountType) && (
+                <div>
+                  <label className="mb-1.5 block text-sm font-semibold">Interest Rate / APY (%)</label>
+                  <input
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    value={editForm.interestRatePercent}
+                    onChange={(e) =>
+                      setEditForm({ ...editForm, interestRatePercent: e.target.value })
+                    }
+                    placeholder="e.g. 4.50"
+                    className="w-full rounded-xl border border-[var(--border)] bg-[var(--surface-container-low)] px-3 py-2.5 text-sm focus:border-[var(--primary)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)]/30 transition-all"
+                  />
+                </div>
+              )}
+              <div className="flex items-center justify-end gap-3 pt-2">
+                <button
+                  type="button"
+                  onClick={() => setEditTarget(null)}
+                  className="rounded-lg border border-[var(--border)] px-4 py-2 text-sm hover:bg-[var(--muted)]"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={updateAccount.isPending}
+                  className="flex items-center gap-2 rounded-lg bg-[var(--primary)] px-4 py-2 text-sm font-medium text-[var(--primary-foreground)] hover:opacity-90 disabled:opacity-50"
+                >
+                  {updateAccount.isPending ? 'Saving...' : 'Save Changes'}
+                </button>
+              </div>
             </form>
           </div>
         </div>

--- a/db/migrations/0029_account_interest_rate.sql
+++ b/db/migrations/0029_account_interest_rate.sql
@@ -1,0 +1,5 @@
+-- Add nullable interest_rate_bps to accounts so interest-bearing accounts
+-- (savings, cash_sweep, etc.) can record their own APY directly.
+-- Additive-only: nullable column, no backfill, existing rows get NULL.
+
+ALTER TABLE "accounts" ADD COLUMN IF NOT EXISTS "interest_rate_bps" integer;

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1784560600000,
       "tag": "0028_suitability_settings",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1784560700000,
+      "tag": "0029_account_interest_rate",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -78,6 +78,8 @@ export interface Account {
   lastFour: string;
   startingBalanceCents: number;
   creditLimitCents: number | null;
+  /** Basis points (e.g. 450 = 4.50% APY). Only meaningful for interest-bearing types. */
+  interestRateBps: number | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/packages/shared/src/validation/index.ts
+++ b/packages/shared/src/validation/index.ts
@@ -54,6 +54,8 @@ export const createAccountSchema = z.object({
     .regex(/^\d{4}$/),
   startingBalanceCents: z.int(),
   creditLimitCents: z.int().nullable().optional(),
+  /** Basis points (e.g. 450 = 4.50% APY). Only meaningful for interest-bearing types. */
+  interestRateBps: z.int().min(0).max(100000).nullable().optional(),
 });
 
 export const updateAccountSchema = createAccountSchema.partial();


### PR DESCRIPTION
Committed.

## Summary

Addressed the three review findings from the previous pass:

1. **Contract (med) — verified, no change needed**: `AccountsService.update()` was audited and confirmed to already persist `interestRateBps`. Unlike `create()`, which maps columns explicitly, `update()` spreads the full validated `UpdateAccountInput` directly onto Drizzle's `set()` — the same mechanism `nickname`/`accountType` already relied on. So edit-modal saves were never silently dropping the rate; this was confirmed structurally by reading the update method and re-running the full API test suite (716 tests, all passing) rather than by inspecting any live data.

2. **Advisory — create-form gap**: added the interest-rate percentage input to the account **create** form (previously only the edit modal exposed it), gated on the same interest-bearing account types. A new savings/cash_sweep/brokerage account can now have its APY recorded in one step instead of requiring create-then-edit.

3. **Advisory — balance-Map invariant**: added a comment above the `balanceByAccountId` Map construction in `cash-manager.service.ts` documenting that the underlying query is `DISTINCT ON (account_id)` (guaranteeing at most one row per account), so the map-per-row approach is safe today, and flagging that this must be re-verified if that query is ever changed to return multiple snapshot rows per account.

Verified: `packages/shared` and `apps/api` build cleanly, `apps/web`'s modified file type-checks with no new errors, and the full API test suite (88 files / 716 tests) passes.

---
### Test evidence
**1 new test case(s) added** (heuristic count):
```
 .../__tests__/cash-manager.service.spec.ts         |  54 +++++++-
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

### Review
**Review verdict:** fix

Findings (advisory — did not block landing):
- [med/contract] apps/api/src/accounts/accounts.service.ts:56 — Only the create path is shown persisting interestRateBps; the edit modal writes exclusively through the update service, which is not in the diff. If update() maps columns explicitly (as create does for creditLimitCents/lastFour), interestRateBps must be added there too — otherwise every edit-modal save silently drops the rate and the cash-manager feature that depends on it never receives data. Verify update() persists interestRateBps.
- [low/advisory] apps/web/src/app/(protected)/accounts/page.tsx:76 — The account create form was not given an interest-rate input; the rate can only be set via the edit modal, so a newly created interest-bearing account requires a second edit step to record its APY.
- [low/advisory] apps/api/src/recommendations/cash-manager.service.ts:124 — The balance Map refactor assumes one row per account_id (DISTINCT ON); if the underlying SQL ever returns multiple snapshot rows per account, Map.set would keep only the last-iterated (oldest) snapshot instead of summing — worth a brief comment or DISTINCT ON assertion to lock the invariant.

---
Dispatched via coxd (`MyMoney-account-editing-name-type-an-1784943605`) · cost $2.729 · 🤖 coxd