### PR TITLE
AI observability: cost tracking + extend coverage to all real LLM call

### DIFF
--- a/apps/api/src/ai-logs/__tests__/model-pricing.spec.ts
+++ b/apps/api/src/ai-logs/__tests__/model-pricing.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { costCentsFor, MODEL_PRICING } from '../model-pricing';
+
+describe('costCentsFor', () => {
+  it('computes cost from known input/output token counts against a real priced model', () => {
+    // 1,000,000 input + 1,000,000 output tokens costs exactly the table's per-1M rates.
+    const price = MODEL_PRICING['gpt-4o'];
+    const cost = costCentsFor('gpt-4o', 1_000_000, 1_000_000);
+    expect(cost).toBeCloseTo(price.inputCentsPer1M + price.outputCentsPer1M, 6);
+  });
+
+  it('scales linearly with token counts below 1M', () => {
+    const price = MODEL_PRICING['claude-3-5-haiku-latest'];
+    const cost = costCentsFor('claude-3-5-haiku-latest', 500_000, 250_000);
+    const expected =
+      (500_000 / 1_000_000) * price.inputCentsPer1M +
+      (250_000 / 1_000_000) * price.outputCentsPer1M;
+    expect(cost).toBeCloseTo(expected, 6);
+  });
+
+  it('returns 0 for a local/Ollama model not present in the price table', () => {
+    expect(costCentsFor('llama3.2:3b', 5000, 2000)).toBe(0);
+    expect(costCentsFor('nomic-embed-text', 1200, 0)).toBe(0);
+  });
+
+  it('returns 0 for an unmapped/unknown cloud model rather than throwing', () => {
+    expect(costCentsFor('some-future-model-nobody-priced-yet', 1000, 1000)).toBe(0);
+  });
+
+  it('returns 0 for null/undefined model or missing token counts', () => {
+    expect(costCentsFor(null, 1000, 1000)).toBe(0);
+    expect(costCentsFor(undefined, 1000, 1000)).toBe(0);
+    expect(costCentsFor('gpt-4o', null, null)).toBe(0);
+    expect(costCentsFor('gpt-4o', undefined, undefined)).toBe(0);
+  });
+});

--- a/apps/api/src/ai-logs/ai-logs.service.ts
+++ b/apps/api/src/ai-logs/ai-logs.service.ts
@@ -3,6 +3,7 @@ import { DATABASE_CONNECTION } from '../db/db.module';
 import * as schema from '../db/schema';
 import { sql, desc } from 'drizzle-orm';
 import { encryptField, decryptField } from '../common/crypto';
+import { costCentsFor } from './model-pricing';
 
 export interface CreateAiLogDto {
   userId?: string;
@@ -80,7 +81,10 @@ export class AiLogsService {
     const extractedRows = rows.rows ?? rows;
     const total = (countResult.rows ?? countResult)[0]?.total ?? 0;
 
-    return { rows: extractedRows.map((r: any) => this.decryptLog(r)), total };
+    return {
+      rows: extractedRows.map((r: any) => this.decryptLog(this.withCost(r))),
+      total,
+    };
   }
 
   async getStats() {
@@ -94,13 +98,31 @@ export class AiLogsService {
         SUM(transactions_count)::int AS total_transactions,
         SUM(categories_assigned)::int AS total_categorized,
         SUM(CASE WHEN pii_detected THEN 1 ELSE 0 END)::int AS pii_detections,
+        SUM(token_count_in)::int AS total_tokens_in,
+        SUM(token_count_out)::int AS total_tokens_out,
         MIN(created_at) AS first_call,
         MAX(created_at) AS last_call
       FROM ${schema.aiPromptLogs}
       GROUP BY prompt_type, model
       ORDER BY total_calls DESC
     `);
-    return result.rows ?? result;
+    const rows = result.rows ?? result;
+    // Cost is computed here, at query time, against the static price table —
+    // never stored on the row — so historical costs stay accurate if prices
+    // are corrected later.
+    return rows.map((r: any) => ({
+      ...r,
+      total_cost_cents: costCentsFor(r.model, r.total_tokens_in, r.total_tokens_out),
+    }));
+  }
+
+  /** Attach a per-row estimated cost (cents) computed from the price table. */
+  private withCost(row: any) {
+    if (!row) return row;
+    return {
+      ...row,
+      cost_cents: costCentsFor(row.model, row.token_count_in, row.token_count_out),
+    };
   }
 
   async getRecentPiiAlerts(limit = 20) {

--- a/apps/api/src/ai-logs/model-pricing.ts
+++ b/apps/api/src/ai-logs/model-pricing.ts
@@ -1,0 +1,69 @@
+/**
+ * Hand-maintained LLM pricing table used to turn logged token counts into an
+ * estimated dollar cost, computed at *query time* (not write time) so prices
+ * can be corrected retroactively without touching `ai_prompt_logs` rows.
+ *
+ * Units: cents per 1,000,000 (1M) tokens, split input vs output, because most
+ * vendors price them differently. Update this file by hand whenever a vendor
+ * changes pricing — there is no live pricing fetch by design.
+ *
+ * Local models (Ollama) are intentionally NOT listed here: `costCentsFor`
+ * treats any model missing from this table as free ($0) rather than erroring,
+ * which is exactly right for local/self-hosted inference (nothing left the
+ * box, no vendor invoice) and also fails safe for any model we simply haven't
+ * priced yet.
+ *
+ * Sources: vendor list-price pages as of the last time this file was edited.
+ * Prices are USD cents per 1M tokens.
+ */
+export interface ModelPrice {
+  /** Cents per 1,000,000 input tokens. */
+  inputCentsPer1M: number;
+  /** Cents per 1,000,000 output tokens. */
+  outputCentsPer1M: number;
+}
+
+export const MODEL_PRICING: Record<string, ModelPrice> = {
+  // ── Anthropic (Claude) ──────────────────────────────────────
+  'claude-opus-4-8': { inputCentsPer1M: 1_500, outputCentsPer1M: 7_500 },
+  'claude-opus-4': { inputCentsPer1M: 1_500, outputCentsPer1M: 7_500 },
+  'claude-sonnet-4': { inputCentsPer1M: 300, outputCentsPer1M: 1_500 },
+  'claude-3-5-sonnet-latest': { inputCentsPer1M: 300, outputCentsPer1M: 1_500 },
+  'claude-3-5-haiku-latest': { inputCentsPer1M: 80, outputCentsPer1M: 400 },
+
+  // ── OpenAI ───────────────────────────────────────────────────
+  'gpt-4o': { inputCentsPer1M: 250, outputCentsPer1M: 1_000 },
+  'gpt-4o-mini': { inputCentsPer1M: 15, outputCentsPer1M: 60 },
+  'gpt-4.1': { inputCentsPer1M: 200, outputCentsPer1M: 800 },
+  'gpt-4.1-mini': { inputCentsPer1M: 40, outputCentsPer1M: 160 },
+
+  // ── Google (Gemini) ──────────────────────────────────────────
+  'gemini-3.5-flash': { inputCentsPer1M: 7.5, outputCentsPer1M: 30 },
+  'gemini-1.5-flash': { inputCentsPer1M: 7.5, outputCentsPer1M: 30 },
+  'gemini-1.5-pro': { inputCentsPer1M: 125, outputCentsPer1M: 500 },
+};
+
+/**
+ * Estimated cost in cents for a single call, given the model name and the
+ * (already-logged) token counts. Returns 0 for any model not present in
+ * {@link MODEL_PRICING} — this covers local/Ollama models by design, and
+ * fails safe (never throws / never shows a bogus number) for any cloud model
+ * that hasn't been priced here yet.
+ */
+export function costCentsFor(
+  model: string | null | undefined,
+  tokenCountIn: number | null | undefined,
+  tokenCountOut: number | null | undefined,
+): number {
+  if (!model) return 0;
+  const price = MODEL_PRICING[model];
+  if (!price) return 0;
+
+  const tokensIn = tokenCountIn ?? 0;
+  const tokensOut = tokenCountOut ?? 0;
+
+  const inputCost = (tokensIn / 1_000_000) * price.inputCentsPer1M;
+  const outputCost = (tokensOut / 1_000_000) * price.outputCentsPer1M;
+
+  return inputCost + outputCost;
+}

--- a/apps/api/src/analytics/__tests__/digest.service.spec.ts
+++ b/apps/api/src/analytics/__tests__/digest.service.spec.ts
@@ -31,12 +31,17 @@ const mockNotifications = {
   createAndDispatch: vi.fn().mockResolvedValue({ id: 'notif-1' }),
 };
 
+const mockAiLogs = {
+  create: vi.fn().mockResolvedValue({ id: 1 }),
+};
+
 function makeService() {
   return new DigestService(
     mockDb as any,
     mockConfig as any,
     mockOllamaHealth as any,
     mockNotifications as any,
+    mockAiLogs as any,
   );
 }
 
@@ -117,6 +122,50 @@ describe('DigestService', () => {
       const result = await svc.buildDigest('user-1', 'daily');
 
       expect(result.voiceSummary).not.toBe('');
+    });
+
+    it('logs the Ollama narrative call to ai_prompt_logs when Ollama is available', async () => {
+      setDailyDbResponses();
+      mockOllamaHealth.isAvailable.mockResolvedValue(true);
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({
+            response: '{"message": "You spent $84 today.", "voiceSummary": "You spent $84 today."}',
+            prompt_eval_count: 120,
+            eval_count: 40,
+          }),
+        }),
+      );
+
+      const svc = makeService();
+      await svc.buildDigest('user-1', 'daily');
+
+      expect(mockAiLogs.create).toHaveBeenCalledTimes(1);
+      const dto = mockAiLogs.create.mock.calls[0][0];
+      expect(dto.promptType).toBe('advisor');
+      expect(dto.model).toBe('llama3.2');
+      expect(dto.tokenCountIn).toBe(120);
+      expect(dto.tokenCountOut).toBe(40);
+      expect(dto.piiDetected).toBe(false);
+
+      vi.unstubAllGlobals();
+    });
+
+    it('still logs (with a null output) when the Ollama narrative call fails, then falls back to template', async () => {
+      setDailyDbResponses();
+      mockOllamaHealth.isAvailable.mockResolvedValue(true);
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500, json: async () => ({}) }));
+
+      const svc = makeService();
+      const result = await svc.buildDigest('user-1', 'daily');
+
+      expect(result.voiceSummary).not.toBe('');
+      expect(mockAiLogs.create).toHaveBeenCalledTimes(1);
+      expect(mockAiLogs.create.mock.calls[0][0].outputText).toBeUndefined();
+
+      vi.unstubAllGlobals();
     });
   });
 

--- a/apps/api/src/analytics/analytics.module.ts
+++ b/apps/api/src/analytics/analytics.module.ts
@@ -17,9 +17,10 @@ import { CategorizationModule } from '../categorization/categorization.module';
 import { BillsModule } from '../bills/bills.module';
 import { LoansModule } from '../loans/loans.module';
 import { MarketDataModule } from '../market-data/market-data.module';
+import { AiLogsModule } from '../ai-logs/ai-logs.module';
 
 @Module({
-  imports: [NotificationsModule, CategorizationModule, BillsModule, LoansModule, MarketDataModule],
+  imports: [NotificationsModule, CategorizationModule, BillsModule, LoansModule, MarketDataModule, AiLogsModule],
   providers: [AnalyticsService, AnomalyDetectorService, DigestService, BriefService, BalanceSnapshotService, ForecastService, AccountFreshnessService, FreshnessDetectorService, WatchdogDetectorService, MarketInsightDetectorService, BudgetPlanService],
   controllers: [AnalyticsController, DigestController],
   exports: [AnalyticsService, AnomalyDetectorService, DigestService, BriefService, BalanceSnapshotService, ForecastService, AccountFreshnessService, FreshnessDetectorService, WatchdogDetectorService, MarketInsightDetectorService, BudgetPlanService],

--- a/apps/api/src/analytics/digest.service.ts
+++ b/apps/api/src/analytics/digest.service.ts
@@ -5,6 +5,7 @@ import { sql, eq } from 'drizzle-orm';
 import { ConfigService } from '@nestjs/config';
 import { OllamaHealthService } from '../categorization/ollama-health.service';
 import { NotificationsService } from '../notifications/notifications.service';
+import { AiLogsService } from '../ai-logs/ai-logs.service';
 import type { DigestPeriod } from '@moneypulse/shared';
 
 interface DigestSection {
@@ -53,6 +54,7 @@ export class DigestService {
     private readonly config: ConfigService,
     private readonly ollamaHealth: OllamaHealthService,
     private readonly notificationsService: NotificationsService,
+    private readonly aiLogs: AiLogsService,
   ) {
     this.ollamaUrl = this.config.get<string>('OLLAMA_URL', 'http://localhost:11434');
     this.ollamaModel = this.config.get<string>('OLLAMA_MODEL', 'llama3.2');
@@ -357,6 +359,7 @@ Return ONLY valid JSON with two fields:
   "voiceSummary": "one concise sentence (under 20 words) for a voice assistant announcement"
 }`;
 
+    const startMs = Date.now();
     try {
       const response = await fetch(`${this.ollamaUrl}/api/generate`, {
         method: 'POST',
@@ -373,7 +376,11 @@ Return ONLY valid JSON with two fields:
       clearTimeout(timeout);
       if (!response.ok) throw new Error(`Ollama HTTP ${response.status}`);
 
-      const data = (await response.json()) as { response: string };
+      const data = (await response.json()) as {
+        response: string;
+        prompt_eval_count?: number;
+        eval_count?: number;
+      };
       const raw = data.response ?? '';
       const match = raw.match(/\{[\s\S]*\}/);
       if (!match) throw new Error('No JSON in Ollama response');
@@ -381,9 +388,42 @@ Return ONLY valid JSON with two fields:
       const parsed = JSON.parse(match[0]) as { message?: string; voiceSummary?: string };
       if (!parsed.message || !parsed.voiceSummary) throw new Error('Missing fields in Ollama JSON');
 
+      this.logPrompt(
+        prompt,
+        raw,
+        startMs,
+        data.prompt_eval_count,
+        data.eval_count,
+      );
       return { message: parsed.message, voiceSummary: parsed.voiceSummary };
+    } catch (err) {
+      this.logPrompt(prompt, null, startMs);
+      throw err;
     } finally {
       clearTimeout(timeout);
     }
+  }
+
+  /** Fire-and-forget: log this Ollama digest-narrative call for observability. */
+  private logPrompt(
+    inputText: string,
+    outputText: string | null,
+    startMs: number,
+    tokenCountIn?: number,
+    tokenCountOut?: number,
+  ) {
+    this.aiLogs
+      .create({
+        promptType: 'advisor',
+        model: this.ollamaModel,
+        inputText,
+        outputText: outputText ?? undefined,
+        tokenCountIn,
+        tokenCountOut,
+        latencyMs: Date.now() - startMs,
+        piiDetected: false,
+        piiTypesFound: [],
+      })
+      .catch((err) => this.logger.warn(`Failed to log AI prompt: ${err.message}`));
   }
 }

--- a/apps/api/src/embeddings/__tests__/ollama-embedding.service.spec.ts
+++ b/apps/api/src/embeddings/__tests__/ollama-embedding.service.spec.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { OllamaEmbeddingService, EMBEDDING_MODEL } from '../ollama-embedding.service';
+
+const mockConfig = { get: vi.fn(() => undefined) };
+const mockAiLogs = { create: vi.fn().mockResolvedValue({ id: 1 }) };
+
+function makeService() {
+  return new OllamaEmbeddingService(mockConfig as any, mockAiLogs as any);
+}
+
+describe('OllamaEmbeddingService', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockAiLogs.create.mockClear();
+  });
+
+  it('logs a successful embedding call to ai_prompt_logs with model + latency', async () => {
+    const embedding = Array(768).fill(0.01);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ embedding }),
+      }),
+    );
+
+    const svc = makeService();
+    const result = await svc.embed('Starbucks purchase');
+
+    expect(result).toEqual(embedding);
+    expect(mockAiLogs.create).toHaveBeenCalledTimes(1);
+    const dto = mockAiLogs.create.mock.calls[0][0];
+    expect(dto.promptType).toBe('categorization');
+    expect(dto.model).toBe(EMBEDDING_MODEL);
+    expect(dto.inputText).toBe('Starbucks purchase');
+    expect(dto.latencyMs).toBeGreaterThanOrEqual(0);
+    expect(dto.piiDetected).toBe(false);
+
+    vi.unstubAllGlobals();
+  });
+
+  it('still logs (with a null output) when Ollama returns a non-2xx response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 500, json: async () => ({}) }),
+    );
+
+    const svc = makeService();
+    const result = await svc.embed('some description');
+
+    expect(result).toBeNull();
+    expect(mockAiLogs.create).toHaveBeenCalledTimes(1);
+    expect(mockAiLogs.create.mock.calls[0][0].outputText).toBeUndefined();
+
+    vi.unstubAllGlobals();
+  });
+
+  it('does not call Ollama or log for empty/blank input', async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const svc = makeService();
+    const result = await svc.embed('   ');
+
+    expect(result).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(mockAiLogs.create).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/apps/api/src/embeddings/embeddings.module.ts
+++ b/apps/api/src/embeddings/embeddings.module.ts
@@ -2,8 +2,10 @@ import { Module } from '@nestjs/common';
 import { OllamaEmbeddingService } from './ollama-embedding.service';
 import { EmbeddingService } from './embedding.service';
 import { EmbeddingCategorizerService } from './embedding-categorizer.service';
+import { AiLogsModule } from '../ai-logs/ai-logs.module';
 
 @Module({
+  imports: [AiLogsModule],
   providers: [OllamaEmbeddingService, EmbeddingService, EmbeddingCategorizerService],
   exports: [OllamaEmbeddingService, EmbeddingService, EmbeddingCategorizerService],
 })

--- a/apps/api/src/embeddings/ollama-embedding.service.ts
+++ b/apps/api/src/embeddings/ollama-embedding.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { AiLogsService } from '../ai-logs/ai-logs.service';
 
 export const EMBEDDING_MODEL = 'nomic-embed-text';
 export const EMBEDDING_DIMENSIONS = 768;
@@ -9,6 +10,10 @@ export const EMBEDDING_DIMENSIONS = 768;
  * `nomic-embed-text` model (768-dim). Returns `null` on any failure
  * (network error, non-2xx, wrong dimensionality) so callers can treat
  * embedding as best-effort — never throws for "Ollama is unreachable".
+ *
+ * Runs entirely against the local Ollama instance, so — unlike the cloud
+ * advisor providers — no PII pre-redaction is needed before logging; the
+ * text never leaves the box.
  */
 @Injectable()
 export class OllamaEmbeddingService {
@@ -16,7 +21,10 @@ export class OllamaEmbeddingService {
   private readonly ollamaUrl: string;
   private readonly timeoutMs: number;
 
-  constructor(private readonly config: ConfigService) {
+  constructor(
+    private readonly config: ConfigService,
+    private readonly aiLogs: AiLogsService,
+  ) {
     this.ollamaUrl = this.config.get<string>('OLLAMA_URL') || 'http://localhost:11434';
     this.timeoutMs = parseInt(
       this.config.get<string>('OLLAMA_EMBEDDING_TIMEOUT_MS') || '30000',
@@ -30,6 +38,7 @@ export class OllamaEmbeddingService {
 
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+    const startMs = Date.now();
     try {
       const response = await fetch(`${this.ollamaUrl}/api/embeddings`, {
         method: 'POST',
@@ -39,6 +48,7 @@ export class OllamaEmbeddingService {
       });
       if (!response.ok) {
         this.logger.warn(`Ollama embeddings HTTP ${response.status}`);
+        this.logPrompt(trimmed, null, startMs);
         return null;
       }
       const data = (await response.json()) as { embedding?: number[] };
@@ -46,14 +56,32 @@ export class OllamaEmbeddingService {
         this.logger.warn(
           `Unexpected embedding dimensionality: ${data.embedding?.length ?? 'none'}`,
         );
+        this.logPrompt(trimmed, null, startMs);
         return null;
       }
+      this.logPrompt(trimmed, `[${data.embedding.length}-dim vector]`, startMs);
       return data.embedding;
     } catch (err: any) {
       this.logger.warn(`Ollama embedding request failed: ${err.message}`);
+      this.logPrompt(trimmed, null, startMs);
       return null;
     } finally {
       clearTimeout(timeout);
     }
+  }
+
+  /** Fire-and-forget: log this embedding call to the database for observability. */
+  private logPrompt(inputText: string, outputText: string | null, startMs: number) {
+    this.aiLogs
+      .create({
+        promptType: 'categorization',
+        model: EMBEDDING_MODEL,
+        inputText,
+        outputText: outputText ?? undefined,
+        latencyMs: Date.now() - startMs,
+        piiDetected: false,
+        piiTypesFound: [],
+      })
+      .catch((err) => this.logger.warn(`Failed to log AI prompt: ${err.message}`));
   }
 }

--- a/apps/web/src/app/(protected)/ai-logs/page.tsx
+++ b/apps/web/src/app/(protected)/ai-logs/page.tsx
@@ -17,8 +17,19 @@ import {
   AlertTriangle,
   CheckCircle2,
   Zap,
+  DollarSign,
 } from 'lucide-react';
 import { MobileCard } from '@/components/MobileCard';
+
+/** Format a cents figure (may be fractional) as a USD string, e.g. "$0.0032". */
+function formatCents(cents: number): string {
+  const dollars = cents / 100;
+  if (dollars === 0) return '$0.00';
+  // Small AI costs are often fractions of a cent-in-dollars; show enough
+  // precision to be meaningful instead of always rounding to "$0.00".
+  const decimals = dollars < 0.01 ? 4 : 2;
+  return `$${dollars.toFixed(decimals)}`;
+}
 
 function StatCard({
   label,
@@ -132,6 +143,10 @@ function LogRow({ log }: { log: AiLogEntry }) {
               <p className="text-[var(--muted-foreground)]">Categorized</p>
               <p className="font-medium">{log.categories_assigned ?? '—'}</p>
             </div>
+            <div>
+              <p className="text-[var(--muted-foreground)]">Est. Cost</p>
+              <p className="font-medium">{formatCents(log.cost_cents ?? 0)}</p>
+            </div>
           </div>
           {log.pii_detected && log.pii_types_found.length > 0 && (
             <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3">
@@ -206,6 +221,7 @@ export default function AiLogsPage() {
         )
       : 0;
   const totalPii = stats.reduce((s, r) => s + (r.pii_detections ?? 0), 0);
+  const totalCostCents = stats.reduce((s, r) => s + (r.total_cost_cents ?? 0), 0);
   const avgConf =
     stats.length > 0
       ? stats
@@ -258,6 +274,12 @@ export default function AiLogsPage() {
           icon={ShieldAlert}
           variant={totalPii > 0 ? 'danger' : 'default'}
         />
+        <StatCard
+          label="Est. Total Cost"
+          value={statsLoading ? '—' : formatCents(totalCostCents)}
+          sub="Cloud model cost estimate ($0 for local/Ollama)"
+          icon={DollarSign}
+        />
       </div>
 
       {/* Model Performance Table */}
@@ -288,6 +310,7 @@ export default function AiLogsPage() {
                   <th className="px-5 py-2 font-medium text-right">
                     PII Hits
                   </th>
+                  <th className="px-5 py-2 font-medium text-right">Cost</th>
                   <th className="px-5 py-2 font-medium">Last Used</th>
                 </tr>
               </thead>
@@ -335,6 +358,9 @@ export default function AiLogsPage() {
                         </span>
                       )}
                     </td>
+                    <td className="px-5 py-2 text-right font-mono text-xs">
+                      {formatCents(row.total_cost_cents ?? 0)}
+                    </td>
                     <td className="px-5 py-2 text-xs text-[var(--muted-foreground)]">
                       {row.last_call
                         ? new Date(row.last_call).toLocaleDateString()
@@ -381,6 +407,10 @@ export default function AiLogsPage() {
                     value: row.pii_detections > 0
                       ? String(row.pii_detections)
                       : '0',
+                  },
+                  {
+                    label: 'Cost',
+                    value: formatCents(row.total_cost_cents ?? 0),
                   },
                   {
                     label: 'Last Used',

--- a/apps/web/src/lib/hooks/useAiLogs.ts
+++ b/apps/web/src/lib/hooks/useAiLogs.ts
@@ -19,6 +19,8 @@ export interface AiLogEntry {
   pii_detected: boolean;
   pii_types_found: string[];
   created_at: string;
+  /** Estimated cost in USD cents, computed from the price table at read time. */
+  cost_cents: number;
 }
 
 export interface AiModelStats {
@@ -30,6 +32,10 @@ export interface AiModelStats {
   total_transactions: number;
   total_categorized: number;
   pii_detections: number;
+  total_tokens_in: number | null;
+  total_tokens_out: number | null;
+  /** Estimated total cost in USD cents for this prompt_type+model group. */
+  total_cost_cents: number;
   first_call: string;
   last_call: string;
 }


### PR DESCRIPTION
Committed successfully.

## Summary

**Root cause:** The `ai_prompt_logs` observability feature captured tokens/latency/prompts for 4 of 6 real LLM call sites, but had zero cost tracking and two Ollama call sites (`ollama-embedding.service.ts`, `digest.service.ts`) went completely unlogged.

**Fix:**
1. Added `apps/api/src/ai-logs/model-pricing.ts` — a single hand-maintained price table (cents per 1M input/output tokens) keyed by model name, covering every Anthropic/OpenAI/Google model currently reachable via `advisor-settings.service.ts`/`DEFAULT_MODELS`. `costCentsFor()` treats any unmapped model (all local Ollama models) as $0 rather than throwing, and is designed to be edited by hand as pricing changes.
2. `AiLogsService.findAll()`/`getStats()` now compute cost at read time against real logged token counts — nothing new stored on `ai_prompt_logs` itself, so retroactive price corrections apply to historical rows automatically.
3. `/ai-logs` dashboard now shows per-row cost, an aggregate cost stat card, and a cost column in the model-performance table, all correctly showing $0 for Ollama-sourced rows.
4. Added logging to the two previously-uncovered real LLM calls — `OllamaEmbeddingService.embed()` and `DigestService.generateNarrative()` — following the existing fire-and-forget pattern used elsewhere, tagged as local calls (no PII pre-redaction needed since nothing leaves the box).

**Verification:** Ran the full relevant Vitest suites (`ai-logs`, `embeddings`, `analytics` digest, `advisor`) — 76 tests pass, including new tests for `costCentsFor` (known token counts against real table prices), the new embedding-service logging paths (success/HTTP-error/blank-input), and the new digest-narrative logging paths (success/failure-with-fallback). Confirmed no new TypeScript errors were introduced in touched files (pre-existing `@moneypulse/shared` module-resolution failures in this sandbox are unrelated to this change and affect unrelated files across the repo).

---
### Test evidence
**10 new test case(s) added** (heuristic count):
```
 .../src/ai-logs/__tests__/model-pricing.spec.ts    | 36 +++++++++++
 .../src/analytics/__tests__/digest.service.spec.ts | 49 +++++++++++++++
 .../__tests__/ollama-embedding.service.spec.ts     | 71 ++++++++++++++++++++++
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/sync/__tests__/signing.service.spec.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 5[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/sync/__tests__/sync-payload.util.spec.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 11[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/expected-cycle-date.spec.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/audit/audit.service.spec.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 8[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/sync-delivery.processor.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 4[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/next-loan-due-date.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/categorization/__tests__/learning.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m90 passed[39m[22m[90m (90)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m734 passed[39m[22m[90m (734)[39m
@moneypulse/api:test: [2m   Start at [22m 15:02:04
@moneypulse/api:test: [2m   Duration [22m 12.06s[2m (transform 3.77s, setup 0ms, import 67.27s, tests 2.39s, environment 5ms)[22m
@moneypulse/api:test: 

 Tasks:    3 successful, 3 total
Cached:    1 cached, 3 total
  Time:    12.594s
```
</details>

### Review
**Review verdict:** approve

Findings (advisory — did not block landing):
- [low/advisory] apps/api/src/ai-logs/ai-logs.service.ts:101 — SUM(token_count_in/out)::int can overflow Postgres int (>2.1B tokens) and error the getStats query over a long horizon; consider ::bigint. Mirrors the pre-existing ::int pattern, so non-blocking.
- [low/advisory] apps/api/src/ai-logs/model-pricing.ts:35 — Several price-table keys (e.g. 'claude-opus-4-8', 'gemini-3.5-flash') look like placeholder/non-existent model names; verify against real vendor model identifiers so cost lookups actually match logged models.
- [low/advisory] apps/api/src/analytics/digest.service.ts:393 — The catch path logs outputText=null even when the fetch succeeded but JSON parse/validation failed, discarding the raw response that was actually received.

---
Dispatched via coxd (`MyMoney-ai-observability-cost-tracki-1784988319`) · cost $1.188 · 🤖 coxd