### PR TITLE
13.1 Phase 13 schema + shared contracts (monthly close, manual assets,

### DIFF
--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1187,10 +1187,149 @@ export const suitabilitySettings = pgTable(
     tickerAssetClassMap: jsonb('ticker_asset_class_map').notNull().default({}),
     dcaDayOfMonth: integer('dca_day_of_month'),
     dcaAmountCents: integer('dca_amount_cents'),
+    // 13.1: employer 401k match settings (decision #12) — nullable, appended to this
+    // versioned table rather than creating a new one. Basis points and cents, never
+    // floats.
+    employerMatchBps: integer('employer_match_bps'),
+    employerMatchLimitCents: integer('employer_match_limit_cents'),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
     uniqueIndex('uq_suitability_settings_user_version').on(table.userId, table.version),
     index('idx_suitability_settings_user_created').on(table.userId, table.createdAt.desc()),
+  ],
+);
+
+// ── Monthly Close: Manual Assets, Loan Balance Snapshots, Monthly Financial
+// Snapshots (13.1) ────────────────────────────────────────────
+// Schema-only slice — see specs/PHASE13-MONTHLY-CLOSE-SPEC.md Data Model section,
+// WITH overrides from epic #158 "Resolved decisions": no household_id anywhere
+// (household scope deferred, decision #5); monthly_snapshot_events intentionally
+// NOT created — edited_at/is_edited on monthly_financial_snapshots is the whole
+// audit trail (decision #6).
+
+export const manualAssets = pgTable(
+  'manual_assets',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id),
+    name: varchar('name', { length: 120 }).notNull(),
+    assetType: varchar('asset_type', { length: 30 }).notNull(), // home | car | gold | other
+    liquidityClass: varchar('liquidity_class', { length: 30 }).notNull(), // liquid | semi_liquid | illiquid
+    isDepreciating: boolean('is_depreciating').notNull().default(false),
+    notes: text('notes'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (table) => [index('idx_manual_assets_user').on(table.userId)],
+);
+
+export const manualAssetSnapshots = pgTable(
+  'manual_asset_snapshots',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    manualAssetId: uuid('manual_asset_id')
+      .notNull()
+      .references(() => manualAssets.id),
+    snapshotMonth: date('snapshot_month').notNull(), // first day of month
+    valueCents: integer('value_cents').notNull(),
+    source: varchar('source', { length: 40 }).notNull().default('manual'), // manual | estimate | imported
+    notes: text('notes'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('uq_manual_asset_snapshots_asset_month').on(
+      table.manualAssetId,
+      table.snapshotMonth,
+    ),
+  ],
+);
+
+export const loanBalanceSnapshots = pgTable(
+  'loan_balance_snapshots',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    loanId: uuid('loan_id')
+      .notNull()
+      .references(() => loans.id),
+    snapshotMonth: date('snapshot_month').notNull(),
+    balanceCents: integer('balance_cents').notNull(),
+    source: varchar('source', { length: 40 }).notNull(), // amortized | manual_statement
+    verifiedAt: timestamp('verified_at', { withTimezone: true }),
+    notes: text('notes'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('uq_loan_balance_snapshots_loan_month_source').on(
+      table.loanId,
+      table.snapshotMonth,
+      table.source,
+    ),
+  ],
+);
+
+export const monthlyFinancialSnapshots = pgTable(
+  'monthly_financial_snapshots',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id),
+    snapshotMonth: date('snapshot_month').notNull(), // first day of month
+    status: varchar('status', { length: 20 }).notNull().default('draft'), // draft | confirmed
+
+    takeHomeIncomeCents: integer('take_home_income_cents').notNull().default(0),
+    grossIncomeCents: integer('gross_income_cents'),
+    expenseCents: integer('expense_cents').notNull().default(0),
+    fixedExpenseCents: integer('fixed_expense_cents').notNull().default(0),
+    variableExpenseCents: integer('variable_expense_cents').notNull().default(0),
+
+    cashSavingsCents: integer('cash_savings_cents').notNull().default(0),
+    investmentContributionCents: integer('investment_contribution_cents').notNull().default(0),
+    debtPrincipalPaidCents: integer('debt_principal_paid_cents').notNull().default(0),
+    extraDebtPrincipalPaidCents: integer('extra_debt_principal_paid_cents').notNull().default(0),
+
+    liquidAssetCents: integer('liquid_asset_cents').notNull().default(0),
+    investmentAssetCents: integer('investment_asset_cents').notNull().default(0),
+    manualAssetCents: integer('manual_asset_cents').notNull().default(0),
+    totalAssetCents: integer('total_asset_cents').notNull().default(0),
+
+    creditCardLiabilityCents: integer('credit_card_liability_cents').notNull().default(0),
+    loanLiabilityCents: integer('loan_liability_cents').notNull().default(0),
+    totalLiabilityCents: integer('total_liability_cents').notNull().default(0),
+    netWorthCents: integer('net_worth_cents').notNull().default(0),
+
+    savingsRateBps: integer('savings_rate_bps'), // cash_savings / take_home_income
+    investingRateBps: integer('investing_rate_bps'), // investment_contribution / take_home_income
+    debtPaydownRateBps: integer('debt_paydown_rate_bps'), // debt principal / take_home_income
+    wealthBuildingRateBps: integer('wealth_building_rate_bps'), // savings + investments + principal / take_home_income
+    expenseRatioBps: integer('expense_ratio_bps'), // expenses / take_home_income
+    liquidNetWorthRatioBps: integer('liquid_net_worth_ratio_bps'), // liquid assets / net worth
+    debtAssetRatioBps: integer('debt_asset_ratio_bps'), // total liabilities / total assets
+    debtPaymentIncomeRatioBps: integer('debt_payment_income_ratio_bps'),
+
+    targetStatus: jsonb('target_status').notNull().default({}),
+    freshness: jsonb('freshness').notNull().default({}),
+    calculationVersion: varchar('calculation_version', { length: 30 }).notNull(),
+    notes: text('notes'),
+    aiReview: text('ai_review'),
+    // Lightweight audit trail (decision #6): confirmed snapshots stay editable;
+    // edits stamp these two fields instead of a separate events table.
+    editedAt: timestamp('edited_at', { withTimezone: true }),
+    isEdited: boolean('is_edited').notNull().default(false),
+    confirmedAt: timestamp('confirmed_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('uq_monthly_financial_snapshots_user_month').on(
+      table.userId,
+      table.snapshotMonth,
+    ),
   ],
 );

--- a/db/migrations/0031_monthly_close.sql
+++ b/db/migrations/0031_monthly_close.sql
@@ -1,0 +1,118 @@
+-- 13.1 Monthly close, manual assets, and loan balance snapshots (schema-only slice).
+-- Additive-only: new tables + two new nullable columns on suitability_settings. No
+-- backfill needed and no existing reads are affected.
+--
+-- Deviations from the original spec doc, per epic #158 "Resolved decisions" (these
+-- override the spec body):
+--   - manual_assets: no household_id (user-scoped only, decision #5).
+--   - monthly_financial_snapshots: no household_id (decision #5); adds edited_at +
+--     is_edited for the lightweight audit approach instead of a separate events
+--     table (decision #6).
+--   - monthly_snapshot_events is intentionally NOT created (decision #6).
+--   - suitability_settings gets employer_match_bps / employer_match_limit_cents
+--     (decision #12), appended via the table's existing versioned/append-only
+--     pattern — no backfill of historical versions.
+
+CREATE TABLE IF NOT EXISTS "manual_assets" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "user_id" uuid NOT NULL REFERENCES "users"("id"),
+  "name" varchar(120) NOT NULL,
+  "asset_type" varchar(30) NOT NULL, -- home | car | gold | other
+  "liquidity_class" varchar(30) NOT NULL, -- liquid | semi_liquid | illiquid
+  "is_depreciating" boolean NOT NULL DEFAULT false,
+  "notes" text,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  "deleted_at" timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS "idx_manual_assets_user" ON "manual_assets" ("user_id");
+
+CREATE TABLE IF NOT EXISTS "manual_asset_snapshots" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "manual_asset_id" uuid NOT NULL REFERENCES "manual_assets"("id"),
+  "snapshot_month" date NOT NULL, -- first day of month
+  "value_cents" integer NOT NULL,
+  "source" varchar(40) NOT NULL DEFAULT 'manual', -- manual | estimate | imported
+  "notes" text,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_manual_asset_snapshots_asset_month"
+  ON "manual_asset_snapshots" ("manual_asset_id", "snapshot_month");
+
+CREATE TABLE IF NOT EXISTS "loan_balance_snapshots" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "loan_id" uuid NOT NULL REFERENCES "loans"("id"),
+  "snapshot_month" date NOT NULL,
+  "balance_cents" integer NOT NULL,
+  "source" varchar(40) NOT NULL, -- amortized | manual_statement
+  "verified_at" timestamptz,
+  "notes" text,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_loan_balance_snapshots_loan_month_source"
+  ON "loan_balance_snapshots" ("loan_id", "snapshot_month", "source");
+
+CREATE TABLE IF NOT EXISTS "monthly_financial_snapshots" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "user_id" uuid NOT NULL REFERENCES "users"("id"),
+  "snapshot_month" date NOT NULL, -- first day of month
+  "status" varchar(20) NOT NULL DEFAULT 'draft', -- draft | confirmed
+
+  "take_home_income_cents" integer NOT NULL DEFAULT 0,
+  "gross_income_cents" integer,
+  "expense_cents" integer NOT NULL DEFAULT 0,
+  "fixed_expense_cents" integer NOT NULL DEFAULT 0,
+  "variable_expense_cents" integer NOT NULL DEFAULT 0,
+
+  "cash_savings_cents" integer NOT NULL DEFAULT 0,
+  "investment_contribution_cents" integer NOT NULL DEFAULT 0,
+  "debt_principal_paid_cents" integer NOT NULL DEFAULT 0,
+  "extra_debt_principal_paid_cents" integer NOT NULL DEFAULT 0,
+
+  "liquid_asset_cents" integer NOT NULL DEFAULT 0,
+  "investment_asset_cents" integer NOT NULL DEFAULT 0,
+  "manual_asset_cents" integer NOT NULL DEFAULT 0,
+  "total_asset_cents" integer NOT NULL DEFAULT 0,
+
+  "credit_card_liability_cents" integer NOT NULL DEFAULT 0,
+  "loan_liability_cents" integer NOT NULL DEFAULT 0,
+  "total_liability_cents" integer NOT NULL DEFAULT 0,
+  "net_worth_cents" integer NOT NULL DEFAULT 0,
+
+  "savings_rate_bps" integer, -- cash_savings / take_home_income
+  "investing_rate_bps" integer, -- investment_contribution / take_home_income
+  "debt_paydown_rate_bps" integer, -- debt principal / take_home_income
+  "wealth_building_rate_bps" integer, -- savings + investments + principal / take_home_income
+  "expense_ratio_bps" integer, -- expenses / take_home_income
+  "liquid_net_worth_ratio_bps" integer, -- liquid assets / net worth
+  "debt_asset_ratio_bps" integer, -- total liabilities / total assets
+  "debt_payment_income_ratio_bps" integer,
+
+  "target_status" jsonb NOT NULL DEFAULT '{}',
+  "freshness" jsonb NOT NULL DEFAULT '{}',
+  "calculation_version" varchar(30) NOT NULL,
+  "notes" text,
+  "ai_review" text,
+  -- Lightweight audit trail (decision #6): confirmed snapshots stay editable;
+  -- edits stamp these two fields instead of writing to a separate events table.
+  "edited_at" timestamptz,
+  "is_edited" boolean NOT NULL DEFAULT false,
+  "confirmed_at" timestamptz,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_monthly_financial_snapshots_user_month"
+  ON "monthly_financial_snapshots" ("user_id", "snapshot_month");
+
+-- Employer 401k match fields (decision #12) — added to the existing versioned,
+-- append-only suitability_settings table. Nullable so historical versions (and any
+-- version written before the FOO overlay reads this) are unaffected.
+ALTER TABLE "suitability_settings"
+  ADD COLUMN IF NOT EXISTS "employer_match_bps" integer,
+  ADD COLUMN IF NOT EXISTS "employer_match_limit_cents" integer;

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1784560800000,
       "tag": "0030_investment_account_interest_rate",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1784560900000,
+      "tag": "0031_monthly_close",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -453,3 +453,43 @@ export const MARKET_INSIGHT_THRESHOLDS = {
   /** Gas dip note: min week-over-week % move in state gas price to fire a brief update. */
   GAS_WOW_PERCENT: 3,
 } as const;
+
+// ── Monthly Close: target bands & calculation version (13.1) ────
+// Bands are expressed in basis points (1% = 100 bps) to match the *_bps columns on
+// monthly_financial_snapshots — never floats for ratios. All bands are inclusive of
+// their lower bound and exclusive of their upper bound. Defaults per
+// specs/PHASE13-MONTHLY-CLOSE-SPEC.md, as narrowed by epic #158 decision #10
+// (single expense-ratio band for v1 — no fixed/variable split yet).
+
+/** Liquid assets / net worth. Green band centered on a 30% default target. */
+export const LIQUID_NET_WORTH_RATIO_TARGET_BPS = {
+  DEFAULT_TARGET_BPS: 3000,
+  GREEN_MIN_BPS: 2500,
+  GREEN_MAX_BPS: 3500,
+  YELLOW_LOW_MIN_BPS: 1500,
+  YELLOW_HIGH_MAX_BPS: 4500,
+  RED_MAX_BPS: 1500,
+} as const;
+
+/** Total liabilities / total assets. */
+export const DEBT_ASSET_RATIO_TARGET_BPS = {
+  GREEN_MAX_BPS: 2500,
+  YELLOW_MAX_BPS: 4000,
+} as const;
+
+/** Required monthly debt payments / take-home income. */
+export const DEBT_PAYMENT_INCOME_RATIO_TARGET_BPS = {
+  GREEN_MAX_BPS: 2500,
+  YELLOW_MAX_BPS: 3500,
+} as const;
+
+/** Expenses / take-home income. Single band for v1 (decision #10). */
+export const EXPENSE_RATIO_TARGET_BPS = {
+  GREEN_MAX_BPS: 6000,
+  YELLOW_MAX_BPS: 7500,
+} as const;
+
+/** Bumped whenever the monthly-close aggregate/ratio calculation logic changes, so
+ *  a frozen snapshot can be compared against the version that produced it (same
+ *  convention as the recommendation-engine `*_CALCULATION_VERSION` constants). */
+export const MONTHLY_CLOSE_CALCULATION_VERSION = 'monthly-close-v1';

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -505,3 +505,128 @@ export interface Allocation {
   missingPriceFound: boolean;
   staleDays: number;
 }
+
+// ── Monthly Close: Manual Assets, Loan Balance Snapshots, Monthly Financial
+// Snapshots (13.1) ────────────────────────────────────────────
+// User-scoped only — no household_id (household scope deferred per epic #158
+// decision #5).
+
+export type ManualAssetType = 'home' | 'car' | 'gold' | 'other';
+export type ManualAssetLiquidityClass = 'liquid' | 'semi_liquid' | 'illiquid';
+export type ManualAssetSnapshotSource = 'manual' | 'estimate' | 'imported';
+export type LoanBalanceSnapshotSource = 'amortized' | 'manual_statement';
+export type MonthlyCloseStatus = 'draft' | 'confirmed';
+export type TargetStatusLevel = 'green' | 'yellow' | 'red' | 'info' | 'unknown';
+
+export interface ManualAsset {
+  id: string;
+  userId: string;
+  name: string;
+  assetType: ManualAssetType;
+  liquidityClass: ManualAssetLiquidityClass;
+  isDepreciating: boolean;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+}
+
+export interface ManualAssetSnapshot {
+  id: string;
+  manualAssetId: string;
+  snapshotMonth: string; // first day of month
+  valueCents: number;
+  source: ManualAssetSnapshotSource;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface LoanBalanceSnapshot {
+  id: string;
+  loanId: string;
+  snapshotMonth: string; // first day of month
+  balanceCents: number;
+  source: LoanBalanceSnapshotSource;
+  verifiedAt: string | null;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Frozen monthly household close: balance sheet, income statement, and ratios for
+ *  one calendar month. Confirmed rows stay editable — `isEdited`/`editedAt` are the
+ *  lightweight audit trail (no separate events table, per epic #158 decision #6). */
+export interface MonthlyFinancialSnapshot {
+  id: string;
+  userId: string;
+  snapshotMonth: string; // first day of month
+  status: MonthlyCloseStatus;
+
+  takeHomeIncomeCents: number;
+  grossIncomeCents: number | null;
+  expenseCents: number;
+  fixedExpenseCents: number;
+  variableExpenseCents: number;
+
+  cashSavingsCents: number;
+  investmentContributionCents: number;
+  debtPrincipalPaidCents: number;
+  extraDebtPrincipalPaidCents: number;
+
+  liquidAssetCents: number;
+  investmentAssetCents: number;
+  manualAssetCents: number;
+  totalAssetCents: number;
+
+  creditCardLiabilityCents: number;
+  loanLiabilityCents: number;
+  totalLiabilityCents: number;
+  netWorthCents: number;
+
+  savingsRateBps: number | null;
+  investingRateBps: number | null;
+  debtPaydownRateBps: number | null;
+  wealthBuildingRateBps: number | null;
+  expenseRatioBps: number | null;
+  liquidNetWorthRatioBps: number | null;
+  debtAssetRatioBps: number | null;
+  debtPaymentIncomeRatioBps: number | null;
+
+  targetStatus: Record<string, TargetStatusLevel>;
+  freshness: Record<string, unknown>;
+  calculationVersion: string;
+  notes: string | null;
+  aiReview: string | null;
+  editedAt: string | null;
+  isEdited: boolean;
+  confirmedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Rollup shape returned by `GET /monthly-close` list + detail endpoints. */
+export interface MonthlyCloseSummary {
+  month: string;
+  status: MonthlyCloseStatus;
+  headline: {
+    expensesCents: number;
+    netWorthCents: number;
+    savingsRateBps: number | null;
+    investingRateBps: number | null;
+    debtPaydownRateBps: number | null;
+    liquidNetWorthRatioBps: number | null;
+  };
+  // MonthlyCloseSection shape is defined in a later 13.x slice (grid/UI-facing);
+  // left as unknown[] here since this issue is schema-only.
+  sections: unknown[];
+  targetStatus: Record<string, TargetStatusLevel>;
+  freshness: {
+    isComplete: boolean;
+    missingManualAssets: string[];
+    staleAccounts: string[];
+    unverifiedLoans: string[];
+  };
+  notes: string | null;
+  aiReview: string | null;
+}

--- a/packages/shared/src/validation/index.ts
+++ b/packages/shared/src/validation/index.ts
@@ -430,6 +430,11 @@ export const suitabilitySettingsInputSchema = z.object({
   tickerAssetClassMap: z.record(z.string(), z.string()).default({}),
   dcaDayOfMonth: z.int().min(1).max(28).nullable().optional(),
   dcaAmountCents: z.int().min(0).nullable().optional(),
+  // 13.1 (decision #12): employer 401k match, in basis points of eligible pay
+  // + an annual dollar cap, so the FOO next-dollar overlay can sequence "capture
+  // the match".
+  employerMatchBps: z.int().min(0).max(100000).nullable().optional(),
+  employerMatchLimitCents: z.int().min(0).nullable().optional(),
 });
 
 export type SuitabilitySettingsInput = z.infer<typeof suitabilitySettingsInputSchema>;
@@ -471,3 +476,52 @@ export const updatePaycheckProfileSchema = createPaycheckProfileSchema.partial()
 
 export type CreatePaycheckProfileInput = z.infer<typeof createPaycheckProfileSchema>;
 export type UpdatePaycheckProfileInput = z.infer<typeof updatePaycheckProfileSchema>;
+
+// ── Monthly Close: Manual Assets, Loan Balance Snapshots, Monthly Financial
+// Snapshots (13.1) ────────────────────────────────────────────
+
+export const createManualAssetSchema = z.object({
+  name: z.string().min(1).max(120),
+  assetType: z.enum(['home', 'car', 'gold', 'other']),
+  liquidityClass: z.enum(['liquid', 'semi_liquid', 'illiquid']),
+  isDepreciating: z.boolean().default(false),
+  notes: z.string().max(2000).nullable().optional(),
+});
+
+export const updateManualAssetSchema = createManualAssetSchema.partial();
+
+export type CreateManualAssetInput = z.infer<typeof createManualAssetSchema>;
+export type UpdateManualAssetInput = z.infer<typeof updateManualAssetSchema>;
+
+/** Body for `PUT /manual-assets/:id/snapshots/:month` — the month itself comes
+ *  from the URL, not the body. */
+export const putManualAssetSnapshotSchema = z.object({
+  valueCents: z.int().min(0),
+  source: z.enum(['manual', 'estimate', 'imported']).default('manual'),
+  notes: z.string().max(2000).nullable().optional(),
+});
+
+export type PutManualAssetSnapshotInput = z.infer<typeof putManualAssetSnapshotSchema>;
+
+/** Body for `PUT /loans/:id/balance-snapshots/:month` — the month itself comes
+ *  from the URL, not the body. `manual_statement` is the only source a user can
+ *  submit; `amortized` rows are system-computed. */
+export const putLoanBalanceSnapshotSchema = z.object({
+  balanceCents: z.int().min(0),
+  source: z.literal('manual_statement').default('manual_statement'),
+  verifiedAt: z.iso.datetime().nullable().optional(),
+  notes: z.string().max(2000).nullable().optional(),
+});
+
+export type PutLoanBalanceSnapshotInput = z.infer<typeof putLoanBalanceSnapshotSchema>;
+
+/** Body for `PATCH /monthly-close/:month` — user edits to notes and a small set of
+ *  overridable fields on an existing (draft or confirmed) close. Recalculated
+ *  aggregate fields are not user-settable directly. */
+export const patchMonthlyCloseSchema = z.object({
+  notes: z.string().max(4000).nullable().optional(),
+  fixedExpenseCents: z.int().min(0).nullable().optional(),
+  variableExpenseCents: z.int().min(0).nullable().optional(),
+});
+
+export type PatchMonthlyCloseInput = z.infer<typeof patchMonthlyCloseSchema>;


### PR DESCRIPTION
Committed successfully. Working tree is clean.

## Summary

Implemented issue #159 — the schema-only slice of the Phase 13 monthly-close epic:

- **Migration `db/migrations/0031_monthly_close.sql`** (next-free number confirmed at implementation time — `0029`/`0030` were already taken): adds `manual_assets`, `manual_asset_snapshots`, `loan_balance_snapshots`, `monthly_financial_snapshots`, and two new nullable columns on `suitability_settings` (`employer_match_bps`, `employer_match_limit_cents`), following the epic's resolved decisions rather than the original spec body — no `household_id` on any new table, no `monthly_snapshot_events` table, and a lightweight `edited_at`/`is_edited` audit trail on `monthly_financial_snapshots` instead.
- **`apps/api/src/db/schema.ts`**: matching Drizzle table definitions for all four new tables plus the `suitabilitySettings` column additions.
- **`packages/shared/src/types/index.ts`**: `ManualAsset`, `ManualAssetSnapshot`, `LoanBalanceSnapshot`, `MonthlyFinancialSnapshot`, and `MonthlyCloseSummary` (per the spec's API Design section).
- **`packages/shared/src/validation/index.ts`**: Zod schemas for manual-asset create/update, manual-asset-snapshot put, loan-balance-snapshot put, monthly-close patch, plus employer-match fields added to the existing suitability-settings schema.
- **`packages/shared/src/constants/index.ts`**: liquid%, debt/asset, debt-payment/income, and expense-ratio target bands (in basis points) and the `monthly-close-v1` calculation-version string.

Verification performed:
- `pnpm --filter @moneypulse/shared build`, `pnpm --filter @moneypulse/api build`, and `pnpm build` all pass.
- Applied the full migration chain (0000→0031) against a disposable Postgres container, confirming it runs clean and that a second apply is a no-op (idempotent, matching this repo's existing migration style).
- Inspected the resulting table/column shapes via `\d` and confirmed they match the Drizzle schema exactly, with no `household_id`

_(summary truncated)_

---
### Test evidence
_No test files were added or modified in this change._

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/sync/__tests__/signing.service.spec.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 5[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/sync/__tests__/sync-payload.util.spec.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 12[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/expected-cycle-date.spec.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 4[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/sync-delivery.processor.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 4[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/next-loan-due-date.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/audit/audit.service.spec.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 8[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/categorization/__tests__/learning.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m90 passed[39m[22m[90m (90)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m744 passed[39m[22m[90m (744)[39m
@moneypulse/api:test: [2m   Start at [22m 18:43:33
@moneypulse/api:test: [2m   Duration [22m 9.73s[2m (transform 3.55s, setup 0ms, import 51.47s, tests 1.97s, environment 6ms)[22m
@moneypulse/api:test: 

 Tasks:    2 successful, 2 total
Cached:    1 cached, 2 total
  Time:    11.085s
```
</details>

### Review
**Review verdict:** approve

---
Dispatched via coxd (`MyMoney-13-1-phase-13-schema-shared-1785090982`) · cost $1.998 · 🤖 coxd