### PR TITLE
Investment accounts (money-market cash/sweep) are invisible to Cash Ma

### DIFF
--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -652,6 +652,11 @@ export const investmentAccounts = pgTable('investment_accounts', {
   institution: varchar('institution', { length: 100 }).notNull(),
   accountType: varchar('account_type', { length: 50 }).notNull(),
   nickname: varchar('nickname', { length: 100 }).notNull(),
+  /** Basis points (e.g. 335 = 3.35% APY). Optional — lets a cash-equivalent position inside
+   * a brokerage account (money-market fund, cash sweep) declare its own yield, the same way
+   * `accounts.interestRateBps` does for checking/savings. Only meaningful when the account's
+   * balance is effectively cash (see Cash Manager's use of this field). */
+  interestRateBps: integer('interest_rate_bps'),
   createdAt: timestamp('created_at', { withTimezone: true })
     .notNull()
     .defaultNow(),

--- a/apps/api/src/investments/investments.service.ts
+++ b/apps/api/src/investments/investments.service.ts
@@ -34,6 +34,7 @@ export class InvestmentsService {
         ia.institution,
         ia.account_type,
         ia.nickname,
+        ia.interest_rate_bps,
         ia.created_at,
         ia.updated_at,
         ia.deleted_at,
@@ -57,6 +58,7 @@ export class InvestmentsService {
       institution: r.institution,
       accountType: r.account_type,
       nickname: r.nickname,
+      interestRateBps: r.interest_rate_bps != null ? Number(r.interest_rate_bps) : null,
       createdAt: r.created_at,
       updatedAt: r.updated_at,
       deletedAt: r.deleted_at ?? null,
@@ -76,6 +78,7 @@ export class InvestmentsService {
         institution: input.institution,
         accountType: input.accountType,
         nickname: input.nickname,
+        interestRateBps: input.interestRateBps ?? null,
       })
       .returning();
     const row = rows[0];

--- a/apps/api/src/recommendations/__tests__/cash-manager.service.spec.ts
+++ b/apps/api/src/recommendations/__tests__/cash-manager.service.spec.ts
@@ -45,6 +45,7 @@ function buildMockDb(opts: {
     }),
     execute: vi
       .fn()
+      .mockResolvedValueOnce([]) // rated investment accounts (none in these fixtures)
       .mockResolvedValueOnce(
         opts.balanceRows ?? [{ balance_cents: opts.balanceCents }],
       ) // liquid balance

--- a/apps/api/src/recommendations/cash-manager.service.ts
+++ b/apps/api/src/recommendations/cash-manager.service.ts
@@ -94,11 +94,12 @@ export class CashManagerService {
 
   /**
    * Event trigger leg 2 (manifest: "liquid-balance-move(>=20%)"). Compares each user's
-   * latest two liquid (checking+savings) balance snapshot totals — a straightforward
-   * latest-vs-previous comparison over `account_balance_snapshots`, reusing the same
-   * checking/savings account-type filter as `runForUser`'s own liquid-balance query.
-   * Users with fewer than two snapshot dates, or a zero/negative prior total (nothing
-   * to compute a meaningful percentage move against), are skipped rather than flagged.
+   * latest two liquid (checking+savings, plus any investment account with a declared
+   * cash-equivalent yield) balance snapshot totals — a straightforward latest-vs-previous
+   * comparison, reusing the same account-type/rated filter as `runForUser`'s own
+   * liquid-balance query. Users with fewer than two snapshot dates, or a zero/negative
+   * prior total (nothing to compute a meaningful percentage move against), are skipped
+   * rather than flagged.
    */
   async findUsersWithLiquidBalanceMove(): Promise<string[]> {
     const rows = await this.db.execute(sql`
@@ -106,18 +107,32 @@ export class CashManagerService {
         SELECT id, user_id FROM ${schema.accounts}
         WHERE deleted_at IS NULL AND account_type IN ('checking', 'savings')
       ),
+      rated_investment_accounts AS (
+        SELECT id, user_id FROM ${schema.investmentAccounts}
+        WHERE deleted_at IS NULL AND interest_rate_bps IS NOT NULL
+      ),
       by_date AS (
         SELECT la.user_id, abs.snapshot_date, SUM(abs.balance_cents) AS total_cents
         FROM ${schema.accountBalanceSnapshots} abs
         JOIN liquid_accounts la ON la.id = abs.account_id
         GROUP BY la.user_id, abs.snapshot_date
+        UNION ALL
+        SELECT ria.user_id, isn.date::date AS snapshot_date, SUM(isn.balance_cents) AS total_cents
+        FROM ${schema.investmentSnapshots} isn
+        JOIN rated_investment_accounts ria ON ria.id = isn.investment_account_id
+        GROUP BY ria.user_id, isn.date::date
+      ),
+      merged AS (
+        SELECT user_id, snapshot_date, SUM(total_cents) AS total_cents
+        FROM by_date
+        GROUP BY user_id, snapshot_date
       ),
       ranked AS (
         SELECT
           user_id,
           total_cents,
           ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY snapshot_date DESC) AS rnk
-        FROM by_date
+        FROM merged
       )
       SELECT
         user_id,
@@ -200,15 +215,53 @@ export class CashManagerService {
           sql`${schema.accounts.accountType} IN ('checking', 'savings')`,
         ),
       );
-    if (accounts.length === 0) return { ran: false, suppressed: false, recommended: false };
+
+    // Investment accounts with a declared cash-equivalent yield (e.g. a money-market
+    // fund's or cash sweep's rate) are folded into the same rated blend as regular
+    // checking/savings accounts, using their latest `investment_snapshots` balance — a
+    // distinct table from `account_balance_snapshots` since investment accounts have no
+    // CSV-imported transactions. Unrated investment accounts (equities, index funds with
+    // no declared yield) are deliberately excluded — they aren't cash-equivalent.
+    const investmentAccountRows = await this.db.execute(sql`
+      SELECT ia.id, ia.interest_rate_bps, snap.balance_cents AS latest_balance_cents
+      FROM ${schema.investmentAccounts} ia
+      LEFT JOIN LATERAL (
+        SELECT balance_cents
+        FROM ${schema.investmentSnapshots}
+        WHERE investment_account_id = ia.id
+        ORDER BY date DESC, created_at DESC
+        LIMIT 1
+      ) snap ON true
+      WHERE ia.user_id = ${userId}
+        AND ia.deleted_at IS NULL
+        AND ia.interest_rate_bps IS NOT NULL
+    `);
+    const ratedInvestmentAccounts: Array<{
+      id: string;
+      interestRateBps: number;
+      balanceCents: number;
+    }> = (investmentAccountRows.rows ?? investmentAccountRows)
+      .filter((r: any) => r.latest_balance_cents !== null)
+      .map((r: any) => ({
+        id: String(r.id),
+        interestRateBps: Number(r.interest_rate_bps),
+        balanceCents: Number(r.latest_balance_cents),
+      }));
+
+    if (accounts.length === 0 && ratedInvestmentAccounts.length === 0) {
+      return { ran: false, suppressed: false, recommended: false };
+    }
     const accountIds = accounts.map((a: any) => a.id);
 
-    const balanceRows = await this.db.execute(sql`
+    const balanceRows =
+      accountIds.length > 0
+        ? await this.db.execute(sql`
       SELECT DISTINCT ON (account_id) account_id, balance_cents
       FROM ${schema.accountBalanceSnapshots}
       WHERE account_id = ANY(${accountIds})
       ORDER BY account_id, snapshot_date DESC
-    `);
+    `)
+        : { rows: [] };
     // The query above is `DISTINCT ON (account_id)`, so Postgres guarantees at most one row
     // per account_id (the most recent snapshot). Map construction is therefore safe — there is
     // no later-row-wins ambiguity to worry about. If this query is ever changed to return
@@ -220,10 +273,13 @@ export class CashManagerService {
         Number(r.balance_cents),
       ]),
     );
-    const liquidBalanceCents = Array.from(balanceByAccountId.values()).reduce(
-      (sum, cents) => sum + cents,
+    const investmentBalanceCents = ratedInvestmentAccounts.reduce(
+      (sum, a) => sum + a.balanceCents,
       0,
     );
+    const liquidBalanceCents =
+      Array.from(balanceByAccountId.values()).reduce((sum, cents) => sum + cents, 0) +
+      investmentBalanceCents;
 
     const expenseRows = await this.db.execute(sql`
       SELECT COALESCE(SUM(amount_cents), 0)::bigint AS total_cents
@@ -249,26 +305,33 @@ export class CashManagerService {
     const idleCashBufferMonths = 1; // 11.7 default; overridden by user_settings when present, handled upstream
 
     // Prefer the user-entered interest_rate_bps on each account (a direct signal) over the
-    // transaction-heuristic when at least one in-scope account has it set. Blend by current
-    // balance across the accounts that have a rate set; accounts without one are excluded from
-    // this direct-signal blend (their balances still count toward liquidBalanceCents above).
+    // transaction-heuristic when at least one in-scope account (regular or rated investment)
+    // has it set. Blend by current balance across the accounts that have a rate set; accounts
+    // without one are excluded from this direct-signal blend (their balances still count
+    // toward liquidBalanceCents above).
     const today = new Date().toISOString().slice(0, 10);
     const ratedAccounts = accounts.filter(
       (a: any) => a.interestRateBps !== null && a.interestRateBps !== undefined,
     );
-    const ratedWeight = ratedAccounts.reduce(
-      (sum: number, a: any) => sum + (balanceByAccountId.get(a.id) ?? 0),
-      0,
-    );
+    const ratedWeight =
+      ratedAccounts.reduce(
+        (sum: number, a: any) => sum + (balanceByAccountId.get(a.id) ?? 0),
+        0,
+      ) + investmentBalanceCents;
 
     let currentEarnedApyBps: number;
     let earnedApyAsOf: string;
-    if (ratedAccounts.length > 0 && ratedWeight > 0) {
-      const weightedSum = ratedAccounts.reduce(
-        (sum: number, a: any) =>
-          sum + a.interestRateBps * (balanceByAccountId.get(a.id) ?? 0),
-        0,
-      );
+    if ((ratedAccounts.length > 0 || ratedInvestmentAccounts.length > 0) && ratedWeight > 0) {
+      const weightedSum =
+        ratedAccounts.reduce(
+          (sum: number, a: any) =>
+            sum + a.interestRateBps * (balanceByAccountId.get(a.id) ?? 0),
+          0,
+        ) +
+        ratedInvestmentAccounts.reduce(
+          (sum, a) => sum + a.interestRateBps * a.balanceCents,
+          0,
+        );
       currentEarnedApyBps = Math.round(weightedSum / ratedWeight);
       earnedApyAsOf = today;
     } else {

--- a/apps/web/src/app/(protected)/investments/page.tsx
+++ b/apps/web/src/app/(protected)/investments/page.tsx
@@ -36,6 +36,7 @@ function AddAccountModal({ onClose }: { onClose: () => void }) {
     nickname: '',
     institution: '',
     accountType: '401k',
+    cashYieldPercent: '',
   });
   const [errors, setErrors] = useState<Record<string, string>>({});
 
@@ -43,6 +44,10 @@ function AddAccountModal({ onClose }: { onClose: () => void }) {
     const e: Record<string, string> = {};
     if (!form.nickname.trim()) e.nickname = 'Nickname is required';
     if (!form.institution.trim()) e.institution = 'Institution is required';
+    if (form.cashYieldPercent.trim()) {
+      const pct = Number(form.cashYieldPercent);
+      if (!Number.isFinite(pct) || pct < 0) e.cashYieldPercent = 'Enter a valid percentage';
+    }
     return e;
   }
 
@@ -51,8 +56,14 @@ function AddAccountModal({ onClose }: { onClose: () => void }) {
     const errs = validate();
     setErrors(errs);
     if (Object.keys(errs).length > 0) return;
+    const trimmedYield = form.cashYieldPercent.trim();
     create.mutate(
-      { nickname: form.nickname.trim(), institution: form.institution.trim(), accountType: form.accountType },
+      {
+        nickname: form.nickname.trim(),
+        institution: form.institution.trim(),
+        accountType: form.accountType,
+        interestRateBps: trimmedYield ? Math.round(Number(trimmedYield) * 100) : undefined,
+      },
       {
         onSuccess: () => {
           toast.success('Account added');
@@ -110,6 +121,27 @@ function AddAccountModal({ onClose }: { onClose: () => void }) {
                 <option key={t.value} value={t.value}>{t.label}</option>
               ))}
             </select>
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-sm font-semibold">Cash yield % (optional)</label>
+            <input
+              type="number"
+              step="0.01"
+              min="0"
+              inputMode="decimal"
+              value={form.cashYieldPercent}
+              onChange={(e) => setForm({ ...form, cashYieldPercent: e.target.value })}
+              placeholder="e.g. 3.66 for a money-market fund or cash sweep"
+              className="w-full rounded-xl border border-[var(--border)] bg-[var(--surface-container-low)] px-3 py-2.5 text-sm focus:border-[var(--primary)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)]/30 transition-all"
+            />
+            <p className="mt-1 text-xs text-[var(--muted-foreground)]">
+              Only set this if the account&apos;s balance is effectively cash (money-market fund,
+              cash sweep) — Cash Manager uses it to compare against your other liquid balances.
+            </p>
+            {errors.cashYieldPercent && (
+              <p className="mt-1 text-xs text-red-500">{errors.cashYieldPercent}</p>
+            )}
           </div>
 
           <div className="flex gap-3 pt-1">

--- a/db/migrations/0030_investment_account_interest_rate.sql
+++ b/db/migrations/0030_investment_account_interest_rate.sql
@@ -1,0 +1,6 @@
+-- Add nullable interest_rate_bps to investment_accounts so a cash-equivalent position
+-- inside a brokerage account (money-market fund, cash sweep balance) can declare its own
+-- yield, the same way accounts.interest_rate_bps does for checking/savings (see 0029).
+-- Additive-only: nullable column, no backfill, existing rows get NULL.
+
+ALTER TABLE "investment_accounts" ADD COLUMN IF NOT EXISTS "interest_rate_bps" integer;

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1784560700000,
       "tag": "0029_account_interest_rate",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1784560800000,
+      "tag": "0030_investment_account_interest_rate",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/src/validation/index.ts
+++ b/packages/shared/src/validation/index.ts
@@ -342,6 +342,10 @@ export const createInvestmentAccountSchema = z.object({
   institution: z.string().min(1).max(100),
   accountType: z.string().min(1).max(50),
   nickname: z.string().min(1).max(100),
+  /** Basis points (e.g. 335 = 3.35% APY) for a cash-equivalent position inside this
+   * account (money-market fund, cash sweep). Optional — most investment accounts
+   * (equities, index funds) have no meaningful "yield" to declare here. */
+  interestRateBps: z.int().min(0).max(100000).nullable().optional(),
 });
 
 export const updateInvestmentAccountSchema = createInvestmentAccountSchema.partial();


### PR DESCRIPTION
Committed successfully.

## Summary

**Root cause:** `investment_accounts` had no interest/yield field at all, and `CashManagerService.runForUser`/`findUsersWithLiquidBalanceMove` hard-filtered to `accounts.account_type IN ('checking','savings')`. A Vanguard-style brokerage account's money-market/cash-sweep balance (economically identical to a savings account) was therefore structurally invisible to Cash Manager's APY blend and liquid-balance-move detection — always treated as $0-yield or simply excluded.

**Fix:**
- Added a nullable `interest_rate_bps` column to `investment_accounts` (additive migration `0030`, mirrors the existing `accounts.interest_rate_bps` from #29), plus the matching validation field and a "Cash yield %" input on the Add Investment Account form.
- `CashManagerService.runForUser` now fetches investment accounts that have a declared rate, joins their latest `investment_snapshots` balance (a separate table from `account_balance_snapshots`, since investment accounts have no imported transactions), and folds them into the same balance-weighted current-APY blend and `liquidBalanceCents` total used for regular accounts. Unrated (equity/index-fund) investment accounts are left out — they aren't cash-equivalent.
- `findUsersWithLiquidBalanceMove` was extended to union in the same rated-investment-account snapshot history so the latest-vs-prior liquid-balance-move trigger also reacts to these balances.

**Verification:** Ran the full backend `investments`/`recommendations` unit-test suites (updated the existing mock-db test to account for the new query call) — all 90 tests pass; confirmed a clean `tsc --noEmit` for the `api` and `shared` packages (the `web` package has pre-existing, unrelated vitest-globals typecheck noise in its test files that predates this change).

---
### Test evidence
```
 .../__tests__/cash-manager.service.spec.ts         |   1 +
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/sync/__tests__/signing.service.spec.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 5[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/sync/__tests__/sync-payload.util.spec.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 10[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/expected-cycle-date.spec.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/audit/audit.service.spec.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 8[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/sync-delivery.processor.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 4[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/next-loan-due-date.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/categorization/__tests__/learning.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m90 passed[39m[22m[90m (90)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m744 passed[39m[22m[90m (744)[39m
@moneypulse/api:test: [2m   Start at [22m 18:24:54
@moneypulse/api:test: [2m   Duration [22m 12.25s[2m (transform 4.50s, setup 0ms, import 67.87s, tests 2.31s, environment 6ms)[22m
@moneypulse/api:test: 

 Tasks:    3 successful, 3 total
Cached:    0 cached, 3 total
  Time:    13.454s
```
</details>

### Review
**Review verdict:** approve

Findings (advisory — did not block landing):
- [low/correctness] apps/api/src/recommendations/cash-manager.service.ts:115 — findUsersWithLiquidBalanceMove UNION-ALLs account_balance_snapshots and investment_snapshots and sums per (user_id, snapshot_date); the two tables have independent date cadences, so a date present in only one source yields a total missing the other source's balance, producing spurious percentage moves and false triggers. Non-blocking because the trigger only gates re-evaluation and runForUser recomputes from each account's own latest balance.

---
Dispatched via coxd (`MyMoney-investment-accounts-money-ma-1785089931`) · cost $2.048 · 🤖 coxd