### PR TITLE
13.3 Replace AnalyticsService.netWorth() to include all assets/liabili

### DIFF
--- a/apps/api/src/analytics/__tests__/analytics.service.spec.ts
+++ b/apps/api/src/analytics/__tests__/analytics.service.spec.ts
@@ -266,27 +266,60 @@ describe('AnalyticsService', () => {
   });
 
   describe('netWorth', () => {
-    it('should calculate net worth with camelCase keys', async () => {
+    /** netWorth() issues 4 sequential db.execute calls in this order:
+     *  1. accounts (liquid / regular-account investments / credit-card liabilities)
+     *  2. investment_accounts (holdings-x-price else snapshot)
+     *  3. manual_assets (carry-forward)
+     *  4. loans (manual-statement else amortized)
+     */
+    function mockNetWorthQueries(overrides: {
+      acct?: any;
+      investment?: any;
+      manualAsset?: any;
+      loans?: any[];
+    }) {
       mockDb.execute
         .mockResolvedValueOnce({
-          rows: [{ assets_cents: '800000', liabilities_cents: '150000' }],
+          rows: [
+            {
+              liquid_cents: '0',
+              regular_investment_cents: '0',
+              liabilities_cents: '0',
+              ...overrides.acct,
+            },
+          ],
         })
         .mockResolvedValueOnce({
-          rows: [{ investment_total_cents: '200000' }],
-        });
+          rows: [
+            {
+              holdings_total_cents: '0',
+              snapshot_total_cents: '0',
+              ...overrides.investment,
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          rows: [{ manual_asset_total_cents: '0', ...overrides.manualAsset }],
+        })
+        .mockResolvedValueOnce({ rows: overrides.loans ?? [] });
+    }
+
+    it('should calculate net worth with camelCase keys', async () => {
+      mockNetWorthQueries({
+        acct: { liquid_cents: '800000', liabilities_cents: '150000' },
+        investment: { snapshot_total_cents: '200000' },
+      });
 
       const result = await service.netWorth(TEST_USER_ID, { household: false });
 
-      expect(result.assets).toBe(1000000); // 800000 + 200000
+      expect(result.assets).toBe(1000000); // 800000 liquid + 200000 investments
       expect(result.liabilities).toBe(150000);
       expect(result.investments).toBe(200000);
       expect(result.netWorth).toBe(850000); // 1000000 - 150000
     });
 
     it('should handle zero balances', async () => {
-      mockDb.execute
-        .mockResolvedValueOnce({ rows: [{ assets_cents: '0', liabilities_cents: '0' }] })
-        .mockResolvedValueOnce({ rows: [{ investment_total_cents: '0' }] });
+      mockNetWorthQueries({});
 
       const result = await service.netWorth(TEST_USER_ID, { household: false });
 
@@ -298,14 +331,99 @@ describe('AnalyticsService', () => {
     it('should handle missing investment data', async () => {
       mockDb.execute
         .mockResolvedValueOnce({
-          rows: [{ assets_cents: '500000', liabilities_cents: '100000' }],
+          rows: [
+            { liquid_cents: '500000', regular_investment_cents: '0', liabilities_cents: '100000' },
+          ],
         })
-        .mockResolvedValueOnce({ rows: [{}] });
+        .mockResolvedValueOnce({ rows: [{}] })
+        .mockResolvedValueOnce({ rows: [{}] })
+        .mockResolvedValueOnce({ rows: [] });
 
       const result = await service.netWorth(TEST_USER_ID, { household: false });
 
       expect(result.investments).toBe(0);
       expect(result.netWorth).toBe(400000);
+    });
+
+    it('includes brokerage/edu_529 regular-account balances in investments, never double-counted', async () => {
+      mockNetWorthQueries({
+        acct: { liquid_cents: '100000', regular_investment_cents: '50000' },
+      });
+
+      const result = await service.netWorth(TEST_USER_ID, { household: false });
+
+      expect(result.investments).toBe(50000);
+      expect(result.assets).toBe(150000);
+    });
+
+    it('uses holdings x price when holdings exist, ignoring any snapshot for that same total', async () => {
+      // Even if a snapshot total were non-zero, the service's holdings_total_cents
+      // and snapshot_total_cents come from mutually exclusive per-account SQL CTEs
+      // (an account contributes to exactly one), so summing both here is safe and
+      // reflects that no account is counted twice.
+      mockNetWorthQueries({
+        investment: { holdings_total_cents: '300000', snapshot_total_cents: '0' },
+      });
+
+      const result = await service.netWorth(TEST_USER_ID, { household: false });
+
+      expect(result.investments).toBe(300000);
+    });
+
+    it('includes manual assets (home/car/gold/other) in total assets', async () => {
+      mockNetWorthQueries({
+        acct: { liquid_cents: '100000' },
+        manualAsset: { manual_asset_total_cents: '400000' },
+      });
+
+      const result = await service.netWorth(TEST_USER_ID, { household: false });
+
+      expect(result.assets).toBe(500000);
+      expect(result.netWorth).toBe(500000);
+    });
+
+    it('subtracts loan liabilities: manual-statement balance wins over amortized calc', async () => {
+      mockNetWorthQueries({
+        acct: { liquid_cents: '1000000' },
+        loans: [
+          {
+            original_balance_cents: '10000000',
+            apr_bps: '400',
+            scheduled_payment_cents: '50000',
+            start_date: '2020-01-01',
+            manual_balance_cents: '9500000',
+            latest_source: 'manual_statement',
+          },
+        ],
+      });
+
+      const result = await service.netWorth(TEST_USER_ID, { household: false });
+
+      expect(result.liabilities).toBe(9500000);
+      expect(result.netWorth).toBe(1000000 - 9500000);
+    });
+
+    it('falls back to amortized loan balance when no manual statement snapshot exists', async () => {
+      mockNetWorthQueries({
+        acct: { liquid_cents: '1000000' },
+        loans: [
+          {
+            original_balance_cents: '10000000',
+            apr_bps: '400',
+            scheduled_payment_cents: '50000',
+            start_date: '2020-01-01',
+            manual_balance_cents: null,
+            latest_source: null,
+          },
+        ],
+      });
+
+      const result = await service.netWorth(TEST_USER_ID, { household: false });
+
+      // Amortized balance after time has elapsed since 2020-01-01 must be strictly
+      // less than the original balance (payments have been applied) but still positive.
+      expect(result.liabilities).toBeGreaterThan(0);
+      expect(result.liabilities).toBeLessThan(10000000);
     });
   });
 

--- a/apps/api/src/analytics/analytics.service.ts
+++ b/apps/api/src/analytics/analytics.service.ts
@@ -9,6 +9,7 @@ import type {
   BillFrequency,
 } from '@moneypulse/shared';
 import { annualCostCents } from '../bills/bills.service';
+import { computeLoanState } from '@moneypulse/shared';
 
 @Injectable()
 export class AnalyticsService {
@@ -296,16 +297,26 @@ export class AnalyticsService {
   }
 
   /**
-   * Returns a net worth snapshot: assets minus liabilities plus investments.
-   * Assets = checking + savings balances. Liabilities = credit card balances.
-   * Investments = latest snapshot balance per investment account.
+   * Returns a full net worth snapshot across every asset/liability source the app
+   * tracks (see Phase 13 epic #158 decisions):
+   *  - Liquid = checking + savings + cash_sweep regular accounts (starting balance
+   *    + summed non-deleted transactions).
+   *  - Investments = per investment_account, holdings x latest EOD close when the
+   *    account has declared holdings, ELSE its latest manual investment_snapshot
+   *    — never both (decision #2) — plus brokerage/edu_529 balances held as
+   *    regular accounts (starting balance + transactions, same as liquid).
+   *  - Manual assets = latest carry-forward manual_asset_snapshots value per
+   *    non-deleted manual_asset (home/car/gold/other).
+   *  - Liabilities = credit_card account balances plus loan balances
+   *    (manual-statement-wins else amortized via `computeLoanState`).
    * Scoped to the authenticated user or their household members.
    *
    * @param {string} userId - The authenticated user's ID.
    * @param {Pick<AnalyticsQuery, 'household'>} query - Household flag for scoping.
    * @param {string | null} [householdId] - Optional household ID for multi-user scoping.
    * @returns {Promise<{ assets: number; liabilities: number; investments: number; netWorth: number }>}
-   *   Net worth snapshot with assets, liabilities, investments, and net total.
+   *   Net worth snapshot with assets (liquid + investments + manual assets),
+   *   liabilities (credit cards + loans), investments, and net total.
    * @throws {Error} If the database query fails.
    */
   async netWorth(
@@ -313,21 +324,35 @@ export class AnalyticsService {
     query: Pick<AnalyticsQuery, 'household'>,
     householdId?: string | null,
   ) {
-    const userScope = householdId && query.household
+    const acctUserScope = householdId && query.household
       ? sql`a.user_id IN (SELECT id FROM ${schema.users} WHERE household_id = ${householdId})`
       : sql`a.user_id = ${userId}`;
-
     const invUserScope = householdId && query.household
       ? sql`ia.user_id IN (SELECT id FROM ${schema.users} WHERE household_id = ${householdId})`
       : sql`ia.user_id = ${userId}`;
+    const maUserScope = householdId && query.household
+      ? sql`ma.user_id IN (SELECT id FROM ${schema.users} WHERE household_id = ${householdId})`
+      : sql`ma.user_id = ${userId}`;
+    const loanUserScope = householdId && query.household
+      ? sql`l.user_id IN (SELECT id FROM ${schema.users} WHERE household_id = ${householdId})`
+      : sql`l.user_id = ${userId}`;
 
-    const rows = await this.db.execute(sql`
+    // Liquid (checking/savings/cash_sweep), regular-account investments
+    // (brokerage/edu_529 held directly on `accounts`, not via investment_accounts),
+    // and credit-card liabilities — all computed the same way (starting balance +
+    // summed non-deleted transactions).
+    const acctRows = await this.db.execute(sql`
       SELECT
         SUM(CASE
-          WHEN a.account_type IN ('checking', 'savings') THEN
+          WHEN a.account_type IN ('checking', 'savings', 'cash_sweep') THEN
             a.starting_balance_cents + COALESCE(sub.net, 0)
           ELSE 0
-        END) AS assets_cents,
+        END) AS liquid_cents,
+        SUM(CASE
+          WHEN a.account_type IN ('brokerage', 'edu_529') THEN
+            a.starting_balance_cents + COALESCE(sub.net, 0)
+          ELSE 0
+        END) AS regular_investment_cents,
         SUM(CASE
           WHEN a.account_type = 'credit_card' THEN
             ABS(a.starting_balance_cents + COALESCE(sub.net, 0))
@@ -344,38 +369,137 @@ export class AnalyticsService {
           AND t.deleted_at IS NULL
       ) sub ON true
       WHERE a.deleted_at IS NULL
-        AND ${userScope}
+        AND ${acctUserScope}
     `);
-
-    const row = this.extractRows(rows)[0] || {
-      assets_cents: 0,
+    const acctRow = this.extractRows(acctRows)[0] || {
+      liquid_cents: 0,
+      regular_investment_cents: 0,
       liabilities_cents: 0,
     };
 
-    // Add investment balances (latest snapshot per account) scoped to user
+    // Manual investment_accounts (Phase 8): per account, holdings x latest EOD
+    // close when holdings exist, else the latest manual snapshot — never both.
     const investmentRows = await this.db.execute(sql`
-      SELECT COALESCE(SUM(latest.balance_cents), 0) AS investment_total_cents
-      FROM (
-        SELECT DISTINCT ON (ia.id) is2.balance_cents
+      WITH acct AS (
+        SELECT ia.id,
+          EXISTS (
+            SELECT 1 FROM ${schema.investmentHoldings} ih
+            WHERE ih.investment_account_id = ia.id
+          ) AS has_holdings
         FROM ${schema.investmentAccounts} ia
-        JOIN ${schema.investmentSnapshots} is2 ON ia.id = is2.investment_account_id
         WHERE ia.deleted_at IS NULL
           AND ${invUserScope}
-        ORDER BY ia.id, is2.date DESC
-      ) latest
+      ),
+      holdings_value AS (
+        SELECT ih.investment_account_id, SUM(
+          ih.share_count * COALESCE(sp.close_cents, 0)
+        ) AS value_cents
+        FROM ${schema.investmentHoldings} ih
+        JOIN acct ON acct.id = ih.investment_account_id AND acct.has_holdings
+        LEFT JOIN LATERAL (
+          SELECT close_cents
+          FROM ${schema.securityPrices} sp2
+          WHERE sp2.ticker = ih.ticker
+          ORDER BY sp2.price_date DESC
+          LIMIT 1
+        ) sp ON true
+        GROUP BY ih.investment_account_id
+      ),
+      snapshot_value AS (
+        SELECT acct.id AS investment_account_id, snap.balance_cents
+        FROM acct
+        LEFT JOIN LATERAL (
+          SELECT balance_cents
+          FROM ${schema.investmentSnapshots} s
+          WHERE s.investment_account_id = acct.id
+          ORDER BY s.date DESC, s.created_at DESC
+          LIMIT 1
+        ) snap ON true
+        WHERE NOT acct.has_holdings
+      )
+      SELECT
+        COALESCE((SELECT SUM(value_cents) FROM holdings_value), 0) AS holdings_total_cents,
+        COALESCE((SELECT SUM(balance_cents) FROM snapshot_value), 0) AS snapshot_total_cents
     `);
+    const investmentRow = this.extractRows(investmentRows)[0] || {
+      holdings_total_cents: 0,
+      snapshot_total_cents: 0,
+    };
 
+    // Manual assets (home/car/gold/other): latest carry-forward value per asset.
+    const manualAssetRows = await this.db.execute(sql`
+      SELECT COALESCE(SUM(latest.value_cents), 0) AS manual_asset_total_cents
+      FROM ${schema.manualAssets} ma
+      LEFT JOIN LATERAL (
+        SELECT value_cents
+        FROM ${schema.manualAssetSnapshots} mas
+        WHERE mas.manual_asset_id = ma.id
+        ORDER BY mas.snapshot_month DESC
+        LIMIT 1
+      ) latest ON true
+      WHERE ma.deleted_at IS NULL
+        AND ${maUserScope}
+    `);
+    const manualAssetCents = Number(
+      this.extractRows(manualAssetRows)[0]?.manual_asset_total_cents ?? 0,
+    );
+
+    // Loans: manual-statement-wins else amortized via computeLoanState.
+    const loanRows = await this.db.execute(sql`
+      SELECT
+        l.original_balance_cents,
+        l.apr_bps,
+        l.scheduled_payment_cents,
+        l.start_date::text AS start_date,
+        latest.balance_cents AS manual_balance_cents,
+        latest.source AS latest_source
+      FROM ${schema.loans} l
+      LEFT JOIN LATERAL (
+        SELECT balance_cents, source
+        FROM ${schema.loanBalanceSnapshots} lbs
+        WHERE lbs.loan_id = l.id
+        ORDER BY lbs.snapshot_month DESC
+        LIMIT 1
+      ) latest ON true
+      WHERE l.deleted_at IS NULL
+        AND l.is_active = true
+        AND ${loanUserScope}
+    `);
+    const loanLiabilityCents = this.extractRows(loanRows).reduce(
+      (sum: number, l: any) => {
+        if (l.latest_source === 'manual_statement' && l.manual_balance_cents != null) {
+          return sum + Number(l.manual_balance_cents);
+        }
+        const state = computeLoanState(
+          {
+            originalBalanceCents: Number(l.original_balance_cents),
+            aprBps: Number(l.apr_bps),
+            scheduledPaymentCents: Number(l.scheduled_payment_cents),
+            startDate: l.start_date,
+          },
+          [],
+        );
+        return sum + state.currentBalanceCents;
+      },
+      0,
+    );
+
+    const liquidCents = Number(acctRow.liquid_cents ?? 0);
+    const regularInvestmentCents = Number(acctRow.regular_investment_cents ?? 0);
+    const creditCardLiabilityCents = Number(acctRow.liabilities_cents ?? 0);
     const investmentCents =
-      this.extractRows(investmentRows)[0]?.investment_total_cents ?? 0;
+      Number(investmentRow.holdings_total_cents ?? 0) +
+      Number(investmentRow.snapshot_total_cents ?? 0) +
+      regularInvestmentCents;
+
+    const assets = liquidCents + investmentCents + manualAssetCents;
+    const liabilities = creditCardLiabilityCents + loanLiabilityCents;
 
     return {
-      assets: Number(row.assets_cents) + Number(investmentCents),
-      liabilities: Number(row.liabilities_cents),
-      investments: Number(investmentCents),
-      netWorth:
-        Number(row.assets_cents) +
-        Number(investmentCents) -
-        Number(row.liabilities_cents),
+      assets,
+      liabilities,
+      investments: investmentCents,
+      netWorth: assets - liabilities,
     };
   }
 


### PR DESCRIPTION
Committed successfully. Summary of the fix:

## Summary

`AnalyticsService.netWorth()` previously only counted checking/savings for assets, credit-card balances for liabilities, and manual `investment_snapshots` for investments — silently ignoring brokerage/edu_529/cash_sweep accounts, loans, manual assets (home/car/gold/other), and holdings×EOD-close pricing. Since the Phase 13 monthly close depends on a correct net worth and this method is shared app-wide, the fix lives here.

`netWorth()` now composes:
- **Liquid**: checking + savings + cash_sweep (starting balance + summed non-deleted transactions).
- **Investments**: per `investment_account`, holdings×latest EOD close when holdings exist, else its latest manual snapshot (mutually exclusive per account, so no double-counting), plus brokerage/edu_529 balances held as regular accounts.
- **Manual assets**: latest carry-forward `manual_asset_snapshots` value per non-deleted asset.
- **Liabilities**: credit-card balances plus loan balances (manual-statement wins, else amortized via the shared `computeLoanState` helper, mirroring the existing pattern already used in `market-insight-detector.service.ts`).

The method signature and its one caller (`analytics.controller.ts`) are unchanged.

Verification:
- Rewrote the `netWorth` test block to match the new 4-query `db.execute` sequence and added coverage for regular-account investments, holdings-vs-snapshot precedence, manual assets, and both loan-liability paths (manual-statement vs. amortized).
- `pnpm --filter @moneypulse/api test analytics` → 138/138 passing.
- Full `pnpm --filter @moneypulse/api test` → 766/766 passing.
- `tsc --noEmit` clean.

---
### Test evidence
**6 new test case(s) added** (heuristic count):
```
 .../analytics/__tests__/analytics.service.spec.ts  | 138 ++++++++++++++--
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
cations/__tests__/telegram-push.service.spec.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/advisor/digest/__tests__/digest-signals.service.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 8[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/sync-delivery.processor.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 4[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/suitability-settings/__tests__/suitability-settings.service.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/categorization/__tests__/learning.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/next-loan-due-date.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/expected-cycle-date.spec.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m91 passed[39m[22m[90m (91)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m766 passed[39m[22m[90m (766)[39m
@moneypulse/api:test: [2m   Start at [22m 12:37:39
@moneypulse/api:test: [2m   Duration [22m 9.23s[2m (transform 2.88s, setup 0ms, import 48.34s, tests 1.88s, environment 6ms)[22m
@moneypulse/api:test: 

 Tasks:    2 successful, 2 total
Cached:    1 cached, 2 total
  Time:    9.713s
```
</details>

### Review
**Review verdict:** approve

Findings (advisory — did not block landing):
- [low/advisory] apps/api/src/analytics/analytics.service.ts:386 — An investment account with holdings rows but no matching securityPrices row contributes 0 (COALESCE close_cents to 0) and is excluded from the snapshot fallback, so a priced-but-stale/unpriced holding silently reads as zero value.

---
Dispatched via coxd (`MyMoney-13-3-replace-analyticsservic-1785155629`) · cost $1.567 · 🤖 coxd