### PR TITLE
13.2 Monthly-close calculator (pure, fixture-tested)

### DIFF
--- a/apps/api/src/monthly-close/__tests__/monthly-close-calculator.spec.ts
+++ b/apps/api/src/monthly-close/__tests__/monthly-close-calculator.spec.ts
@@ -1,0 +1,351 @@
+import {
+  calculateMonthlyClose,
+  FOO_MIN_INVESTING_RATE_BPS,
+  FOO_STARTER_EMERGENCY_FUND_MONTHS,
+  MonthlyCloseCalculatorInput,
+  MonthlyCloseTransactionLine,
+} from '../monthly-close-calculator';
+import { MONTHLY_CLOSE_CALCULATION_VERSION } from '@moneypulse/shared';
+
+function line(
+  overrides: Partial<MonthlyCloseTransactionLine> & { id: string; amountCents: number },
+): MonthlyCloseTransactionLine {
+  return {
+    direction: 'debit',
+    isTransfer: false,
+    isSplitParent: false,
+    isDeleted: false,
+    isDebtPrincipalTransfer: false,
+    categoryBucket: null,
+    ...overrides,
+  };
+}
+
+function baseInput(
+  overrides: Partial<MonthlyCloseCalculatorInput> = {},
+): MonthlyCloseCalculatorInput {
+  return {
+    month: '2026-06-01',
+    takeHomeIncomeCents: 600_000,
+    grossIncomeCents: null,
+    transactions: [],
+    cashSavingsCents: 0,
+    investmentContributionCents: 0,
+    debtPrincipalPaidCents: 0,
+    extraDebtPrincipalPaidCents: 0,
+    requiredMonthlyDebtPaymentCents: 0,
+    liquidAssetCents: 0,
+    investmentAssetCents: 0,
+    manualAssetCents: 0,
+    creditCardLiabilityCents: 0,
+    loanLiabilityCents: 0,
+    emergencyFundMonths: 3,
+    hasHighInterestDebt: false,
+    employerMatch: { available: false, captured: null },
+    freshness: { missingManualAssets: [], staleAccounts: [], unverifiedLoans: [] },
+    ...overrides,
+  };
+}
+
+describe('calculateMonthlyClose', () => {
+  // ── Full hand-computed household month-end close ────────────
+  // Take-home $6,000.00. Home ($400,000) + car ($20,000) + gold ($5,000) manual
+  // assets; a $300,000 mortgage carried at its manual-statement balance
+  // (overriding the amortized estimate); a credit card with a payment transfer
+  // (excluded), a purchase and interest (both counted as expenses), and a
+  // carried-balance principal payoff (debt paydown, not an expense).
+  it('hand-computes one full household month-end close', () => {
+    const transactions: MonthlyCloseTransactionLine[] = [
+      // Paycheck deposit — a credit, never touches the (debit-only) expense sum.
+      line({ id: 'paycheck', amountCents: 600_000, direction: 'credit' }),
+      // Ordinary "needs" spend.
+      line({ id: 'groceries', amountCents: 80_000, categoryBucket: 'needs' }),
+      // Ordinary "wants" spend.
+      line({ id: 'restaurants', amountCents: 30_000, categoryBucket: 'wants' }),
+      // Credit-card PAYMENT: a transfer, excluded from expenses.
+      line({ id: 'cc-payment', amountCents: 120_000, isTransfer: true }),
+      // Credit-card PURCHASE: not a transfer, counted as an expense.
+      line({ id: 'cc-purchase-dining', amountCents: 15_000, categoryBucket: 'wants' }),
+      // Credit-card interest: not a transfer, counted as an expense.
+      line({ id: 'cc-interest', amountCents: 2_500, categoryBucket: 'needs' }),
+      // Carried-balance principal payoff: excluded from expenses (debt paydown).
+      line({
+        id: 'cc-principal-payoff',
+        amountCents: 30_000,
+        isTransfer: true,
+        isDebtPrincipalTransfer: true,
+      }),
+      // Investment contribution transfer: excluded from expenses (fed separately
+      // via investmentContributionCents so it is never double-counted).
+      line({ id: 'brokerage-transfer', amountCents: 60_000, isTransfer: true }),
+      // Explicit savings transfer: excluded from expenses (fed via cashSavingsCents).
+      line({ id: 'savings-transfer', amountCents: 40_000, isTransfer: true }),
+      // Split parent: excluded regardless of amount/bucket.
+      line({ id: 'split-parent', amountCents: 50_000, isSplitParent: true, categoryBucket: 'wants' }),
+      // Deleted row: excluded regardless of amount/bucket.
+      line({ id: 'deleted-row', amountCents: 999_900, isDeleted: true, categoryBucket: 'wants' }),
+    ];
+
+    const input = baseInput({
+      transactions,
+      grossIncomeCents: 800_000,
+      cashSavingsCents: 40_000,
+      investmentContributionCents: 60_000,
+      // Mortgage principal ($500) + carried-CC principal payoff ($300).
+      debtPrincipalPaidCents: 80_000,
+      extraDebtPrincipalPaidCents: 20_000,
+      // Mortgage minimum ($1,800) — CC has no separate minimum modeled here.
+      requiredMonthlyDebtPaymentCents: 180_000,
+      liquidAssetCents: 1_500_000, // $15,000 checking/savings/cash_sweep
+      investmentAssetCents: 5_000_000, // $50,000 brokerage/401k
+      manualAssetCents: 42_500_000, // $400k home + $20k car + $5k gold
+      creditCardLiabilityCents: 200_000, // $2,000 statement balance
+      loanLiabilityCents: 30_000_000, // $300,000 mortgage, manual-statement wins
+      emergencyFundMonths: 3,
+      hasHighInterestDebt: false,
+      employerMatch: { available: true, captured: false },
+      freshness: {
+        missingManualAssets: [],
+        staleAccounts: ['acct-checking'],
+        unverifiedLoans: [],
+      },
+    });
+
+    const result = calculateMonthlyClose(input);
+
+    // Expenses: groceries + restaurants + cc-purchase + cc-interest only.
+    expect(result.expenseCents).toBe(80_000 + 30_000 + 15_000 + 2_500);
+    expect(result.expenseCents).toBe(127_500);
+
+    // Balance sheet.
+    expect(result.totalAssetCents).toBe(1_500_000 + 5_000_000 + 42_500_000);
+    expect(result.totalAssetCents).toBe(49_000_000);
+    expect(result.totalLiabilityCents).toBe(200_000 + 30_000_000);
+    expect(result.totalLiabilityCents).toBe(30_200_000);
+    expect(result.netWorthCents).toBe(49_000_000 - 30_200_000);
+    expect(result.netWorthCents).toBe(18_800_000);
+
+    // Rates over take-home ($600,000 cents = $6,000.00).
+    expect(result.savingsRateBps).toBe(667); // 40,000 / 600,000 = 6.667%
+    expect(result.investingRateBps).toBe(1_000); // 60,000 / 600,000 = 10%
+    expect(result.debtPaydownRateBps).toBe(1_333); // 80,000 / 600,000 = 13.333%
+    expect(result.wealthBuildingRateBps).toBe(3_000); // 180,000 / 600,000 = 30%
+    expect(result.expenseRatioBps).toBe(2_125); // 127,500 / 600,000 = 21.25%
+
+    // Ratios.
+    expect(result.liquidNetWorthRatioBps).toBe(798); // 1,500,000 / 18,800,000
+    expect(result.debtAssetRatioBps).toBe(6_163); // 30,200,000 / 49,000,000
+    expect(result.debtPaymentIncomeRatioBps).toBe(3_000); // 180,000 / 600,000
+
+    // Target statuses against the constant bands.
+    expect(result.targetStatus.expense_ratio).toBe('green'); // 21.25% < 60%
+    expect(result.targetStatus.liquid_net_worth_ratio).toBe('red'); // 7.98% < 15%
+    expect(result.targetStatus.debt_asset_ratio).toBe('red'); // 61.63% > 40%
+    expect(result.targetStatus.debt_payment_income_ratio).toBe('yellow'); // 30% in [25%,35%)
+    expect(result.targetStatus.savings_rate).toBe('info');
+    expect(result.targetStatus.investing_rate).toBe('info');
+    expect(result.targetStatus.debt_paydown_rate).toBe('info');
+    expect(result.targetStatus.wealth_building_rate).toBe('info');
+
+    // Ramit buckets: Fixed = needs-expenses (80,000 + 2,500) + all debt principal (80,000).
+    expect(result.ramitBuckets.fixedCents).toBe(80_000 + 2_500 + 80_000);
+    expect(result.ramitBuckets.fixedCents).toBe(162_500);
+    expect(result.ramitBuckets.investmentsCents).toBe(60_000);
+    expect(result.ramitBuckets.savingsCents).toBe(40_000);
+    // Guilt-free = wants-expenses: restaurants (30,000) + cc-purchase (15,000).
+    expect(result.ramitBuckets.guiltFreeCents).toBe(45_000);
+
+    // FOO: starter emergency fund OK, no high-interest debt, employer match
+    // available but not captured -> capture the match next.
+    expect(result.fooRecommendation.priority).toBe('capture_employer_match');
+    expect(result.fooRecommendation.citations.length).toBeGreaterThan(0);
+
+    // Freshness: one stale account -> incomplete.
+    expect(result.freshness.isComplete).toBe(false);
+    expect(result.freshness.staleAccounts).toEqual(['acct-checking']);
+
+    expect(result.calculationVersion).toBe(MONTHLY_CLOSE_CALCULATION_VERSION);
+  });
+
+  // ── Critical invariants ──────────────────────────────────────
+
+  it('excludes credit-card payments from expenses but counts purchases, interest, and fees', () => {
+    const input = baseInput({
+      transactions: [
+        line({ id: 'cc-payment', amountCents: 50_000, isTransfer: true }),
+        line({ id: 'cc-purchase', amountCents: 12_000 }),
+        line({ id: 'cc-interest', amountCents: 1_500 }),
+        line({ id: 'cc-late-fee', amountCents: 3_500 }),
+      ],
+    });
+
+    const result = calculateMonthlyClose(input);
+
+    expect(result.expenseCents).toBe(12_000 + 1_500 + 3_500);
+  });
+
+  it('treats carried-balance principal payoff as debt paydown, not an expense', () => {
+    const withPrincipal = baseInput({
+      transactions: [
+        line({
+          id: 'cc-principal',
+          amountCents: 25_000,
+          isTransfer: true,
+          isDebtPrincipalTransfer: true,
+        }),
+      ],
+      debtPrincipalPaidCents: 25_000,
+    });
+
+    const result = calculateMonthlyClose(withPrincipal);
+
+    expect(result.expenseCents).toBe(0);
+    expect(result.debtPrincipalPaidCents).toBe(25_000);
+  });
+
+  it('counts mortgage principal in debt paydown and wealth-building rate but not savings rate', () => {
+    const input = baseInput({
+      takeHomeIncomeCents: 500_000,
+      cashSavingsCents: 20_000,
+      debtPrincipalPaidCents: 100_000, // mortgage principal
+    });
+
+    const result = calculateMonthlyClose(input);
+
+    expect(result.savingsRateBps).toBe(400); // 20,000 / 500,000 — unaffected by principal
+    expect(result.debtPaydownRateBps).toBe(2_000); // 100,000 / 500,000
+    expect(result.wealthBuildingRateBps).toBe(2_400); // (20,000 + 100,000) / 500,000
+  });
+
+  it('includes home/car/gold in net worth but excludes them from liquid assets', () => {
+    const input = baseInput({
+      liquidAssetCents: 100_000,
+      manualAssetCents: 50_000_000, // home + car + gold
+    });
+
+    const result = calculateMonthlyClose(input);
+
+    expect(result.totalAssetCents).toBe(50_100_000);
+    expect(result.netWorthCents).toBe(50_100_000);
+    // Liquid ratio uses liquidAssetCents alone, not the manual assets.
+    expect(result.liquidNetWorthRatioBps).toBe(Math.round((100_000 / 50_100_000) * 10_000));
+    expect(result.liquidAssetCents).toBe(100_000);
+  });
+
+  it('never double-counts investments: the resolved investmentAssetCents figure is a single input', () => {
+    // The service resolves holdings-x-EOD-close vs the manual snapshot upstream
+    // (decision #2) into one number; this calculator has no second investment
+    // field to accidentally sum against it.
+    const input = baseInput({ investmentAssetCents: 10_000_000 });
+
+    const result = calculateMonthlyClose(input);
+
+    expect(result.investmentAssetCents).toBe(10_000_000);
+    expect(result.totalAssetCents).toBe(10_000_000);
+  });
+
+  // ── Null/zero edge cases ──────────────────────────────────────
+
+  it('returns null rates and unknown target status when take-home income is zero', () => {
+    const input = baseInput({ takeHomeIncomeCents: 0, cashSavingsCents: 10_000 });
+
+    const result = calculateMonthlyClose(input);
+
+    expect(result.savingsRateBps).toBeNull();
+    expect(result.investingRateBps).toBeNull();
+    expect(result.debtPaydownRateBps).toBeNull();
+    expect(result.wealthBuildingRateBps).toBeNull();
+    expect(result.expenseRatioBps).toBeNull();
+    expect(result.debtPaymentIncomeRatioBps).toBeNull();
+    expect(result.targetStatus.savings_rate).toBe('unknown');
+    expect(result.targetStatus.expense_ratio).toBe('unknown');
+  });
+
+  it('returns a null liquid ratio and unknown status when net worth is zero or negative', () => {
+    const input = baseInput({
+      liquidAssetCents: 10_000,
+      loanLiabilityCents: 10_000, // equals total assets -> net worth 0
+    });
+
+    const result = calculateMonthlyClose(input);
+
+    expect(result.netWorthCents).toBe(0);
+    expect(result.liquidNetWorthRatioBps).toBeNull();
+    expect(result.targetStatus.liquid_net_worth_ratio).toBe('unknown');
+  });
+
+  it('marks freshness complete only when nothing is missing/stale/unverified', () => {
+    const complete = calculateMonthlyClose(baseInput());
+    expect(complete.freshness.isComplete).toBe(true);
+
+    const incomplete = calculateMonthlyClose(
+      baseInput({
+        freshness: {
+          missingManualAssets: ['home'],
+          staleAccounts: [],
+          unverifiedLoans: [],
+        },
+      }),
+    );
+    expect(incomplete.freshness.isComplete).toBe(false);
+  });
+
+  // ── FOO next-dollar priority ordering ────────────────────────
+
+  it('prioritizes emergency reserves when below the starter buffer', () => {
+    const result = calculateMonthlyClose(
+      baseInput({ emergencyFundMonths: FOO_STARTER_EMERGENCY_FUND_MONTHS - 0.5 }),
+    );
+    expect(result.fooRecommendation.priority).toBe('build_emergency_reserves');
+  });
+
+  it('prioritizes emergency reserves when the emergency fund is unknown', () => {
+    const result = calculateMonthlyClose(baseInput({ emergencyFundMonths: null }));
+    expect(result.fooRecommendation.priority).toBe('build_emergency_reserves');
+  });
+
+  it('prioritizes high-interest debt payoff once the starter buffer is met', () => {
+    const result = calculateMonthlyClose(
+      baseInput({ emergencyFundMonths: FOO_STARTER_EMERGENCY_FUND_MONTHS, hasHighInterestDebt: true }),
+    );
+    expect(result.fooRecommendation.priority).toBe('pay_high_interest_debt');
+  });
+
+  it('prioritizes capturing the employer match once reserves are OK and no high-interest debt', () => {
+    const result = calculateMonthlyClose(
+      baseInput({
+        emergencyFundMonths: 3,
+        hasHighInterestDebt: false,
+        employerMatch: { available: true, captured: false },
+      }),
+    );
+    expect(result.fooRecommendation.priority).toBe('capture_employer_match');
+  });
+
+  it('prioritizes investing more when the match is captured (or unavailable) and investing rate is low', () => {
+    const result = calculateMonthlyClose(
+      baseInput({
+        emergencyFundMonths: 3,
+        hasHighInterestDebt: false,
+        employerMatch: { available: true, captured: true },
+        takeHomeIncomeCents: 600_000,
+        investmentContributionCents: 30_000, // 5% < 15% threshold
+      }),
+    );
+    expect(result.fooRecommendation.priority).toBe('invest');
+  });
+
+  it('falls through to debt acceleration once everything else clears', () => {
+    const result = calculateMonthlyClose(
+      baseInput({
+        emergencyFundMonths: 3,
+        hasHighInterestDebt: false,
+        employerMatch: { available: false, captured: null },
+        takeHomeIncomeCents: 600_000,
+        investmentContributionCents: 100_000, // 16.67% >= 15% threshold
+      }),
+    );
+    expect(result.fooRecommendation.priority).toBe('debt_acceleration');
+    expect(result.investingRateBps).toBeGreaterThanOrEqual(FOO_MIN_INVESTING_RATE_BPS);
+  });
+});

--- a/apps/api/src/monthly-close/monthly-close-calculator.ts
+++ b/apps/api/src/monthly-close/monthly-close-calculator.ts
@@ -1,0 +1,388 @@
+import {
+  LIQUID_NET_WORTH_RATIO_TARGET_BPS,
+  DEBT_ASSET_RATIO_TARGET_BPS,
+  DEBT_PAYMENT_INCOME_RATIO_TARGET_BPS,
+  EXPENSE_RATIO_TARGET_BPS,
+  MONTHLY_CLOSE_CALCULATION_VERSION,
+} from '@moneypulse/shared';
+import type { TargetStatusLevel } from '@moneypulse/shared';
+
+/**
+ * 13.2 — Monthly Close's deterministic core. Pure, DB-free, LLM-free: given a
+ * month's already-resolved figures (take-home income, transaction lines, account
+ * balances, manual asset carry-forwards, resolved loan/employer-match settings —
+ * all the DB reads/joins happen in the service layer per the epic), compute the
+ * full income-statement/balance-sheet close, the Metric Contract ratios, target
+ * bands, the Ramit Conscious Spending overlay, the Money Guy FOO next-dollar
+ * priority, and the freshness flags.
+ *
+ * See specs/PHASE13-MONTHLY-CLOSE-SPEC.md "Metric Contracts" for the exact
+ * formulas and epic #158's resolved-decisions table for the deviations from the
+ * original spec body (take-home = paycheck-profile net, holdings-else-snapshot
+ * investment pricing, carry-forward manual assets, derived Ramit Investments
+ * bucket, no household scope).
+ */
+
+// ── Local FOO thresholds ──────────────────────────────────────
+// The spec's V1 FOO output text fixes the *order* of priorities ("Build emergency
+// reserves / Pay high-interest debt / Capture match / Invest / Debt acceleration")
+// but does not pin exact numeric gates. These starter-buffer/investing-rate
+// thresholds are this module's deterministic interpretation — bump
+// MONTHLY_CLOSE_CALCULATION_VERSION if they change.
+export const FOO_STARTER_EMERGENCY_FUND_MONTHS = 1;
+export const FOO_MIN_INVESTING_RATE_BPS = 1500; // 15%
+
+export type CategoryBucket = 'needs' | 'wants' | 'savings_debt' | null;
+
+/** One month's already-classified transaction line, flattened for this pure
+ *  calculator. Category joins (isTransfer, bucket) happen in the service. */
+export interface MonthlyCloseTransactionLine {
+  id: string;
+  amountCents: number; // always a non-negative magnitude
+  direction: 'debit' | 'credit';
+  /** category.isTransfer — internal money movement (CC payment, account-to-account,
+   *  investment contribution transfer, etc). */
+  isTransfer: boolean;
+  isSplitParent: boolean;
+  isDeleted: boolean;
+  /** True for a debit line that is principal paid toward a carried credit-card
+   *  balance, a mortgage, an auto loan, or a personal loan. Excluded from expenses
+   *  regardless of isTransfer; folded into debt paydown instead. */
+  isDebtPrincipalTransfer: boolean;
+  categoryBucket: CategoryBucket;
+}
+
+export interface EmployerMatchInput {
+  /** Employer 401k match is configured (epic #158 decision #12). */
+  available: boolean;
+  /** Whether this month's contribution rate meets/exceeds the match threshold.
+   *  Null when match is available but capture status is unknown (incomplete data). */
+  captured: boolean | null;
+}
+
+export interface MonthlyCloseFreshnessInput {
+  missingManualAssets: string[];
+  staleAccounts: string[];
+  unverifiedLoans: string[];
+}
+
+export interface MonthlyCloseCalculatorInput {
+  month: string; // first day of month, YYYY-MM-DD
+  /** Paycheck-profile net (decision #1) — NOT transaction-derived. */
+  takeHomeIncomeCents: number;
+  grossIncomeCents: number | null;
+
+  transactions: MonthlyCloseTransactionLine[];
+
+  /** Checking/savings/money-market growth + explicit categorized savings
+   *  transfers for the month (balance-delta based; computed upstream). */
+  cashSavingsCents: number;
+  /** 401k/IRA/brokerage/HSA/529 invested contributions, market appreciation
+   *  excluded (derived per decision #4; computed upstream). */
+  investmentContributionCents: number;
+  /** All principal paid this month: mortgage + auto + personal loan + carried
+   *  credit-card payoff (manual-statement-wins else amortized; computed
+   *  upstream from loan-balance deltas, not re-derived from raw transaction
+   *  amounts, to avoid mismatches between a blended payment and its true
+   *  principal/interest/escrow split). */
+  debtPrincipalPaidCents: number;
+  /** Subset of debtPrincipalPaidCents that is above the required minimum. */
+  extraDebtPrincipalPaidCents: number;
+  requiredMonthlyDebtPaymentCents: number;
+
+  /** Checking + savings + cash_sweep. Never includes brokerage (decision #7). */
+  liquidAssetCents: number;
+  /** Holdings x EOD close when holdings exist, else the manual snapshot value —
+   *  never both (decision #2). Includes brokerage/401k/IRA/HSA/529. */
+  investmentAssetCents: number;
+  /** Carry-forward home/car/gold/other values (decision #3). */
+  manualAssetCents: number;
+  creditCardLiabilityCents: number;
+  loanLiabilityCents: number;
+
+  emergencyFundMonths: number | null;
+  hasHighInterestDebt: boolean;
+  employerMatch: EmployerMatchInput;
+
+  freshness: MonthlyCloseFreshnessInput;
+}
+
+export interface RamitBuckets {
+  fixedCents: number;
+  investmentsCents: number;
+  savingsCents: number;
+  guiltFreeCents: number;
+}
+
+export type FooPriority =
+  | 'build_emergency_reserves'
+  | 'pay_high_interest_debt'
+  | 'capture_employer_match'
+  | 'invest'
+  | 'debt_acceleration';
+
+export interface FooRecommendation {
+  priority: FooPriority;
+  label: string;
+  citations: string[];
+}
+
+export interface MonthlyCloseResult {
+  month: string;
+
+  takeHomeIncomeCents: number;
+  grossIncomeCents: number | null;
+  expenseCents: number;
+
+  cashSavingsCents: number;
+  investmentContributionCents: number;
+  debtPrincipalPaidCents: number;
+  extraDebtPrincipalPaidCents: number;
+
+  liquidAssetCents: number;
+  investmentAssetCents: number;
+  manualAssetCents: number;
+  totalAssetCents: number;
+  creditCardLiabilityCents: number;
+  loanLiabilityCents: number;
+  totalLiabilityCents: number;
+  netWorthCents: number;
+
+  savingsRateBps: number | null;
+  investingRateBps: number | null;
+  debtPaydownRateBps: number | null;
+  wealthBuildingRateBps: number | null;
+  expenseRatioBps: number | null;
+  liquidNetWorthRatioBps: number | null;
+  debtAssetRatioBps: number | null;
+  debtPaymentIncomeRatioBps: number | null;
+
+  targetStatus: Record<string, TargetStatusLevel>;
+  ramitBuckets: RamitBuckets;
+  fooRecommendation: FooRecommendation;
+  freshness: MonthlyCloseFreshnessInput & { isComplete: boolean };
+  calculationVersion: string;
+}
+
+function bpsOf(numeratorCents: number, denominatorCents: number): number | null {
+  if (denominatorCents <= 0) return null;
+  return Math.round((numeratorCents / denominatorCents) * 10_000);
+}
+
+/** Green/yellow/red over a single ascending green-max/yellow-max pair — "lower is
+ *  better" metrics (expense ratio, debt/asset, debt-payment/income). */
+function lowerIsBetterStatus(
+  bps: number | null,
+  greenMaxBps: number,
+  yellowMaxBps: number,
+): TargetStatusLevel {
+  if (bps === null) return 'unknown';
+  if (bps < greenMaxBps) return 'green';
+  if (bps < yellowMaxBps) return 'yellow';
+  return 'red';
+}
+
+/** Liquid-net-worth-ratio's centered band: green window, yellow shoulders either
+ *  side, red below the floor, informational above the ceiling. */
+function liquidRatioStatus(bps: number | null): TargetStatusLevel {
+  if (bps === null) return 'unknown';
+  const b = LIQUID_NET_WORTH_RATIO_TARGET_BPS;
+  if (bps < b.RED_MAX_BPS) return 'red';
+  if (bps < b.GREEN_MIN_BPS) return 'yellow';
+  if (bps < b.GREEN_MAX_BPS) return 'green';
+  if (bps < b.YELLOW_HIGH_MAX_BPS) return 'yellow';
+  return 'info';
+}
+
+/** Expenses per the Metric Contract: debits excluding transfers, split parents,
+ *  deleted rows, and debt-principal transfer lines. Credit-card purchases and
+ *  interest/fees count; credit-card payments (transfers) and any principal
+ *  payoff line do not. */
+function computeExpenseCents(transactions: MonthlyCloseTransactionLine[]): number {
+  return transactions
+    .filter(
+      (t) =>
+        t.direction === 'debit' &&
+        !t.isDeleted &&
+        !t.isTransfer &&
+        !t.isSplitParent &&
+        !t.isDebtPrincipalTransfer,
+    )
+    .reduce((sum, t) => sum + t.amountCents, 0);
+}
+
+/** Ramit Conscious Spending Plan buckets. Fixed = "needs"-bucketed expenses plus
+ *  all debt principal paid (minimums are a required fixed obligation; extra
+ *  paydown still isn't guilt-free spending, so it stays in Fixed rather than
+ *  being invented as a 5th bucket). Investments/Savings reuse the derived
+ *  aggregates directly (decision #4 — do not recategorize). Guilt-free is
+ *  everything else: "wants"/"savings_debt"/unclassified expense-counted debits.
+ *  Reuses `category_bucket` per decision #4 rather than a competing taxonomy. */
+function computeRamitBuckets(
+  transactions: MonthlyCloseTransactionLine[],
+  debtPrincipalPaidCents: number,
+  investmentContributionCents: number,
+  cashSavingsCents: number,
+): RamitBuckets {
+  const expenseLines = transactions.filter(
+    (t) =>
+      t.direction === 'debit' &&
+      !t.isDeleted &&
+      !t.isTransfer &&
+      !t.isSplitParent &&
+      !t.isDebtPrincipalTransfer,
+  );
+  const needsCents = expenseLines
+    .filter((t) => t.categoryBucket === 'needs')
+    .reduce((sum, t) => sum + t.amountCents, 0);
+  const otherCents = expenseLines
+    .filter((t) => t.categoryBucket !== 'needs')
+    .reduce((sum, t) => sum + t.amountCents, 0);
+
+  return {
+    fixedCents: needsCents + debtPrincipalPaidCents,
+    investmentsCents: investmentContributionCents,
+    savingsCents: cashSavingsCents,
+    guiltFreeCents: otherCents,
+  };
+}
+
+function computeFooRecommendation(input: MonthlyCloseCalculatorInput, investingRateBps: number | null): FooRecommendation {
+  const citations: string[] = [
+    `Emergency fund: ${input.emergencyFundMonths === null ? 'unknown' : `${input.emergencyFundMonths} month(s)`}.`,
+    `High-interest debt present: ${input.hasHighInterestDebt ? 'yes' : 'no'}.`,
+    `Employer match: ${
+      input.employerMatch.available
+        ? input.employerMatch.captured === null
+          ? 'available, capture status unknown'
+          : input.employerMatch.captured
+            ? 'available and captured'
+            : 'available and NOT fully captured'
+        : 'not configured'
+    }.`,
+    `Investing rate: ${investingRateBps === null ? 'unknown' : `${(investingRateBps / 100).toFixed(1)}%`}.`,
+  ];
+
+  if (
+    input.emergencyFundMonths === null ||
+    input.emergencyFundMonths < FOO_STARTER_EMERGENCY_FUND_MONTHS
+  ) {
+    return { priority: 'build_emergency_reserves', label: 'Build emergency reserves', citations };
+  }
+  if (input.hasHighInterestDebt) {
+    return { priority: 'pay_high_interest_debt', label: 'Pay high-interest debt', citations };
+  }
+  if (input.employerMatch.available && input.employerMatch.captured === false) {
+    return { priority: 'capture_employer_match', label: 'Capture employer match', citations };
+  }
+  if (investingRateBps === null || investingRateBps < FOO_MIN_INVESTING_RATE_BPS) {
+    return { priority: 'invest', label: 'Invest', citations };
+  }
+  return { priority: 'debt_acceleration', label: 'Debt acceleration', citations };
+}
+
+/**
+ * Compute one month's full close. Never mutates inputs; safe to call repeatedly
+ * (e.g. once for a live run, once again inside a test) with identical inputs
+ * producing identical output.
+ */
+export function calculateMonthlyClose(
+  input: MonthlyCloseCalculatorInput,
+): MonthlyCloseResult {
+  const expenseCents = computeExpenseCents(input.transactions);
+
+  const totalAssetCents =
+    input.liquidAssetCents + input.investmentAssetCents + input.manualAssetCents;
+  const totalLiabilityCents = input.creditCardLiabilityCents + input.loanLiabilityCents;
+  const netWorthCents = totalAssetCents - totalLiabilityCents;
+
+  const savingsRateBps = bpsOf(input.cashSavingsCents, input.takeHomeIncomeCents);
+  const investingRateBps = bpsOf(input.investmentContributionCents, input.takeHomeIncomeCents);
+  const debtPaydownRateBps = bpsOf(input.debtPrincipalPaidCents, input.takeHomeIncomeCents);
+  const wealthBuildingRateBps = bpsOf(
+    input.cashSavingsCents + input.investmentContributionCents + input.debtPrincipalPaidCents,
+    input.takeHomeIncomeCents,
+  );
+  const expenseRatioBps = bpsOf(expenseCents, input.takeHomeIncomeCents);
+  const liquidNetWorthRatioBps = bpsOf(input.liquidAssetCents, netWorthCents);
+  const debtAssetRatioBps = bpsOf(totalLiabilityCents, totalAssetCents);
+  const debtPaymentIncomeRatioBps = bpsOf(
+    input.requiredMonthlyDebtPaymentCents,
+    input.takeHomeIncomeCents,
+  );
+
+  const targetStatus: Record<string, TargetStatusLevel> = {
+    // No fixed band defined for these (v1) — 'info' once computable, 'unknown'
+    // when the take-home denominator is missing/zero.
+    savings_rate: savingsRateBps === null ? 'unknown' : 'info',
+    investing_rate: investingRateBps === null ? 'unknown' : 'info',
+    debt_paydown_rate: debtPaydownRateBps === null ? 'unknown' : 'info',
+    wealth_building_rate: wealthBuildingRateBps === null ? 'unknown' : 'info',
+    expense_ratio: lowerIsBetterStatus(
+      expenseRatioBps,
+      EXPENSE_RATIO_TARGET_BPS.GREEN_MAX_BPS,
+      EXPENSE_RATIO_TARGET_BPS.YELLOW_MAX_BPS,
+    ),
+    liquid_net_worth_ratio: liquidRatioStatus(liquidNetWorthRatioBps),
+    debt_asset_ratio: lowerIsBetterStatus(
+      debtAssetRatioBps,
+      DEBT_ASSET_RATIO_TARGET_BPS.GREEN_MAX_BPS,
+      DEBT_ASSET_RATIO_TARGET_BPS.YELLOW_MAX_BPS,
+    ),
+    debt_payment_income_ratio: lowerIsBetterStatus(
+      debtPaymentIncomeRatioBps,
+      DEBT_PAYMENT_INCOME_RATIO_TARGET_BPS.GREEN_MAX_BPS,
+      DEBT_PAYMENT_INCOME_RATIO_TARGET_BPS.YELLOW_MAX_BPS,
+    ),
+  };
+
+  const ramitBuckets = computeRamitBuckets(
+    input.transactions,
+    input.debtPrincipalPaidCents,
+    input.investmentContributionCents,
+    input.cashSavingsCents,
+  );
+
+  const fooRecommendation = computeFooRecommendation(input, investingRateBps);
+
+  const isComplete =
+    input.freshness.missingManualAssets.length === 0 &&
+    input.freshness.staleAccounts.length === 0 &&
+    input.freshness.unverifiedLoans.length === 0;
+
+  return {
+    month: input.month,
+    takeHomeIncomeCents: input.takeHomeIncomeCents,
+    grossIncomeCents: input.grossIncomeCents,
+    expenseCents,
+
+    cashSavingsCents: input.cashSavingsCents,
+    investmentContributionCents: input.investmentContributionCents,
+    debtPrincipalPaidCents: input.debtPrincipalPaidCents,
+    extraDebtPrincipalPaidCents: input.extraDebtPrincipalPaidCents,
+
+    liquidAssetCents: input.liquidAssetCents,
+    investmentAssetCents: input.investmentAssetCents,
+    manualAssetCents: input.manualAssetCents,
+    totalAssetCents,
+    creditCardLiabilityCents: input.creditCardLiabilityCents,
+    loanLiabilityCents: input.loanLiabilityCents,
+    totalLiabilityCents,
+    netWorthCents,
+
+    savingsRateBps,
+    investingRateBps,
+    debtPaydownRateBps,
+    wealthBuildingRateBps,
+    expenseRatioBps,
+    liquidNetWorthRatioBps,
+    debtAssetRatioBps,
+    debtPaymentIncomeRatioBps,
+
+    targetStatus,
+    ramitBuckets,
+    fooRecommendation,
+    freshness: { ...input.freshness, isComplete },
+    calculationVersion: MONTHLY_CLOSE_CALCULATION_VERSION,
+  };
+}


### PR DESCRIPTION
Committed. Summary:

## Summary

Implemented the 13.2 monthly-close calculator as a pure, DB/Nest/LLM-free module in `apps/api/src/monthly-close/monthly-close-calculator.ts`, following the same discipline as the Phase 12 agent calculators.

**Design**: `calculateMonthlyClose(input)` takes already-resolved figures (paycheck-net take-home, a flat list of pre-classified transaction lines, resolved account/manual-asset/loan balances, employer-match settings) — all DB reads/joins are left to the future service layer — and computes:

- **Expenses** per the exact Metric Contract: debits excluding transfers, split parents, deleted rows, and debt-principal transfer lines (so credit-card payments are excluded while purchases and interest/fees are counted, and carried-balance principal lands in debt paydown instead).
- The five rates (savings/investing/debt-paydown/wealth-building/expense-ratio) over take-home income, and the balance-sheet ratios (liquid/net-worth, debt/asset, debt-payment/income), each with `target_status` evaluated against the existing `packages/shared` constant bands.
- The Ramit Conscious Spending buckets (Fixed/Investments/Savings/Guilt-free), the Money Guy FOO next-dollar priority (with cited deterministic facts), and the freshness completeness flag.

**Tests** (`__tests__/monthly-close-calculator.spec.ts`, 15 cases, all passing): one fully hand-worked household month-end close (home+car+gold manual assets, a manual-statement-overridden mortgage, credit-card transfer exclusion, all ratios asserted against hand-computed values), plus targeted invariant tests (CC payment vs. purchase vs. interest vs. principal-payoff classification, mortgage principal in debt-paydown/wealth-building but not savings rate, home/car/gold excluded from liquid assets, single-source investment value preventing double counting), zero/negative-denominator edge cases, freshness completeness, and the full FOO priority ordering.

Verified with `pnpm --filter @moneypulse/api test mont

_(summary truncated)_

---
### Test evidence
**15 new test case(s) added** (heuristic count):
```
 .../__tests__/monthly-close-calculator.spec.ts     | 351 +++++++++++++++++++
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/sync/__tests__/signing.service.spec.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 7[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/sync/__tests__/sync-payload.util.spec.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 10[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/expected-cycle-date.spec.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 5[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/sync-delivery.processor.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 4[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/categorization/__tests__/learning.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/next-loan-due-date.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/audit/audit.service.spec.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 8[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m91 passed[39m[22m[90m (91)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m761 passed[39m[22m[90m (761)[39m
@moneypulse/api:test: [2m   Start at [22m 11:29:41
@moneypulse/api:test: [2m   Duration [22m 9.22s[2m (transform 2.86s, setup 0ms, import 49.04s, tests 1.96s, environment 5ms)[22m
@moneypulse/api:test: 

 Tasks:    2 successful, 2 total
Cached:    1 cached, 2 total
  Time:    9.689s
```
</details>

### Review
**Review verdict:** approve

Findings (advisory — did not block landing):
- [low/advisory] apps/api/src/monthly-close/monthly-close-calculator.ts:158 — targetStatus is typed as Record<string, TargetStatusLevel>, losing compile-time guarantees on the fixed set of metric keys; a literal-keyed type would prevent typos in consumers.

---
Dispatched via coxd (`MyMoney-13-2-monthly-close-calculato-1785151391`) · cost $1.661 · 🤖 coxd