### PR TITLE
Recurring-bill detection needs 3 occurrences regardless of frequency —

### DIFF
--- a/apps/api/src/bills/__tests__/bills.service.spec.ts
+++ b/apps/api/src/bills/__tests__/bills.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException } from '@nestjs/common';
+import { NotFoundException, BadRequestException, ConflictException } from '@nestjs/common';
 import { BillsService } from '../bills.service';
 import { NotificationsService } from '../../notifications/notifications.service';
 import { DATABASE_CONNECTION } from '../../db/db.module';
@@ -367,7 +367,20 @@ describe('BillsService', () => {
           frequency: 'annual',
           categoryId: null,
         }),
-      ).rejects.toThrow();
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('rejects a whitespace-only bill name with a 400, not a "duplicate" conflict', async () => {
+      mockDb.limit = vi.fn().mockResolvedValue([]);
+
+      await expect(
+        service.create(userId, {
+          normalizedName: '   ',
+          expectedAmountCents: 20000,
+          frequency: 'annual',
+          categoryId: null,
+        }),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 

--- a/apps/api/src/bills/__tests__/bills.service.spec.ts
+++ b/apps/api/src/bills/__tests__/bills.service.spec.ts
@@ -177,6 +177,65 @@ describe('BillsService', () => {
 
       expect(insertedValues?.frequency).toBe('weekly');
     });
+
+    it('detects an annual subscription from just 2 occurrences ~365 days apart with a matching amount', async () => {
+      const txns = [0, 370].map((d) => makeTxn(d, 'Anthropic', 20000));
+      mockDb.orderBy = vi.fn().mockResolvedValue(txns);
+      mockDb.limit = vi.fn().mockResolvedValue([]);
+
+      let insertedValues: any = null;
+      mockDb.insert = vi.fn().mockReturnValue({
+        values: vi.fn().mockImplementation((v) => {
+          insertedValues = v;
+          return Promise.resolve([]);
+        }),
+      });
+
+      const result = await service.detectRecurring(userId);
+
+      expect(result.newBills).toBe(1);
+      expect(insertedValues?.frequency).toBe('annual');
+    });
+
+    it('does not detect 2 occurrences whose gap is a monthly-ish cadence', async () => {
+      const txns = [0, 30].map((d) => makeTxn(d, 'Netflix'));
+      mockDb.orderBy = vi.fn().mockResolvedValue(txns);
+
+      const result = await service.detectRecurring(userId);
+
+      expect(result.newBills).toBe(0);
+    });
+
+    it('does not detect 2 occurrences with an annual-ish gap but mismatched amounts', async () => {
+      const txns = [
+        { date: new Date('2024-01-01T00:00:00Z'), amountCents: 20000, normalizedMerchantName: 'RingSub', merchantName: 'RingSub' },
+        { date: new Date('2025-01-05T00:00:00Z'), amountCents: 5000, normalizedMerchantName: 'RingSub', merchantName: 'RingSub' },
+      ];
+      mockDb.orderBy = vi.fn().mockResolvedValue(txns);
+
+      const result = await service.detectRecurring(userId);
+
+      expect(result.newBills).toBe(0);
+    });
+
+    it('classifies a ~60-day cadence with 3 occurrences as bimonthly', async () => {
+      const txns = [0, 60, 121].map((d) => makeTxn(d, 'HenricoUtilDes', 8000));
+      mockDb.orderBy = vi.fn().mockResolvedValue(txns);
+      mockDb.limit = vi.fn().mockResolvedValue([]);
+
+      let insertedValues: any = null;
+      mockDb.insert = vi.fn().mockReturnValue({
+        values: vi.fn().mockImplementation((v) => {
+          insertedValues = v;
+          return Promise.resolve([]);
+        }),
+      });
+
+      const result = await service.detectRecurring(userId);
+
+      expect(result.newBills).toBe(1);
+      expect(insertedValues?.frequency).toBe('bimonthly');
+    });
   });
 
   // ── Missed Bills ──────────────────────────────────────────
@@ -264,6 +323,53 @@ describe('BillsService', () => {
   });
 
   // ── CRUD ─────────────────────────────────────────────────
+
+  describe('create (manual add)', () => {
+    it('creates a confirmed, active bill immediately usable for annual-total projections', async () => {
+      mockDb.limit = vi.fn().mockResolvedValue([]);
+      const created = {
+        id: 'new-bill-1',
+        userId,
+        merchantPattern: 'Claude.ai',
+        normalizedName: 'Claude.ai',
+        categoryId: null,
+        expectedAmountCents: 20000,
+        frequency: 'annual',
+        isConfirmed: true,
+        isActive: true,
+      };
+      mockDb.insert = vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([created]) }),
+      });
+
+      const result = await service.create(userId, {
+        normalizedName: 'Claude.ai',
+        expectedAmountCents: 20000,
+        frequency: 'annual',
+        categoryId: null,
+      });
+
+      expect(result).toMatchObject({
+        normalizedName: 'Claude.ai',
+        frequency: 'annual',
+        isConfirmed: true,
+        isActive: true,
+      });
+    });
+
+    it('rejects a duplicate manual bill name for the same user', async () => {
+      mockDb.limit = vi.fn().mockResolvedValue([{ id: 'existing-1' }]);
+
+      await expect(
+        service.create(userId, {
+          normalizedName: 'Claude.ai',
+          expectedAmountCents: 20000,
+          frequency: 'annual',
+          categoryId: null,
+        }),
+      ).rejects.toThrow();
+    });
+  });
 
   describe('findAll', () => {
     it('returns bills ordered by nextExpectedDate for user', async () => {

--- a/apps/api/src/bills/bills.controller.ts
+++ b/apps/api/src/bills/bills.controller.ts
@@ -15,8 +15,8 @@ import { BillsService } from './bills.service';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
 import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
-import { updateBillSchema } from '@moneypulse/shared';
-import type { AuthTokenPayload, UpdateBillInput } from '@moneypulse/shared';
+import { updateBillSchema, createBillSchema } from '@moneypulse/shared';
+import type { AuthTokenPayload, UpdateBillInput, CreateBillInput } from '@moneypulse/shared';
 
 @ApiTags('Bills')
 @Controller('bills')
@@ -35,6 +35,17 @@ export class BillsController {
   @ApiOperation({ summary: 'Bills due within the next 7 days (for dashboard)' })
   async upcoming(@CurrentUser() user: AuthTokenPayload) {
     const data = await this.billsService.findUpcoming(user.sub, 7);
+    return { data };
+  }
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Manually declare a recurring bill/subscription' })
+  async create(
+    @Body(new ZodValidationPipe(createBillSchema)) body: CreateBillInput,
+    @CurrentUser() user: AuthTokenPayload,
+  ) {
+    const data = await this.billsService.create(user.sub, body);
     return { data };
   }
 

--- a/apps/api/src/bills/bills.service.ts
+++ b/apps/api/src/bills/bills.service.ts
@@ -4,6 +4,7 @@ import {
   Logger,
   NotFoundException,
   ConflictException,
+  BadRequestException,
 } from '@nestjs/common';
 import { DATABASE_CONNECTION } from '../db/db.module';
 import * as schema from '../db/schema';
@@ -431,7 +432,7 @@ export class BillsService {
   async create(userId: string, input: CreateBillInput) {
     const merchantPattern = input.normalizedName.trim();
     if (!merchantPattern) {
-      throw new ConflictException('Bill name cannot be empty');
+      throw new BadRequestException('Bill name cannot be empty');
     }
 
     const existing = await this.db

--- a/apps/api/src/bills/bills.service.ts
+++ b/apps/api/src/bills/bills.service.ts
@@ -3,18 +3,25 @@ import {
   Inject,
   Logger,
   NotFoundException,
+  ConflictException,
 } from '@nestjs/common';
 import { DATABASE_CONNECTION } from '../db/db.module';
 import * as schema from '../db/schema';
 import { eq, and, isNull, lt, gte, lte, or, asc } from 'drizzle-orm';
 import { NotificationsService } from '../notifications/notifications.service';
-import type { BillFrequency, UpdateBillInput, SubscriptionItem } from '@moneypulse/shared';
+import type {
+  BillFrequency,
+  UpdateBillInput,
+  CreateBillInput,
+  SubscriptionItem,
+} from '@moneypulse/shared';
 
 function annualCostCents(amountCents: number, frequency: BillFrequency): number {
   const multipliers: Record<BillFrequency, number> = {
     weekly: 52,
     biweekly: 26,
     monthly: 12,
+    bimonthly: 6,
     quarterly: 4,
     semi_annual: 2,
     annual: 1,
@@ -33,6 +40,7 @@ function classifyFrequency(medianDays: number): BillFrequency | null {
   if (medianDays >= 5 && medianDays <= 9) return 'weekly';
   if (medianDays >= 12 && medianDays <= 18) return 'biweekly';
   if (medianDays >= 25 && medianDays <= 35) return 'monthly';
+  if (medianDays >= 50 && medianDays <= 70) return 'bimonthly';
   if (medianDays >= 80 && medianDays <= 100) return 'quarterly';
   if (medianDays >= 170 && medianDays <= 200) return 'semi_annual';
   if (medianDays >= 340 && medianDays <= 400) return 'annual';
@@ -50,6 +58,9 @@ function addFrequency(date: Date, frequency: BillFrequency): Date {
       break;
     case 'monthly':
       d.setMonth(d.getMonth() + 1);
+      break;
+    case 'bimonthly':
+      d.setMonth(d.getMonth() + 2);
       break;
     case 'quarterly':
       d.setMonth(d.getMonth() + 3);
@@ -70,6 +81,8 @@ function windowDaysForFrequency(frequency: string): number {
       return 7;
     case 'biweekly':
       return 14;
+    case 'bimonthly':
+      return 20;
     case 'quarterly':
       return 30;
     case 'semi_annual':
@@ -139,31 +152,48 @@ export class BillsService {
     let existingUpdated = 0;
 
     for (const [merchantKey, occurrences] of groups) {
-      // Need at least 3 for reliable detection
-      if (occurrences.length < 3) continue;
-
       occurrences.sort((a, b) => a.date.getTime() - b.date.getTime());
 
-      // Calculate day intervals
-      const intervals: number[] = [];
-      for (let i = 1; i < occurrences.length; i++) {
-        const days = Math.round(
-          (occurrences[i].date.getTime() - occurrences[i - 1].date.getTime()) /
-            86_400_000,
+      // Need at least 3 occurrences for reliable detection of short/medium
+      // cadences, but for long cadences (semi-annual/annual) waiting for a
+      // 3rd occurrence can mean waiting years. If we only have exactly 2
+      // charges, still allow detection when the single gap between them
+      // cleanly classifies as semi_annual or annual and the amounts
+      // roughly match — otherwise require the usual 3+.
+      let frequency: BillFrequency | null;
+      if (occurrences.length === 2) {
+        const [a, b] = occurrences;
+        const days = Math.round((b.date.getTime() - a.date.getTime()) / 86_400_000);
+        const freq = classifyFrequency(days);
+        if (freq !== 'semi_annual' && freq !== 'annual') continue;
+        const amountDelta =
+          Math.abs(a.amountCents - b.amountCents) / Math.max(a.amountCents, b.amountCents);
+        if (amountDelta > 0.2) continue;
+        frequency = freq;
+      } else if (occurrences.length < 3) {
+        continue;
+      } else {
+        // Calculate day intervals
+        const intervals: number[] = [];
+        for (let i = 1; i < occurrences.length; i++) {
+          const days = Math.round(
+            (occurrences[i].date.getTime() - occurrences[i - 1].date.getTime()) /
+              86_400_000,
+          );
+          intervals.push(days);
+        }
+
+        const med = median(intervals);
+        if (med === 0) continue;
+
+        // Require 80% of intervals within 20% of median
+        const withinTolerance = intervals.filter(
+          (d) => Math.abs(d - med) / med <= 0.2,
         );
-        intervals.push(days);
+        if (withinTolerance.length / intervals.length < 0.8) continue;
+
+        frequency = classifyFrequency(med);
       }
-
-      const med = median(intervals);
-      if (med === 0) continue;
-
-      // Require 80% of intervals within 20% of median
-      const withinTolerance = intervals.filter(
-        (d) => Math.abs(d - med) / med <= 0.2,
-      );
-      if (withinTolerance.length / intervals.length < 0.8) continue;
-
-      const frequency = classifyFrequency(med);
       if (!frequency) continue;
 
       const last3 = occurrences.slice(-3);
@@ -390,6 +420,61 @@ export class BillsService {
   }
 
   // ── CRUD ─────────────────────────────────────────────────
+
+  /**
+   * Manually declare a recurring bill/subscription. Lets a user register a
+   * known subscription (e.g. an annual renewal) immediately instead of
+   * waiting for it to accumulate enough transaction history to be
+   * auto-detected. Behaves identically to a detected bill afterward
+   * (edit/deactivate/delete/merge all operate on the same table/rows).
+   */
+  async create(userId: string, input: CreateBillInput) {
+    const merchantPattern = input.normalizedName.trim();
+    if (!merchantPattern) {
+      throw new ConflictException('Bill name cannot be empty');
+    }
+
+    const existing = await this.db
+      .select({ id: schema.recurringBills.id })
+      .from(schema.recurringBills)
+      .where(
+        and(
+          eq(schema.recurringBills.userId, userId),
+          eq(schema.recurringBills.merchantPattern, merchantPattern),
+        ),
+      )
+      .limit(1);
+    if (existing.length > 0) {
+      throw new ConflictException(
+        `A bill named "${merchantPattern}" already exists`,
+      );
+    }
+
+    const now = new Date();
+    const nextExpectedDate = addFrequency(now, input.frequency);
+
+    const [created] = await this.db
+      .insert(schema.recurringBills)
+      .values({
+        userId,
+        merchantPattern,
+        normalizedName: merchantPattern,
+        categoryId: input.categoryId ?? null,
+        expectedAmountCents: input.expectedAmountCents,
+        amountTolerancePercent: input.amountTolerancePercent ?? 15,
+        frequency: input.frequency,
+        nextExpectedDate,
+        lastSeenDate: null,
+        lastAmountCents: null,
+        // A manually declared bill is, by definition, user-confirmed —
+        // it should immediately participate in upcoming/missed-bill alerts.
+        isConfirmed: true,
+        isActive: true,
+      })
+      .returning();
+
+    return created;
+  }
 
   async findAll(userId: string) {
     return this.db

--- a/apps/web/src/app/(protected)/bills/page.tsx
+++ b/apps/web/src/app/(protected)/bills/page.tsx
@@ -21,6 +21,7 @@ const FREQ_LABELS: Record<BillFrequency, string> = {
   weekly: 'Weekly',
   biweekly: 'Biweekly',
   monthly: 'Monthly',
+  bimonthly: 'Bimonthly',
   quarterly: 'Quarterly',
   semi_annual: 'Semi-annual',
   annual: 'Annual',

--- a/apps/web/src/app/(protected)/subscriptions/page.tsx
+++ b/apps/web/src/app/(protected)/subscriptions/page.tsx
@@ -2,12 +2,13 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { Repeat, TrendingUp, AlertTriangle, Pencil, Ban, Trash2, Merge, X, Check } from 'lucide-react';
+import { Repeat, TrendingUp, AlertTriangle, Pencil, Ban, Trash2, Merge, X, Check, Plus } from 'lucide-react';
 import { formatCents } from '@/lib/format';
 import { useSubscriptions } from '@/lib/hooks/useSubscriptions';
 import { useCategories } from '@/lib/hooks/useCategories';
 import {
   useBills,
+  useCreateBill,
   useUpdateBill,
   useDeactivateBill,
   useDeleteBill,
@@ -21,6 +22,7 @@ const FREQ_LABELS: Record<BillFrequency, string> = {
   weekly: 'Weekly',
   biweekly: 'Biweekly',
   monthly: 'Monthly',
+  bimonthly: 'Bimonthly',
   quarterly: 'Quarterly',
   semi_annual: 'Semi-annual',
   annual: 'Annual',
@@ -139,6 +141,109 @@ function EditSubscriptionForm({
       >
         <X className="h-4 w-4" />
       </button>
+    </div>
+  );
+}
+
+function AddSubscriptionForm({
+  categories,
+  onDone,
+  onCancel,
+}: {
+  categories: Array<{ id: string; name: string }>;
+  onDone: () => void;
+  onCancel: () => void;
+}) {
+  const createBill = useCreateBill();
+  const [name, setName] = useState('');
+  const [amount, setAmount] = useState('');
+  const [frequency, setFrequency] = useState<BillFrequency>('annual');
+  const [categoryId, setCategoryId] = useState<string>('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSave = async () => {
+    setError(null);
+    const cents = Math.round(parseFloat(amount) * 100);
+    if (!name.trim()) {
+      setError('Name is required.');
+      return;
+    }
+    if (!Number.isFinite(cents) || cents <= 0) {
+      setError('Enter a valid amount.');
+      return;
+    }
+    try {
+      await createBill.mutateAsync({
+        normalizedName: name.trim(),
+        expectedAmountCents: cents,
+        frequency,
+        categoryId: categoryId || null,
+      });
+      onDone();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not add subscription.');
+    }
+  };
+
+  return (
+    <div className="rounded-xl border border-[var(--primary)]/30 bg-[var(--primary)]/5 p-4 space-y-3">
+      <div className="flex items-center gap-2">
+        <Plus className="h-4 w-4 text-[var(--primary)]" />
+        <span className="text-sm font-semibold">Add a subscription</span>
+      </div>
+      <div className="flex flex-1 flex-wrap items-center gap-2">
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="min-w-[10rem] flex-1 rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-sm"
+          placeholder="Name (e.g. Claude.ai)"
+        />
+        <input
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          inputMode="decimal"
+          className="w-24 rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-sm"
+          placeholder="Amount"
+        />
+        <select
+          value={frequency}
+          onChange={(e) => setFrequency(e.target.value as BillFrequency)}
+          className="rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-sm"
+        >
+          {FREQ_OPTIONS.map((f) => (
+            <option key={f} value={f}>
+              {FREQ_LABELS[f]}
+            </option>
+          ))}
+        </select>
+        <select
+          value={categoryId}
+          onChange={(e) => setCategoryId(e.target.value)}
+          className="rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-sm"
+        >
+          <option value="">Uncategorized</option>
+          {categories.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+        </select>
+        <button
+          onClick={handleSave}
+          disabled={createBill.isPending}
+          className="rounded-lg bg-[var(--primary)] px-3 py-1.5 text-sm font-semibold text-[var(--primary-foreground)] hover:opacity-90 disabled:opacity-50"
+        >
+          {createBill.isPending ? 'Adding…' : 'Add'}
+        </button>
+        <button
+          onClick={onCancel}
+          disabled={createBill.isPending}
+          className="rounded-lg border border-[var(--border)] px-3 py-1.5 text-sm font-semibold hover:bg-[var(--muted)] disabled:opacity-50"
+        >
+          Cancel
+        </button>
+      </div>
+      {error && <p className="text-xs text-[var(--destructive)]">{error}</p>}
     </div>
   );
 }
@@ -370,6 +475,7 @@ export default function SubscriptionsPage() {
   const { data: billsData, isLoading: isBillsLoading } = useBills();
 
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [isAdding, setIsAdding] = useState(false);
 
   const subs = data?.data ?? [];
   const categories = categoriesData?.data ?? [];
@@ -411,13 +517,31 @@ export default function SubscriptionsPage() {
           <Repeat className="h-6 w-6 text-[var(--primary)]" />
           <h1 className="text-2xl font-bold">Subscriptions</h1>
         </div>
-        <Link
-          href="/bills"
-          className="text-sm text-[var(--primary)] hover:underline"
-        >
-          Manage bills →
-        </Link>
+        <div className="flex items-center gap-4">
+          <button
+            onClick={() => setIsAdding((v) => !v)}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--primary)] px-3 py-1.5 text-sm font-semibold text-[var(--primary-foreground)] hover:opacity-90"
+          >
+            <Plus className="h-4 w-4" />
+            Add subscription
+          </button>
+          <Link
+            href="/bills"
+            className="text-sm text-[var(--primary)] hover:underline"
+          >
+            Manage bills →
+          </Link>
+        </div>
       </div>
+
+      {/* Manual add form */}
+      {isAdding && (
+        <AddSubscriptionForm
+          categories={categories}
+          onDone={() => setIsAdding(false)}
+          onCancel={() => setIsAdding(false)}
+        />
+      )}
 
       {/* Summary bar */}
       <div className="grid gap-4 sm:grid-cols-3">

--- a/apps/web/src/lib/hooks/useBills.ts
+++ b/apps/web/src/lib/hooks/useBills.ts
@@ -2,7 +2,7 @@
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '../api';
-import type { RecurringBill, UpdateBillInput } from '@moneypulse/shared';
+import type { RecurringBill, UpdateBillInput, CreateBillInput } from '@moneypulse/shared';
 
 /** Fetch all recurring bills for the current user. */
 export function useBills() {
@@ -17,6 +17,19 @@ export function useUpcomingBills() {
   return useQuery({
     queryKey: ['bills', 'upcoming'],
     queryFn: () => api.get<{ data: RecurringBill[] }>('/bills/upcoming'),
+  });
+}
+
+/** Manually declare a recurring bill/subscription. */
+export function useCreateBill() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: CreateBillInput) =>
+      api.post<{ data: RecurringBill }>('/bills', body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['bills'] });
+      queryClient.invalidateQueries({ queryKey: ['subscriptions'] });
+    },
   });
 }
 

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -127,6 +127,7 @@ export type BillFrequency =
   | 'weekly'
   | 'biweekly'
   | 'monthly'
+  | 'bimonthly'
   | 'quarterly'
   | 'semi_annual'
   | 'annual';

--- a/packages/shared/src/validation/index.ts
+++ b/packages/shared/src/validation/index.ts
@@ -309,6 +309,7 @@ export const billFrequencyEnum = z.enum([
   'weekly',
   'biweekly',
   'monthly',
+  'bimonthly',
   'quarterly',
   'semi_annual',
   'annual',
@@ -323,6 +324,17 @@ export const updateBillSchema = z.object({
 });
 
 export type UpdateBillInput = z.infer<typeof updateBillSchema>;
+
+/** Manual subscription/bill creation — user directly declares a recurring bill. */
+export const createBillSchema = z.object({
+  normalizedName: z.string().min(1).max(200),
+  expectedAmountCents: z.number().int().positive(),
+  frequency: billFrequencyEnum,
+  amountTolerancePercent: z.number().int().min(0).max(50).optional(),
+  categoryId: z.string().uuid().nullable().optional(),
+});
+
+export type CreateBillInput = z.infer<typeof createBillSchema>;
 
 // ── Investment Accounts ──────────────────────────────────────
 


### PR DESCRIPTION
Committed.

## Summary

Addressed two review findings on the recurring-bill-detection PR:

1. **Contract concern (medium)**: reviewer flagged that adding `bimonthly` to `BillFrequency` across types/validation/service had no accompanying DB migration, risking runtime insert failures if the column were a Postgres enum (which also can't be altered inside a transaction-wrapped migration). Verified structurally against the schema/migration source that `recurring_bills.frequency` is a plain `varchar(20)` with no enum type or CHECK constraint — so no migration is required for the new value to be inserted by detection or manual creation. No code change needed here; documented the verification in the commit.

2. **Error-semantics fix (low, addressed)**: `BillsService.create()` threw `ConflictException` ("already exists" / "cannot be empty") for a whitespace-only bill name that passes Zod's `min(1)` but trims to empty — now throws `BadRequestException` instead, correctly signaling a client input error (400) rather than a resource conflict (409).

Added a regression test asserting the whitespace-only case throws `BadRequestException` and tightened the existing duplicate-name test to assert `ConflictException` specifically. Full `bills` test suite (48 tests) and the API build both pass.

---
### Test evidence
**7 new test case(s) added** (heuristic count):
```
 apps/api/src/bills/__tests__/bills.service.spec.ts | 121 +++++++++++++++++-
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

### Review
**Review verdict:** fix

Findings (advisory — did not block landing):
- [med/contract] packages/shared/src/validation/index.ts:312 — New 'bimonthly' BillFrequency value is added across types/validation/service but the diff contains no DB migration. If recurringBills.frequency is a Postgres enum column, all bimonthly inserts (detection + manual create) will fail at runtime; note ALTER TYPE ADD VALUE also cannot run inside a transaction-wrapped migration. Verify the column is plain text or ship the migration.
- [low/advisory] apps/api/src/bills/bills.service.ts:432 — A whitespace-only normalizedName passes Zod min(1) but trims to empty and is rejected with ConflictException ('already exists'/'cannot be empty') rather than a 400 BadRequest — misleading error semantics.

---
Dispatched via coxd (`MyMoney-recurring-bill-detection-nee-1784988320`) · cost $2.840 · 🤖 coxd