### PR TITLE
Subscriptions page: merge duplicate merchant variants, edit/deactivate

### DIFF
--- a/apps/web/src/app/(protected)/subscriptions/page.tsx
+++ b/apps/web/src/app/(protected)/subscriptions/page.tsx
@@ -1,11 +1,19 @@
 'use client';
 
+import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { Repeat, TrendingUp, AlertTriangle } from 'lucide-react';
+import { Repeat, TrendingUp, AlertTriangle, Pencil, Ban, Trash2, Merge, X, Check } from 'lucide-react';
 import { formatCents } from '@/lib/format';
 import { useSubscriptions } from '@/lib/hooks/useSubscriptions';
 import { useCategories } from '@/lib/hooks/useCategories';
-import type { SubscriptionItem, BillFrequency } from '@moneypulse/shared';
+import {
+  useBills,
+  useUpdateBill,
+  useDeactivateBill,
+  useDeleteBill,
+} from '@/lib/hooks/useBills';
+import { useCreateMerchantAlias } from '@/lib/hooks/useMerchantAliases';
+import type { SubscriptionItem, RecurringBill, BillFrequency } from '@moneypulse/shared';
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -17,6 +25,8 @@ const FREQ_LABELS: Record<BillFrequency, string> = {
   semi_annual: 'Semi-annual',
   annual: 'Annual',
 };
+
+const FREQ_OPTIONS = Object.keys(FREQ_LABELS) as BillFrequency[];
 
 function totalAnnual(subs: SubscriptionItem[]): number {
   return subs.reduce((sum, s) => sum + s.annualCostCents, 0);
@@ -48,23 +58,305 @@ function PriceIncreaseBadge({ sub }: { sub: SubscriptionItem }) {
   );
 }
 
-function SubscriptionRow({ sub }: { sub: SubscriptionItem }) {
+function EditSubscriptionForm({
+  sub,
+  categories,
+  onCancel,
+}: {
+  sub: SubscriptionItem;
+  categories: Array<{ id: string; name: string }>;
+  onCancel: () => void;
+}) {
+  const updateBill = useUpdateBill();
+  const [name, setName] = useState(sub.name);
+  const [amount, setAmount] = useState((sub.amountCents / 100).toFixed(2));
+  const [frequency, setFrequency] = useState<BillFrequency>(sub.frequency);
+  const [categoryId, setCategoryId] = useState<string>(sub.categoryId ?? '');
+
+  const handleSave = async () => {
+    const cents = Math.round(parseFloat(amount) * 100);
+    if (!name.trim() || !Number.isFinite(cents) || cents <= 0) return;
+    await updateBill.mutateAsync({
+      id: sub.id,
+      normalizedName: name.trim(),
+      expectedAmountCents: cents,
+      frequency,
+      categoryId: categoryId || null,
+    });
+    onCancel();
+  };
+
+  return (
+    <div className="flex flex-1 flex-wrap items-center gap-2">
+      <input
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        className="min-w-[10rem] flex-1 rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-sm"
+        placeholder="Name"
+      />
+      <input
+        value={amount}
+        onChange={(e) => setAmount(e.target.value)}
+        inputMode="decimal"
+        className="w-24 rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-sm"
+        placeholder="Amount"
+      />
+      <select
+        value={frequency}
+        onChange={(e) => setFrequency(e.target.value as BillFrequency)}
+        className="rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-sm"
+      >
+        {FREQ_OPTIONS.map((f) => (
+          <option key={f} value={f}>
+            {FREQ_LABELS[f]}
+          </option>
+        ))}
+      </select>
+      <select
+        value={categoryId}
+        onChange={(e) => setCategoryId(e.target.value)}
+        className="rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-sm"
+      >
+        <option value="">Uncategorized</option>
+        {categories.map((c) => (
+          <option key={c.id} value={c.id}>
+            {c.name}
+          </option>
+        ))}
+      </select>
+      <button
+        onClick={handleSave}
+        disabled={updateBill.isPending}
+        title="Save"
+        className="rounded p-1.5 text-green-600 hover:bg-green-50 dark:hover:bg-green-900/20"
+      >
+        <Check className="h-4 w-4" />
+      </button>
+      <button
+        onClick={onCancel}
+        title="Cancel"
+        className="rounded p-1.5 text-[var(--muted-foreground)] hover:bg-[var(--muted)]"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}
+
+function SubscriptionRow({
+  sub,
+  categories,
+  selectable = false,
+  selected = false,
+  onToggleSelect,
+}: {
+  sub: SubscriptionItem;
+  categories: Array<{ id: string; name: string }>;
+  selectable?: boolean;
+  selected?: boolean;
+  onToggleSelect?: (id: string) => void;
+}) {
+  const [isEditing, setIsEditing] = useState(false);
+  const deactivate = useDeactivateBill();
+  const remove = useDeleteBill();
+
+  if (isEditing) {
+    return (
+      <div className="flex items-center gap-4 rounded-lg bg-[var(--surface-container-low)] px-4 py-3">
+        <EditSubscriptionForm
+          sub={sub}
+          categories={categories}
+          onCancel={() => setIsEditing(false)}
+        />
+      </div>
+    );
+  }
+
   return (
     <div className="flex items-center justify-between gap-4 rounded-lg bg-[var(--surface-container-low)] px-4 py-3">
-      <div className="flex min-w-0 flex-col gap-0.5">
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="font-medium truncate">{sub.name}</span>
-          <PriceIncreaseBadge sub={sub} />
+      <div className="flex min-w-0 items-center gap-3">
+        {selectable && (
+          <input
+            type="checkbox"
+            checked={selected}
+            onChange={() => onToggleSelect?.(sub.id)}
+            className="h-4 w-4 shrink-0"
+            aria-label={`Select ${sub.name}`}
+          />
+        )}
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-medium truncate">{sub.name}</span>
+            <PriceIncreaseBadge sub={sub} />
+          </div>
+          <span className="text-xs text-[var(--muted-foreground)]">
+            {FREQ_LABELS[sub.frequency]} · {formatCents(sub.amountCents)}/cycle
+          </span>
         </div>
-        <span className="text-xs text-[var(--muted-foreground)]">
-          {FREQ_LABELS[sub.frequency]} · {formatCents(sub.amountCents)}/cycle
+      </div>
+      <div className="flex shrink-0 items-center gap-4">
+        <div className="flex flex-col items-end">
+          <span className="text-sm font-semibold">{formatCents(sub.annualCostCents)}/yr</span>
+          <span className="text-xs text-[var(--muted-foreground)]">
+            {formatCents(Math.round(sub.annualCostCents / 12))}/mo avg
+          </span>
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={() => setIsEditing(true)}
+            title="Edit"
+            className="rounded p-1.5 text-[var(--muted-foreground)] hover:bg-[var(--muted)] transition-colors"
+          >
+            <Pencil className="h-4 w-4" />
+          </button>
+          <button
+            onClick={() => deactivate.mutate(sub.id)}
+            disabled={deactivate.isPending}
+            title="No longer using this"
+            className="rounded p-1.5 text-[var(--muted-foreground)] hover:bg-[var(--muted)] transition-colors"
+          >
+            <Ban className="h-4 w-4" />
+          </button>
+          <button
+            onClick={() => {
+              if (confirm(`Delete "${sub.name}" permanently?`)) remove.mutate(sub.id);
+            }}
+            disabled={remove.isPending}
+            title="Delete"
+            className="rounded p-1.5 text-[var(--destructive)] hover:bg-[var(--destructive)]/10 transition-colors"
+          >
+            <Trash2 className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Merge bar ────────────────────────────────────────────────
+
+function MergeBar({
+  selectedIds,
+  subs,
+  billsById,
+  billsLoaded,
+  onDone,
+  onCancel,
+}: {
+  selectedIds: Set<string>;
+  subs: SubscriptionItem[];
+  billsById: Map<string, RecurringBill>;
+  billsLoaded: boolean;
+  onDone: () => void;
+  onCancel: () => void;
+}) {
+  const selectedSubs = useMemo(
+    () => subs.filter((s) => selectedIds.has(s.id)),
+    [subs, selectedIds],
+  );
+
+  const defaultSurvivorId = useMemo(() => {
+    let best: string | null = null;
+    let bestTime = -Infinity;
+    for (const s of selectedSubs) {
+      const bill = billsById.get(s.id);
+      const t = bill?.lastSeenDate ? new Date(bill.lastSeenDate).getTime() : -Infinity;
+      if (t > bestTime) {
+        bestTime = t;
+        best = s.id;
+      }
+    }
+    return best ?? selectedSubs[0]?.id ?? null;
+  }, [selectedSubs, billsById]);
+
+  const [survivorId, setSurvivorId] = useState<string | null>(defaultSurvivorId);
+
+  useEffect(() => {
+    setSurvivorId((prev) => (prev && selectedIds.has(prev) ? prev : defaultSurvivorId));
+  }, [defaultSurvivorId, selectedIds]);
+
+  const [isMerging, setIsMerging] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const createAlias = useCreateMerchantAlias();
+  const deactivate = useDeactivateBill();
+
+  const handleMerge = async () => {
+    if (!survivorId || !billsLoaded) return;
+    setError(null);
+    setIsMerging(true);
+    try {
+      const survivorBill = billsById.get(survivorId);
+      const survivorSub = subs.find((s) => s.id === survivorId);
+      const survivorName = survivorBill?.normalizedName ?? survivorSub?.name ?? '';
+
+      const others = [...selectedIds].filter((id) => id !== survivorId);
+      for (const id of others) {
+        const bill = billsById.get(id);
+        if (bill?.merchantPattern && survivorName) {
+          await createAlias.mutateAsync({
+            pattern: bill.merchantPattern,
+            matchType: 'exact',
+            displayName: survivorName,
+          });
+        }
+        await deactivate.mutateAsync(id);
+      }
+      onDone();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Merge failed. Please try again.');
+    } finally {
+      setIsMerging(false);
+    }
+  };
+
+  return (
+    <div className="rounded-xl border border-[var(--primary)]/30 bg-[var(--primary)]/5 p-4 space-y-3">
+      <div className="flex items-center gap-2">
+        <Merge className="h-4 w-4 text-[var(--primary)]" />
+        <span className="text-sm font-semibold">
+          Merge {selectedIds.size} selected subscriptions
         </span>
       </div>
-      <div className="flex flex-col items-end shrink-0">
-        <span className="text-sm font-semibold">{formatCents(sub.annualCostCents)}/yr</span>
-        <span className="text-xs text-[var(--muted-foreground)]">
-          {formatCents(Math.round(sub.annualCostCents / 12))}/mo avg
-        </span>
+      <p className="text-xs text-[var(--muted-foreground)]">
+        Pick the row to keep. The others will be deactivated and their merchant text will be
+        remembered as aliases so future imports don&apos;t recreate the duplicate.
+      </p>
+      <div className="space-y-2">
+        {selectedSubs.map((s) => (
+          <label
+            key={s.id}
+            className="flex items-center gap-2 rounded-lg bg-[var(--surface-container-low)] px-3 py-2 text-sm"
+          >
+            <input
+              type="radio"
+              name="survivor"
+              checked={survivorId === s.id}
+              onChange={() => setSurvivorId(s.id)}
+            />
+            <span className="font-medium">{s.name}</span>
+            <span className="text-xs text-[var(--muted-foreground)]">
+              {formatCents(s.amountCents)}/{FREQ_LABELS[s.frequency].toLowerCase()}
+            </span>
+          </label>
+        ))}
+      </div>
+      {error && <p className="text-xs text-[var(--destructive)]">{error}</p>}
+      <div className="flex items-center gap-3">
+        <button
+          onClick={handleMerge}
+          disabled={isMerging || !survivorId || !billsLoaded}
+          className="rounded-lg bg-[var(--primary)] px-4 py-2 text-sm font-semibold text-[var(--primary-foreground)] hover:opacity-90 disabled:opacity-50"
+        >
+          {isMerging ? 'Merging…' : billsLoaded ? 'Merge' : 'Loading…'}
+        </button>
+        <button
+          onClick={onCancel}
+          disabled={isMerging}
+          className="rounded-lg border border-[var(--border)] px-4 py-2 text-sm font-semibold hover:bg-[var(--muted)] disabled:opacity-50"
+        >
+          Cancel
+        </button>
       </div>
     </div>
   );
@@ -75,11 +367,36 @@ function SubscriptionRow({ sub }: { sub: SubscriptionItem }) {
 export default function SubscriptionsPage() {
   const { data, isLoading } = useSubscriptions();
   const { data: categoriesData } = useCategories();
+  const { data: billsData, isLoading: isBillsLoading } = useBills();
+
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
   const subs = data?.data ?? [];
-  const catMap = new Map(
-    (categoriesData?.data ?? []).map((c) => [c.id, c.name]),
+  const categories = categoriesData?.data ?? [];
+  const catMap = new Map(categories.map((c) => [c.id, c.name]));
+  const billsById = useMemo(
+    () => new Map((billsData?.data ?? []).map((b) => [b.id, b])),
+    [billsData],
   );
+
+  // Drop selections for subs that no longer exist (e.g. after merge/delete).
+  const subIdsKey = subs.map((s) => s.id).join(',');
+  useEffect(() => {
+    setSelectedIds((prev) => {
+      const validIds = new Set(subIdsKey ? subIdsKey.split(',') : []);
+      const next = new Set([...prev].filter((id) => validIds.has(id)));
+      return next.size === prev.size ? prev : next;
+    });
+  }, [subIdsKey]);
+
+  const toggleSelect = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
 
   const annualTotal = totalAnnual(subs);
   const monthlyAvg = Math.round(annualTotal / 12);
@@ -135,10 +452,22 @@ export default function SubscriptionsPage() {
           </div>
           <div className="space-y-2">
             {priceIncreases.map((s) => (
-              <SubscriptionRow key={s.id} sub={s} />
+              <SubscriptionRow key={s.id} sub={s} categories={categories} />
             ))}
           </div>
         </div>
+      )}
+
+      {/* Merge bar */}
+      {selectedIds.size >= 2 && (
+        <MergeBar
+          selectedIds={selectedIds}
+          subs={subs}
+          billsById={billsById}
+          billsLoaded={!isBillsLoading}
+          onDone={() => setSelectedIds(new Set())}
+          onCancel={() => setSelectedIds(new Set())}
+        />
       )}
 
       {/* All subscriptions list */}
@@ -165,11 +494,23 @@ export default function SubscriptionsPage() {
         </div>
       ) : (
         <div className="space-y-2">
-          <h2 className="text-sm font-semibold text-[var(--muted-foreground)] uppercase tracking-wide">
-            All Subscriptions
-          </h2>
+          <div className="flex items-center justify-between">
+            <h2 className="text-sm font-semibold text-[var(--muted-foreground)] uppercase tracking-wide">
+              All Subscriptions
+            </h2>
+            <span className="text-xs text-[var(--muted-foreground)]">
+              Select 2+ rows that are really the same subscription to merge them.
+            </span>
+          </div>
           {subs.map((s) => (
-            <SubscriptionRow key={s.id} sub={s} />
+            <SubscriptionRow
+              key={s.id}
+              sub={s}
+              categories={categories}
+              selectable
+              selected={selectedIds.has(s.id)}
+              onToggleSelect={toggleSelect}
+            />
           ))}
         </div>
       )}


### PR DESCRIPTION
Committed.

## Summary

The Subscriptions page was read-only: duplicate rows for the same real-world subscription (distinct raw-merchant-text variants) could only be resolved by navigating to `/bills`, and there was no way to merge them at all.

**Root cause:** `deduplicateBills()` intentionally only merges exact `normalizedName` matches (correctly — fuzzy matching risks conflating genuinely distinct products like Spectrum internet vs. Spectrum Mobile). Everything past exact-match dedup needs a human decision, but the UI never exposed one.

**Fix (frontend-only, no backend/schema changes):**
- Added multi-select checkboxes to `/subscriptions` rows plus a merge bar: pick a survivor among 2+ selected rows, then for each non-survivor the raw merchant text is registered as a merchant alias pointing at the survivor's canonical name (via the existing `POST /merchant-aliases` endpoint, `matchType: 'exact'`) and the non-survivor bill is deactivated (existing `POST /bills/:id/deactivate`). This keeps merging strictly manual/user-initiated — no new fuzzy-matching logic was added anywhere.
- Added inline per-row edit (name/amount/frequency/category via the existing `PATCH /bills/:id` + `useUpdateBill` hook), deactivate, and delete actions directly on `/subscriptions`, reusing the same hooks already wired up on `/bills` (`useDeactivateBill`, `useDeleteBill`, `useUpdateBill`) rather than duplicating that logic.
- Left the existing `annualCostCents/12`/mo-avg display as-is per the acceptance note — verified it renders correctly against the schema's `BillFrequency` enum values (including `annual`).

**Verification:** `tsc --noEmit` and `eslint` pass clean on the changed file and the rest of the web app; no other files were touched.

---
### Test evidence
_No test files were added or modified in this change._

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
3 skipped[39m[2m)[22m[32m 212[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/mobile-card.spec.tsx [2m([22m[2m8 tests[22m[2m)[22m[32m 217[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/investment-holdings.spec.tsx [2m([22m[2m4 tests[22m[2m)[22m[33m 454[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/mobile-nav.spec.tsx [2m([22m[2m15 tests[22m[2m)[22m[33m 567[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/format.spec.ts [2m([22m[2m13 tests[22m[2m)[22m[32m 21[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/split-transaction.spec.tsx [2m([22m[2m10 tests[22m[2m)[22m[33m 1083[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/pwa.spec.tsx [2m([22m[2m5 tests[22m[2m)[22m[32m 12[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/add-transaction.spec.tsx [2m([22m[2m9 tests[22m[2m)[22m[33m 1076[2mms[22m[39m
@moneypulse/web:test: 
@moneypulse/web:test: [2m Test Files [22m [1m[32m9 passed[39m[22m[90m (9)[39m
@moneypulse/web:test: [2m      Tests [22m [1m[32m75 passed[39m[22m[2m | [22m[33m3 skipped[39m[90m (78)[39m
@moneypulse/web:test: [2m   Start at [22m 08:59:17
@moneypulse/web:test: [2m   Duration [22m 2.81s[2m (transform 728ms, setup 611ms, import 2.68s, tests 3.65s, environment 8.54s)[22m
@moneypulse/web:test: 

 Tasks:    2 successful, 2 total
Cached:    1 cached, 2 total
  Time:    4.139s
```
</details>

### Review
**Review verdict:** approve

Findings (advisory — did not block landing):
- [low/correctness] apps/web/src/app/(protected)/subscriptions/page.tsx:142 — Merge loop is non-atomic and possibly non-idempotent: if a later deactivate/alias call fails after earlier createAlias calls succeed, the merge is left half-applied; retrying may re-attempt already-created aliases and fail permanently if the alias endpoint rejects duplicate patterns (behavior unverifiable without backend). Consider upsert semantics or wrapping in a single batch endpoint.
- [low/advisory] apps/web/src/app/(protected)/subscriptions/page.tsx:76 — EditSubscriptionForm.handleSave awaits mutateAsync without try/catch, so a failed update produces an unhandled promise rejection and no user-facing error (unlike MergeBar which handles errors).
- [low/advisory] apps/web/src/app/(protected)/subscriptions/page.tsx:320 — billsLoaded is derived from !isBillsLoading, which is true even on a query error with empty billsById; a merge could then deactivate rows without creating the alias mappings that prevent duplicate re-import. Gate on billsData being present instead.

---
Dispatched via coxd (`MyMoney-subscriptions-page-merge-dup-1784984087`) · cost $1.549 · 🤖 coxd