### PR TITLE
AI observability: pre-flight PII redaction before cloud LLM calls (sec

### DIFF
--- a/apps/api/src/advisor/__tests__/advisor.service.spec.ts
+++ b/apps/api/src/advisor/__tests__/advisor.service.spec.ts
@@ -157,6 +157,54 @@ describe('AdvisorService', () => {
       expect(c.turnParams[0].model).toBe('gpt-4o');
     });
 
+    it('redacts PII from the message before it reaches the cloud provider', async () => {
+      ctx.turns.push(
+        makeTurn(['ok'], {
+          text: 'ok',
+          content: [{ type: 'text', text: 'ok' }],
+          toolCalls: [],
+          stopReason: 'end_turn',
+          usage: { inputTokens: 1, outputTokens: 1 },
+        }),
+      );
+      const rawMessage = 'My SSN is 123-45-6789, email me at jane@example.com';
+      await collect(ctx.service.streamChat('u1', rawMessage));
+
+      // What the provider actually received must not contain the raw PII.
+      const sentMessages = ctx.turnParams[0].messages;
+      const sentUserContent = sentMessages[0].content;
+      expect(sentUserContent).not.toContain('123-45-6789');
+      expect(sentUserContent).not.toContain('jane@example.com');
+      expect(sentUserContent).toContain('[SSN]');
+      expect(sentUserContent).toContain('[EMAIL]');
+
+      // The audit log still records what PII types were caught.
+      const log = ctx.aiLogs.create.mock.calls[0][0];
+      expect(log.piiDetected).toBe(true);
+      expect(log.piiTypesFound).toEqual(expect.arrayContaining(['SSN', 'EMAIL']));
+    });
+
+    it('does not redact for a local (non-cloud) provider', async () => {
+      const c = build({
+        resolved: { provider: 'ollama', model: 'llama3.2', apiKey: '', keySource: 'env' },
+      });
+      c.turns.push(
+        makeTurn(['ok'], {
+          text: 'ok',
+          content: [{ type: 'text', text: 'ok' }],
+          toolCalls: [],
+          stopReason: 'end_turn',
+          usage: { inputTokens: 1, outputTokens: 1 },
+        }),
+      );
+      const rawMessage = 'My SSN is 123-45-6789';
+      await collect(c.service.streamChat('u1', rawMessage));
+
+      const sentMessages = c.turnParams[0].messages;
+      const sentUserContent = sentMessages[0].content;
+      expect(sentUserContent).toBe(rawMessage);
+    });
+
     it('refuses without a tool call when nothing fits', async () => {
       ctx.turns.push(
         makeTurn(["I don't have a way to answer that from your data."], {

--- a/apps/api/src/advisor/__tests__/advisor.service.spec.ts
+++ b/apps/api/src/advisor/__tests__/advisor.service.spec.ts
@@ -184,6 +184,25 @@ describe('AdvisorService', () => {
       expect(log.piiTypesFound).toEqual(expect.arrayContaining(['SSN', 'EMAIL']));
     });
 
+    it('redacts PII from client-supplied conversation history, not just the new message', async () => {
+      ctx.turns.push(
+        makeTurn(['ok'], {
+          text: 'ok',
+          content: [{ type: 'text', text: 'ok' }],
+          toolCalls: [],
+          stopReason: 'end_turn',
+          usage: { inputTokens: 1, outputTokens: 1 },
+        }),
+      );
+      const priorTurn = { role: 'user' as const, content: 'Call me at 555-123-4567 please' };
+      await collect(ctx.service.streamChat('u1', 'and one more thing', [priorTurn]));
+
+      const sentMessages = ctx.turnParams[0].messages;
+      // History entries precede the new user turn.
+      expect(sentMessages[0].content).not.toContain('555-123-4567');
+      expect(sentMessages[0].content).toContain('[PHONE]');
+    });
+
     it('does not redact for a local (non-cloud) provider', async () => {
       const c = build({
         resolved: { provider: 'ollama', model: 'llama3.2', apiKey: '', keySource: 'env' },
@@ -198,11 +217,12 @@ describe('AdvisorService', () => {
         }),
       );
       const rawMessage = 'My SSN is 123-45-6789';
-      await collect(c.service.streamChat('u1', rawMessage));
+      const priorTurn = { role: 'user' as const, content: 'Call me at 555-123-4567 please' };
+      await collect(c.service.streamChat('u1', rawMessage, [priorTurn]));
 
       const sentMessages = c.turnParams[0].messages;
-      const sentUserContent = sentMessages[0].content;
-      expect(sentUserContent).toBe(rawMessage);
+      expect(sentMessages[0].content).toBe(priorTurn.content);
+      expect(sentMessages[1].content).toBe(rawMessage);
     });
 
     it('refuses without a tool call when nothing fits', async () => {

--- a/apps/api/src/advisor/advisor.service.ts
+++ b/apps/api/src/advisor/advisor.service.ts
@@ -101,12 +101,17 @@ export class AdvisorService {
     }
     const provider = this.factory.create(resolved.provider, resolved.apiKey);
 
-    // Pre-flight PII redaction: cloud-bound providers never see the raw message.
+    // Pre-flight PII redaction: cloud-bound providers never see raw PII — neither in
+    // the current message nor in prior turns the client resends as conversation
+    // history (the browser keeps history client-side and replays it every request,
+    // so an unredacted earlier turn would otherwise leak again on every follow-up).
     // Local providers (e.g. a future Ollama route on the NAS's own network) are
     // exempt — the two-tier trust model only protects data that leaves the box.
-    const outboundMessage = CLOUD_PROVIDERS.has(resolved.provider)
-      ? sanitizeText(message)
-      : message;
+    const isCloud = CLOUD_PROVIDERS.has(resolved.provider);
+    const outboundMessage = isCloud ? sanitizeText(message) : message;
+    const outboundHistory: ChatTurn[] = isCloud
+      ? history.map((t) => ({ role: t.role, content: sanitizeText(t.content) }))
+      : history;
 
     const toolDefs = await this.mcp.listAdvisorTools(userId);
     const tools: LlmTool[] = toolDefs.map((t) => ({
@@ -116,7 +121,7 @@ export class AdvisorService {
     }));
 
     const messages: LlmMessage[] = [
-      ...history.map((t) => ({ role: t.role, content: t.content })),
+      ...outboundHistory.map((t) => ({ role: t.role, content: t.content })),
       { role: 'user', content: outboundMessage },
     ];
 

--- a/apps/api/src/advisor/advisor.service.ts
+++ b/apps/api/src/advisor/advisor.service.ts
@@ -1,15 +1,23 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { McpClientService } from './mcp-client.service';
 import { AiLogsService } from '../ai-logs/ai-logs.service';
-import { detectPiiTypes } from '../categorization/pii-sanitizer';
+import { detectPiiTypes, sanitizeText } from '../categorization/pii-sanitizer';
 import { AdvisorSettingsService } from './advisor-settings.service';
 import { LlmProviderFactory } from './llm/provider-factory';
 import type {
   LlmContentBlock,
   LlmMessage,
+  LlmProviderId,
   LlmTool,
   LlmTurnResult,
 } from './llm/types';
+
+/**
+ * Providers whose calls leave this box and go to a third-party cloud API.
+ * Only these get pre-flight PII redaction — a future local provider (e.g. Ollama,
+ * running on the NAS's own network) would not need it and shouldn't pay the cost.
+ */
+const CLOUD_PROVIDERS: ReadonlySet<LlmProviderId> = new Set(['anthropic', 'openai', 'google']);
 
 const MAX_TOKENS = 8192;
 /** Hard cap on tool-use round trips so a loop can't run away. */
@@ -93,6 +101,13 @@ export class AdvisorService {
     }
     const provider = this.factory.create(resolved.provider, resolved.apiKey);
 
+    // Pre-flight PII redaction: cloud-bound providers never see the raw message.
+    // Local providers (e.g. a future Ollama route on the NAS's own network) are
+    // exempt — the two-tier trust model only protects data that leaves the box.
+    const outboundMessage = CLOUD_PROVIDERS.has(resolved.provider)
+      ? sanitizeText(message)
+      : message;
+
     const toolDefs = await this.mcp.listAdvisorTools(userId);
     const tools: LlmTool[] = toolDefs.map((t) => ({
       name: t.name,
@@ -102,7 +117,7 @@ export class AdvisorService {
 
     const messages: LlmMessage[] = [
       ...history.map((t) => ({ role: t.role, content: t.content })),
-      { role: 'user', content: message },
+      { role: 'user', content: outboundMessage },
     ];
 
     const system = buildSystemPrompt();


### PR DESCRIPTION
I attempted the push but the sandbox enforces a hard boundary: workers never push — that's handled by the control plane automatically after commits land here. So no action needed from me there; the commits are in place and the control plane will push/open the PR.

I also addressed the reviewer's flag:

## Follow-up fix: conversation history was still leaking PII

**Finding confirmed:** `history` in the advisor chat isn't stored server-side (no DB persistence) — it's held client-side and resent by the browser on every request via `ChatBody.history` → `AdvisorService.streamChat(userId, message, history)`. The original fix only redacted the *new* message; the `history` array was spread into the outbound `messages` untouched. That meant PII typed in an earlier turn would keep leaking to the cloud provider on every subsequent turn in the same conversation, even though the current message was clean.

**Fix:** Applied the same `sanitizeText()` pre-flight redaction to each history turn's content, still gated on the same `CLOUD_PROVIDERS` check (no added cost for a future local/Ollama route).

**Verification:** Added tests asserting a prior history turn containing a detectable PII pattern (phone number) arrives at the provider redacted, and that history is left untouched when routed to a non-cloud provider. Full advisor + categorization suite (113 tests) passes.

Both commits are in the worktree, not pushed (per the no-push boundary — control plane handles that):
- `fix(advisor): redact PII before sending to cloud LLM providers`
- `fix(advisor): also redact PII in client-resent conversation history`

---
### Test evidence
**3 new test case(s) added** (heuristic count):
```
 .../src/advisor/__tests__/advisor.service.spec.ts  | 68 ++++++++++++++++++++++
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
pi:test: [22m[39m[11.10 NN categorization accuracy] held-out=4 predicted=3 correct=3 precision=100%
@moneypulse/api:test: 
@moneypulse/api:test:  [32m✓[39m src/embeddings/__tests__/embedding-categorizer.service.spec.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 7[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/analytics/__tests__/budget-plan.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 9[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/expected-cycle-date.spec.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/categorization/__tests__/learning.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/advisor/__tests__/mcp-client.service.spec.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 4[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/next-loan-due-date.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m88 passed[39m[22m[90m (88)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m727 passed[39m[22m[90m (727)[39m
@moneypulse/api:test: [2m   Start at [22m 14:24:11
@moneypulse/api:test: [2m   Duration [22m 10.95s[2m (transform 3.10s, setup 0ms, import 58.00s, tests 2.27s, environment 6ms)[22m
@moneypulse/api:test: 

 Tasks:    2 successful, 2 total
Cached:    1 cached, 2 total
  Time:    11.494s
```
</details>

### Review
**Review verdict:** approve

Findings (advisory — did not block landing):
- [low/advisory] apps/api/src/advisor/advisor.service.ts:20 — CLOUD_PROVIDERS is a fail-open allowlist: a future cloud provider added to LlmProviderId but not to this set would silently send raw PII. A fail-closed model (redact unless explicitly known-local) would be safer, though all current cloud providers are covered so this is not a live defect.

---
Dispatched via coxd (`MyMoney-ai-observability-pre-flight-1784988318`) · cost $1.544 · 🤖 coxd