### PR TITLE
Cash Manager excludes cash_sweep accounts from rate tracking

### DIFF
--- a/apps/api/src/recommendations/__tests__/cash-manager.service.spec.ts
+++ b/apps/api/src/recommendations/__tests__/cash-manager.service.spec.ts
@@ -2,6 +2,16 @@ import { describe, it, expect, vi } from 'vitest';
 import { CashManagerService } from '../cash-manager.service';
 import { RecommendationSuppressionService } from '../recommendation-suppression.service';
 
+/** Flattens a drizzle `SQL` wrapper's raw string chunks (ignoring bind-param values) so
+ * tests can assert on the literal SQL text without needing a real dialect/DB connection. */
+function sqlText(node: any): string {
+  if (node == null) return '';
+  if (typeof node === 'string') return node;
+  const chunks = node.queryChunks ?? node.value;
+  if (Array.isArray(chunks)) return chunks.map(sqlText).join(' ');
+  return '';
+}
+
 // Synthetic account fixture that HAS a lastFour set — simulates a real accounts row
 // (even though the service's own query projects only {id, nickname}) so the test holds
 // even if a future edit accidentally widens the select().
@@ -177,6 +187,48 @@ describe('CashManagerService — benchmark-rate-move event trigger', () => {
     const moved = await svc.checkBenchmarkRateMove(['treasury_bill_13w']);
 
     expect(moved).toBe(false);
+  });
+});
+
+describe('CashManagerService — cash_sweep account-type inclusion', () => {
+  it('includes cash_sweep alongside checking/savings in the runForUser accounts filter', async () => {
+    const db = buildMockDb({
+      balanceCents: 22_000_00,
+      expenseCents: 200_000,
+      settings: [{ emergencyFundTargetMonths: 6, taxState: 'CA' }],
+      interestCents: 5_000,
+      avgCents: 20_000_00,
+      watchlist: [],
+    });
+    let capturedWhere: any;
+    const originalWhere = db.select;
+    db.select = vi.fn((_proj?: any) => ({
+      from: () => ({
+        where: (whereArg: any): any => {
+          capturedWhere = capturedWhere ?? whereArg;
+          return originalWhere().from().where();
+        },
+      }),
+    }));
+    const notifications = buildNotifications();
+    const suppression = { checkAndSuppress: vi.fn().mockResolvedValue({ suppressed: false }) };
+    const svc = new CashManagerService(db, notifications as any, suppression as any);
+
+    await svc.runForUser('user-1');
+
+    expect(sqlText(capturedWhere)).toContain('cash_sweep');
+  });
+
+  it('includes cash_sweep alongside checking/savings in the liquid-balance-move CTE filter', async () => {
+    const db: any = { execute: vi.fn().mockResolvedValue([]) };
+    const notifications = buildNotifications();
+    const suppression = { checkAndSuppress: vi.fn() };
+    const svc = new CashManagerService(db, notifications as any, suppression as any);
+
+    await svc.findUsersWithLiquidBalanceMove();
+
+    const executedSql = sqlText(db.execute.mock.calls[0][0]);
+    expect(executedSql).toContain('cash_sweep');
   });
 });
 

--- a/apps/api/src/recommendations/cash-manager.service.ts
+++ b/apps/api/src/recommendations/cash-manager.service.ts
@@ -94,7 +94,7 @@ export class CashManagerService {
 
   /**
    * Event trigger leg 2 (manifest: "liquid-balance-move(>=20%)"). Compares each user's
-   * latest two liquid (checking+savings, plus any investment account with a declared
+   * latest two liquid (checking+savings+cash_sweep, plus any investment account with a declared
    * cash-equivalent yield) balance snapshot totals — a straightforward latest-vs-previous
    * comparison, reusing the same account-type/rated filter as `runForUser`'s own
    * liquid-balance query. Users with fewer than two snapshot dates, or a zero/negative
@@ -105,7 +105,7 @@ export class CashManagerService {
     const rows = await this.db.execute(sql`
       WITH liquid_accounts AS (
         SELECT id, user_id FROM ${schema.accounts}
-        WHERE deleted_at IS NULL AND account_type IN ('checking', 'savings')
+        WHERE deleted_at IS NULL AND account_type IN ('checking', 'savings', 'cash_sweep')
       ),
       rated_investment_accounts AS (
         SELECT id, user_id FROM ${schema.investmentAccounts}
@@ -154,7 +154,7 @@ export class CashManagerService {
     return moved;
   }
 
-  /** Trailing-12mo interest credits / avg balance, per checking+savings account —
+  /** Trailing-12mo interest credits / avg balance, per checking+savings+cash_sweep account —
    * mirrors the MCP `get_earned_apy` tool's math, but only the resulting bps figure
    * (never the underlying interest transactions) leaves this method. */
   private async computeBlendedEarnedApyBps(
@@ -212,7 +212,7 @@ export class CashManagerService {
         and(
           eq(schema.accounts.userId, userId),
           isNull(schema.accounts.deletedAt),
-          sql`${schema.accounts.accountType} IN ('checking', 'savings')`,
+          sql`${schema.accounts.accountType} IN ('checking', 'savings', 'cash_sweep')`,
         ),
       );
 


### PR DESCRIPTION
Committed successfully.

## Summary

`CashManagerService.runForUser` and `findUsersWithLiquidBalanceMove` in `apps/api/src/recommendations/cash-manager.service.ts` hard-filtered the `accounts` table to `account_type IN ('checking', 'savings')`, silently excluding `cash_sweep` even though that enum value and `accounts.interestRateBps` already exist specifically for interest-bearing settlement accounts. A standalone high-yield cash-sweep account (not tied to a brokerage holding) got no benefit from the rate-comparison blend or the liquid-balance-move event trigger.

**Fix**: added `'cash_sweep'` to both `account_type IN (...)` filters (the `runForUser` accounts query and the `findUsersWithLiquidBalanceMove` CTE), and updated the surrounding comments that referenced "checking+savings" for accuracy. No schema change was needed.

**Verification**: added two regression tests that inspect the raw SQL/query text passed to the mocked DB driver for both code paths and assert `cash_sweep` is present in the account-type filter. Confirmed both new tests fail against the pre-fix code (via a temporary `git stash` of just the service change) and pass with the fix applied; the full existing suite (11 tests total) passes.

---
### Test evidence
**2 new test case(s) added** (heuristic count):
```
 .../__tests__/cash-manager.service.spec.ts         | 52 ++++++++++++++++++++++
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/sync/__tests__/signing.service.spec.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 7[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/sync/__tests__/sync-payload.util.spec.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 14[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/expected-cycle-date.spec.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 8[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/audit/audit.service.spec.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 9[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/sync-delivery.processor.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 6[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/next-loan-due-date.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/categorization/__tests__/learning.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m90 passed[39m[22m[90m (90)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m746 passed[39m[22m[90m (746)[39m
@moneypulse/api:test: [2m   Start at [22m 10:58:06
@moneypulse/api:test: [2m   Duration [22m 11.09s[2m (transform 3.59s, setup 0ms, import 59.93s, tests 2.12s, environment 6ms)[22m
@moneypulse/api:test: 

 Tasks:    2 successful, 2 total
Cached:    1 cached, 2 total
  Time:    11.608s
```
</details>

### Review
**Review verdict:** approve

---
Dispatched via coxd (`MyMoney-cash-manager-excludes-cash-s-1785149715`) · cost $0.763 · 🤖 coxd