### PR TITLE
13.4 Manual-assets & loan-balance-snapshot API

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -29,6 +29,7 @@ import { AdvisorModule } from './advisor/advisor.module';
 import { MarketDataModule } from './market-data/market-data.module';
 import { RateWatchlistModule } from './rate-watchlist/rate-watchlist.module';
 import { SuitabilitySettingsModule } from './suitability-settings/suitability-settings.module';
+import { ManualAssetsModule } from './monthly-close/manual-assets.module';
 
 @Module({
   imports: [
@@ -79,6 +80,7 @@ import { SuitabilitySettingsModule } from './suitability-settings/suitability-se
     MarketDataModule,
     RateWatchlistModule,
     SuitabilitySettingsModule,
+    ManualAssetsModule,
     HealthModule,
   ],
   providers: [

--- a/apps/api/src/loans/__tests__/loan-balance-snapshots.service.spec.ts
+++ b/apps/api/src/loans/__tests__/loan-balance-snapshots.service.spec.ts
@@ -1,0 +1,115 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { LoansService } from '../loans.service';
+import { DATABASE_CONNECTION } from '../../db/db.module';
+import { NotificationsService } from '../../notifications/notifications.service';
+
+describe('LoansService — loan balance snapshots', () => {
+  let service: LoansService;
+  let mockDb: any;
+
+  const loan = {
+    id: 'loan-1',
+    userId: 'user-1',
+    name: 'Mortgage',
+    loanType: 'mortgage',
+    lenderPattern: 'wells fargo',
+    extraPrincipalPattern: null,
+    originalBalanceCents: 300_000_00,
+    aprBps: 500, // 5%
+    scheduledPaymentCents: 1_600_00,
+    startDate: '2020-01-01',
+    deletedAt: null,
+  };
+
+  beforeEach(async () => {
+    mockDb = {
+      select: vi.fn().mockReturnThis(),
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue([loan]),
+      insert: vi.fn().mockReturnThis(),
+      values: vi.fn().mockReturnThis(),
+      onConflictDoUpdate: vi.fn().mockReturnThis(),
+      returning: vi.fn().mockResolvedValue([]),
+      update: vi.fn().mockReturnThis(),
+      set: vi.fn().mockReturnThis(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LoansService,
+        { provide: DATABASE_CONNECTION, useValue: mockDb },
+        { provide: NotificationsService, useValue: {} },
+      ],
+    }).compile();
+
+    service = module.get<LoansService>(LoansService);
+  });
+
+  describe('getBalanceForMonth', () => {
+    it('uses the manual_statement balance when one exists for the month, and reports its source', async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([loan]) // requireOwnedLoan
+        .mockResolvedValueOnce([
+          {
+            snapshotMonth: '2026-06-01',
+            balanceCents: 275_000_00,
+            source: 'manual_statement',
+            verifiedAt: null,
+            notes: 'June statement',
+          },
+        ]); // manual lookup
+
+      const result = await service.getBalanceForMonth('loan-1', 'user-1', '2026-06-01');
+
+      expect(result).toEqual({
+        snapshotMonth: '2026-06-01',
+        balanceCents: 275_000_00,
+        source: 'manual_statement',
+        verifiedAt: null,
+        notes: 'June statement',
+      });
+    });
+
+    it('falls back to the amortized estimate when no manual statement exists for the month', async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([loan]) // requireOwnedLoan
+        .mockResolvedValueOnce([]); // no manual_statement row
+      // No extraPrincipalPattern on this loan, so no transactions query is made.
+
+      const result = await service.getBalanceForMonth('loan-1', 'user-1', '2026-06-01');
+
+      expect(result.source).toBe('amortized');
+      expect(result.balanceCents).toBeGreaterThan(0);
+      expect(result.balanceCents).toBeLessThan(loan.originalBalanceCents);
+    });
+
+    it('throws NotFoundException for a loan the user does not own', async () => {
+      mockDb.limit.mockResolvedValueOnce([]);
+      await expect(
+        service.getBalanceForMonth('loan-x', 'user-1', '2026-06-01'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('upsertBalanceSnapshot', () => {
+    it('always writes source=manual_statement regardless of amortized data', async () => {
+      mockDb.limit.mockResolvedValueOnce([loan]); // requireOwnedLoan
+      mockDb.returning.mockResolvedValueOnce([
+        { loanId: 'loan-1', snapshotMonth: '2026-06-01', balanceCents: 275_000_00, source: 'manual_statement' },
+      ]);
+
+      const result = await service.upsertBalanceSnapshot('loan-1', 'user-1', '2026-06-01', {
+        balanceCents: 275_000_00,
+        source: 'manual_statement',
+      });
+
+      const values = mockDb.values.mock.calls.at(-1)[0];
+      expect(values.source).toBe('manual_statement');
+      expect(mockDb.onConflictDoUpdate).toHaveBeenCalled();
+      expect(result.balanceCents).toBe(275_000_00);
+    });
+  });
+});

--- a/apps/api/src/loans/loans.controller.ts
+++ b/apps/api/src/loans/loans.controller.ts
@@ -3,6 +3,7 @@ import {
   Get,
   Post,
   Patch,
+  Put,
   Delete,
   Param,
   Body,
@@ -13,8 +14,17 @@ import { LoansService } from './loans.service';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
 import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
-import { createLoanSchema, updateLoanSchema } from '@moneypulse/shared';
-import type { AuthTokenPayload, CreateLoanInput, UpdateLoanInput } from '@moneypulse/shared';
+import {
+  createLoanSchema,
+  updateLoanSchema,
+  putLoanBalanceSnapshotSchema,
+} from '@moneypulse/shared';
+import type {
+  AuthTokenPayload,
+  CreateLoanInput,
+  UpdateLoanInput,
+  PutLoanBalanceSnapshotInput,
+} from '@moneypulse/shared';
 
 @ApiTags('Loans')
 @Controller('loans')
@@ -57,5 +67,22 @@ export class LoansController {
   @ApiOperation({ summary: 'Delete (soft) a tracked loan' })
   async remove(@Param('id') id: string, @CurrentUser() user: AuthTokenPayload) {
     return { data: await this.loansService.remove(id, user.sub) };
+  }
+
+  @Get(':id/balance-snapshots')
+  @ApiOperation({ summary: 'List explicit monthly balance snapshots for a loan' })
+  async listBalanceSnapshots(@Param('id') id: string, @CurrentUser() user: AuthTokenPayload) {
+    return { data: await this.loansService.listBalanceSnapshots(id, user.sub) };
+  }
+
+  @Put(':id/balance-snapshots/:month')
+  @ApiOperation({ summary: 'Upsert a manual-statement balance for one month' })
+  async upsertBalanceSnapshot(
+    @Param('id') id: string,
+    @Param('month') month: string,
+    @CurrentUser() user: AuthTokenPayload,
+    @Body(new ZodValidationPipe(putLoanBalanceSnapshotSchema)) body: PutLoanBalanceSnapshotInput,
+  ) {
+    return { data: await this.loansService.upsertBalanceSnapshot(id, user.sub, month, body) };
   }
 }

--- a/apps/api/src/loans/loans.service.ts
+++ b/apps/api/src/loans/loans.service.ts
@@ -1,9 +1,22 @@
 import { Inject, Injectable, NotFoundException } from '@nestjs/common';
-import { and, eq, isNull, asc, gte, lte, or, ilike } from 'drizzle-orm';
+import { and, eq, isNull, asc, desc, gte, lte, or, ilike } from 'drizzle-orm';
 import { DATABASE_CONNECTION } from '../db/db.module';
 import * as schema from '../db/schema';
-import type { CreateLoanInput, UpdateLoanInput } from '@moneypulse/shared';
+import type {
+  CreateLoanInput,
+  UpdateLoanInput,
+  PutLoanBalanceSnapshotInput,
+} from '@moneypulse/shared';
+import { computeLoanState, type ExtraPayment } from '@moneypulse/shared';
 import { NotificationsService } from '../notifications/notifications.service';
+
+export interface LoanBalanceSnapshotView {
+  snapshotMonth: string;
+  balanceCents: number;
+  source: 'manual_statement' | 'amortized';
+  verifiedAt: Date | null;
+  notes: string | null;
+}
 
 /**
  * Most recent monthly payment date that is at least `graceDays` in the past, with the
@@ -239,5 +252,150 @@ export class LoansService {
       }));
 
     return results;
+  }
+
+  private async requireOwnedLoan(id: string, userId: string) {
+    const existing = await this.db
+      .select()
+      .from(schema.loans)
+      .where(and(eq(schema.loans.id, id), eq(schema.loans.userId, userId)))
+      .limit(1);
+    if (!existing[0] || existing[0].deletedAt) {
+      throw new NotFoundException('Loan not found');
+    }
+    return existing[0];
+  }
+
+  /** Amortized balance for `month` (last day of month, UTC) computed via computeLoanState,
+   *  replaying any extra-principal transactions detected by the loan's pattern. */
+  private async computeAmortizedBalance(loan: any, month: string): Promise<number> {
+    let extras: ExtraPayment[] = [];
+    if (loan.extraPrincipalPattern) {
+      const pattern = `%${loan.extraPrincipalPattern}%`;
+      const rows = await this.db
+        .select({ date: schema.transactions.date, amountCents: schema.transactions.amountCents })
+        .from(schema.transactions)
+        .where(
+          and(
+            eq(schema.transactions.userId, loan.userId),
+            eq(schema.transactions.isCredit, false),
+            eq(schema.transactions.isSplitParent, false),
+            isNull(schema.transactions.deletedAt),
+            gte(schema.transactions.date, new Date(loan.startDate + 'T00:00:00Z')),
+            or(
+              ilike(schema.transactions.normalizedMerchantName, pattern),
+              ilike(schema.transactions.merchantName, pattern),
+            ),
+          ),
+        );
+      extras = rows.map((r: any) => ({
+        date: new Date(r.date).toISOString().slice(0, 10),
+        amountCents: Number(r.amountCents),
+      }));
+    }
+
+    // As-of end of the requested month (UTC), so the balance reflects that month's close.
+    const [y, m] = month.split('-').map(Number);
+    const asOf = new Date(Date.UTC(y, m, 0, 23, 59, 59));
+
+    const state = computeLoanState(
+      {
+        originalBalanceCents: loan.originalBalanceCents,
+        aprBps: loan.aprBps,
+        scheduledPaymentCents: loan.scheduledPaymentCents,
+        startDate: loan.startDate,
+      },
+      extras,
+      asOf,
+    );
+    return state.currentBalanceCents;
+  }
+
+  /**
+   * All explicit balance-snapshot rows for a loan (both sources), most recent month first.
+   * Ownership-checked.
+   */
+  async listBalanceSnapshots(loanId: string, userId: string) {
+    await this.requireOwnedLoan(loanId, userId);
+    return this.db
+      .select()
+      .from(schema.loanBalanceSnapshots)
+      .where(eq(schema.loanBalanceSnapshots.loanId, loanId))
+      .orderBy(desc(schema.loanBalanceSnapshots.snapshotMonth));
+  }
+
+  /**
+   * The balance to use for `month`: a `manual_statement` row wins if present for that
+   * month; otherwise the amortized estimate computed via `computeLoanState`. Always
+   * reports which source was used.
+   */
+  async getBalanceForMonth(loanId: string, userId: string, month: string): Promise<LoanBalanceSnapshotView> {
+    const loan = await this.requireOwnedLoan(loanId, userId);
+
+    const manual = await this.db
+      .select()
+      .from(schema.loanBalanceSnapshots)
+      .where(
+        and(
+          eq(schema.loanBalanceSnapshots.loanId, loanId),
+          eq(schema.loanBalanceSnapshots.snapshotMonth, month),
+          eq(schema.loanBalanceSnapshots.source, 'manual_statement'),
+        ),
+      )
+      .limit(1);
+    if (manual[0]) {
+      return {
+        snapshotMonth: month,
+        balanceCents: manual[0].balanceCents,
+        source: 'manual_statement',
+        verifiedAt: manual[0].verifiedAt,
+        notes: manual[0].notes,
+      };
+    }
+
+    const balanceCents = await this.computeAmortizedBalance(loan, month);
+    return {
+      snapshotMonth: month,
+      balanceCents,
+      source: 'amortized',
+      verifiedAt: null,
+      notes: null,
+    };
+  }
+
+  /** Upsert a `manual_statement` balance for one month, keyed on (loan, month, source). */
+  async upsertBalanceSnapshot(
+    loanId: string,
+    userId: string,
+    month: string,
+    input: PutLoanBalanceSnapshotInput,
+  ) {
+    await this.requireOwnedLoan(loanId, userId);
+
+    const rows = await this.db
+      .insert(schema.loanBalanceSnapshots)
+      .values({
+        loanId,
+        snapshotMonth: month,
+        balanceCents: input.balanceCents,
+        source: 'manual_statement',
+        verifiedAt: input.verifiedAt ? new Date(input.verifiedAt) : null,
+        notes: input.notes ?? null,
+      })
+      .onConflictDoUpdate({
+        target: [
+          schema.loanBalanceSnapshots.loanId,
+          schema.loanBalanceSnapshots.snapshotMonth,
+          schema.loanBalanceSnapshots.source,
+        ],
+        set: {
+          balanceCents: input.balanceCents,
+          verifiedAt: input.verifiedAt ? new Date(input.verifiedAt) : null,
+          notes: input.notes ?? null,
+          updatedAt: new Date(),
+        },
+      })
+      .returning();
+    return rows[0];
   }
 }

--- a/apps/api/src/monthly-close/__tests__/manual-assets.service.spec.ts
+++ b/apps/api/src/monthly-close/__tests__/manual-assets.service.spec.ts
@@ -1,0 +1,147 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { ManualAssetsService } from '../manual-assets.service';
+import { DATABASE_CONNECTION } from '../../db/db.module';
+
+describe('ManualAssetsService', () => {
+  let service: ManualAssetsService;
+  let mockDb: any;
+
+  const asset = {
+    id: 'asset-1',
+    userId: 'user-1',
+    name: 'Primary home',
+    assetType: 'home',
+    liquidityClass: 'illiquid',
+    isDepreciating: false,
+    deletedAt: null,
+  };
+
+  beforeEach(async () => {
+    mockDb = {
+      select: vi.fn().mockReturnThis(),
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue([asset]),
+      insert: vi.fn().mockReturnThis(),
+      values: vi.fn().mockReturnThis(),
+      onConflictDoUpdate: vi.fn().mockReturnThis(),
+      returning: vi.fn().mockResolvedValue([asset]),
+      update: vi.fn().mockReturnThis(),
+      set: vi.fn().mockReturnThis(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ManualAssetsService, { provide: DATABASE_CONNECTION, useValue: mockDb }],
+    }).compile();
+
+    service = module.get<ManualAssetsService>(ManualAssetsService);
+  });
+
+  describe('create — classification defaults', () => {
+    it.each([
+      ['home', 'illiquid', false],
+      ['car', 'illiquid', true],
+      ['gold', 'semi_liquid', false],
+      ['other', 'illiquid', false],
+    ] as const)('defaults %s to %s / depreciating=%s when not provided', async (assetType, liquidityClass, isDepreciating) => {
+      await service.create('user-1', { name: 'Test', assetType });
+      const values = mockDb.values.mock.calls.at(-1)[0];
+      expect(values.liquidityClass).toBe(liquidityClass);
+      expect(values.isDepreciating).toBe(isDepreciating);
+    });
+
+    it('honors an explicit override instead of the default', async () => {
+      await service.create('user-1', {
+        name: 'Vintage car',
+        assetType: 'car',
+        liquidityClass: 'semi_liquid',
+        isDepreciating: false,
+      });
+      const values = mockDb.values.mock.calls.at(-1)[0];
+      expect(values.liquidityClass).toBe('semi_liquid');
+      expect(values.isDepreciating).toBe(false);
+    });
+  });
+
+  describe('update/remove ownership', () => {
+    it('throws NotFoundException when the asset does not belong to the user', async () => {
+      mockDb.limit.mockResolvedValueOnce([]);
+      await expect(service.update('asset-x', 'user-1', { name: 'x' })).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('throws NotFoundException for a soft-deleted asset', async () => {
+      mockDb.limit.mockResolvedValueOnce([{ ...asset, deletedAt: new Date() }]);
+      await expect(service.remove('asset-1', 'user-1')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('getSnapshotForMonth — carry-forward', () => {
+    it('returns the exact snapshot when one exists for the month', async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([asset]) // requireOwned
+        .mockResolvedValueOnce([
+          { snapshotMonth: '2026-06-01', valueCents: 50_000_00, source: 'manual', notes: null },
+        ]); // exact match
+
+      const result = await service.getSnapshotForMonth('asset-1', 'user-1', '2026-06-01');
+      expect(result).toEqual({
+        snapshotMonth: '2026-06-01',
+        valueCents: 50_000_00,
+        source: 'manual',
+        notes: null,
+        asOfMonth: '2026-06-01',
+        isCarriedForward: false,
+      });
+    });
+
+    it('carries forward the most recent prior value and tags it with its own as-of month', async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([asset]) // requireOwned
+        .mockResolvedValueOnce([]) // no exact match for requested month
+        .mockResolvedValueOnce([
+          { snapshotMonth: '2026-03-01', valueCents: 48_000_00, source: 'manual', notes: 'appraisal' },
+        ]); // most recent prior snapshot
+
+      const result = await service.getSnapshotForMonth('asset-1', 'user-1', '2026-06-01');
+      expect(result).toEqual({
+        snapshotMonth: '2026-06-01',
+        valueCents: 48_000_00,
+        source: 'manual',
+        notes: 'appraisal',
+        asOfMonth: '2026-03-01',
+        isCarriedForward: true,
+      });
+    });
+
+    it('returns null when there is no snapshot for the month or any prior month', async () => {
+      mockDb.limit
+        .mockResolvedValueOnce([asset]) // requireOwned
+        .mockResolvedValueOnce([]) // no exact match
+        .mockResolvedValueOnce([]); // no prior snapshot either
+
+      const result = await service.getSnapshotForMonth('asset-1', 'user-1', '2026-06-01');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('upsertSnapshot', () => {
+    it('upserts keyed on (asset, month)', async () => {
+      mockDb.limit.mockResolvedValueOnce([asset]);
+      mockDb.returning.mockResolvedValueOnce([
+        { manualAssetId: 'asset-1', snapshotMonth: '2026-06-01', valueCents: 51_000_00 },
+      ]);
+
+      const result = await service.upsertSnapshot('asset-1', 'user-1', '2026-06-01', {
+        valueCents: 51_000_00,
+        source: 'manual',
+      });
+
+      expect(mockDb.onConflictDoUpdate).toHaveBeenCalled();
+      expect(result.valueCents).toBe(51_000_00);
+    });
+  });
+});

--- a/apps/api/src/monthly-close/manual-assets.controller.ts
+++ b/apps/api/src/monthly-close/manual-assets.controller.ts
@@ -1,0 +1,74 @@
+import { Controller, Get, Post, Patch, Delete, Put, Param, Body, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { ManualAssetsService } from './manual-assets.service';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
+import {
+  createManualAssetSchema,
+  updateManualAssetSchema,
+  putManualAssetSnapshotSchema,
+} from '@moneypulse/shared';
+import type {
+  AuthTokenPayload,
+  CreateManualAssetInput,
+  UpdateManualAssetInput,
+  PutManualAssetSnapshotInput,
+} from '@moneypulse/shared';
+
+@ApiTags('Manual Assets')
+@Controller('manual-assets')
+@UseGuards(JwtAuthGuard)
+export class ManualAssetsController {
+  constructor(private readonly manualAssetsService: ManualAssetsService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List manual assets (home/car/gold/other) for the current user' })
+  async findAll(@CurrentUser() user: AuthTokenPayload) {
+    return { data: await this.manualAssetsService.findAll(user.sub) };
+  }
+
+  @Post()
+  @ApiOperation({ summary: 'Create a manual asset' })
+  async create(
+    @CurrentUser() user: AuthTokenPayload,
+    @Body(new ZodValidationPipe(createManualAssetSchema)) body: CreateManualAssetInput,
+  ) {
+    return { data: await this.manualAssetsService.create(user.sub, body) };
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update a manual asset' })
+  async update(
+    @Param('id') id: string,
+    @CurrentUser() user: AuthTokenPayload,
+    @Body(new ZodValidationPipe(updateManualAssetSchema)) body: UpdateManualAssetInput,
+  ) {
+    return { data: await this.manualAssetsService.update(id, user.sub, body) };
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete (soft) a manual asset' })
+  async remove(@Param('id') id: string, @CurrentUser() user: AuthTokenPayload) {
+    return { data: await this.manualAssetsService.remove(id, user.sub) };
+  }
+
+  @Get(':id/snapshots')
+  @ApiOperation({ summary: 'List all explicit monthly value snapshots for a manual asset' })
+  async listSnapshots(@Param('id') id: string, @CurrentUser() user: AuthTokenPayload) {
+    return { data: await this.manualAssetsService.listSnapshots(id, user.sub) };
+  }
+
+  @Put(':id/snapshots/:month')
+  @ApiOperation({
+    summary: 'Upsert the value for one month (carry-forward applies when reading gaps)',
+  })
+  async upsertSnapshot(
+    @Param('id') id: string,
+    @Param('month') month: string,
+    @CurrentUser() user: AuthTokenPayload,
+    @Body(new ZodValidationPipe(putManualAssetSnapshotSchema)) body: PutManualAssetSnapshotInput,
+  ) {
+    return { data: await this.manualAssetsService.upsertSnapshot(id, user.sub, month, body) };
+  }
+}

--- a/apps/api/src/monthly-close/manual-assets.module.ts
+++ b/apps/api/src/monthly-close/manual-assets.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ManualAssetsService } from './manual-assets.service';
+import { ManualAssetsController } from './manual-assets.controller';
+
+@Module({
+  providers: [ManualAssetsService],
+  controllers: [ManualAssetsController],
+  exports: [ManualAssetsService],
+})
+export class ManualAssetsModule {}

--- a/apps/api/src/monthly-close/manual-assets.service.ts
+++ b/apps/api/src/monthly-close/manual-assets.service.ts
@@ -1,0 +1,191 @@
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { and, asc, desc, eq, isNull, lte } from 'drizzle-orm';
+import { DATABASE_CONNECTION } from '../db/db.module';
+import * as schema from '../db/schema';
+import type {
+  CreateManualAssetInput,
+  UpdateManualAssetInput,
+  PutManualAssetSnapshotInput,
+} from '@moneypulse/shared';
+import type { ManualAssetLiquidityClass, ManualAssetType } from '@moneypulse/shared';
+
+/** Default classification per the Phase 13 spec — home/car/gold/other. Manual assets
+ *  always count toward net worth but are never treated as liquid (epic #158 decision #7). */
+const DEFAULT_CLASSIFICATION: Record<
+  ManualAssetType,
+  { liquidityClass: ManualAssetLiquidityClass; isDepreciating: boolean }
+> = {
+  home: { liquidityClass: 'illiquid', isDepreciating: false },
+  car: { liquidityClass: 'illiquid', isDepreciating: true },
+  gold: { liquidityClass: 'semi_liquid', isDepreciating: false },
+  other: { liquidityClass: 'illiquid', isDepreciating: false },
+};
+
+export interface ManualAssetSnapshotView {
+  snapshotMonth: string; // the requested month, YYYY-MM-01
+  valueCents: number;
+  source: string;
+  notes: string | null;
+  /** The month the returned value actually came from — differs from `snapshotMonth`
+   *  when this is a carried-forward value (epic #158 decision #3). */
+  asOfMonth: string;
+  isCarriedForward: boolean;
+}
+
+/** CRUD + monthly snapshots for manual (non-account) net-worth assets: home, car, gold,
+ *  other. User-scoped only — no household plumbing (epic #158 decision #5). */
+@Injectable()
+export class ManualAssetsService {
+  constructor(@Inject(DATABASE_CONNECTION) private readonly db: any) {}
+
+  async findAll(userId: string) {
+    return this.db
+      .select()
+      .from(schema.manualAssets)
+      .where(and(eq(schema.manualAssets.userId, userId), isNull(schema.manualAssets.deletedAt)))
+      .orderBy(asc(schema.manualAssets.name));
+  }
+
+  async create(userId: string, input: CreateManualAssetInput) {
+    const defaults = DEFAULT_CLASSIFICATION[input.assetType];
+    const rows = await this.db
+      .insert(schema.manualAssets)
+      .values({
+        userId,
+        name: input.name,
+        assetType: input.assetType,
+        liquidityClass: input.liquidityClass ?? defaults.liquidityClass,
+        isDepreciating: input.isDepreciating ?? defaults.isDepreciating,
+        notes: input.notes ?? null,
+      })
+      .returning();
+    return rows[0];
+  }
+
+  private async requireOwned(id: string, userId: string) {
+    const existing = await this.db
+      .select()
+      .from(schema.manualAssets)
+      .where(and(eq(schema.manualAssets.id, id), eq(schema.manualAssets.userId, userId)))
+      .limit(1);
+    if (!existing[0] || existing[0].deletedAt) {
+      throw new NotFoundException('Manual asset not found');
+    }
+    return existing[0];
+  }
+
+  async update(id: string, userId: string, input: UpdateManualAssetInput) {
+    await this.requireOwned(id, userId);
+    const rows = await this.db
+      .update(schema.manualAssets)
+      .set({ ...input, updatedAt: new Date() })
+      .where(eq(schema.manualAssets.id, id))
+      .returning();
+    return rows[0];
+  }
+
+  async remove(id: string, userId: string) {
+    await this.requireOwned(id, userId);
+    await this.db
+      .update(schema.manualAssets)
+      .set({ deletedAt: new Date() })
+      .where(eq(schema.manualAssets.id, id));
+    return { deleted: true };
+  }
+
+  /**
+   * All explicit snapshots for an asset, most recent month first. Ownership-checked —
+   * throws if the asset doesn't belong to `userId` (or is soft-deleted).
+   */
+  async listSnapshots(assetId: string, userId: string) {
+    await this.requireOwned(assetId, userId);
+    return this.db
+      .select()
+      .from(schema.manualAssetSnapshots)
+      .where(eq(schema.manualAssetSnapshots.manualAssetId, assetId))
+      .orderBy(desc(schema.manualAssetSnapshots.snapshotMonth));
+  }
+
+  /**
+   * The value for `month`, with carry-forward: if there's no explicit snapshot for that
+   * month, returns the most recent prior snapshot (any earlier month), tagged with its
+   * actual "as of" month so the caller can badge staleness. Returns null only when there
+   * is no snapshot for `month` or any earlier month.
+   */
+  async getSnapshotForMonth(
+    assetId: string,
+    userId: string,
+    month: string,
+  ): Promise<ManualAssetSnapshotView | null> {
+    await this.requireOwned(assetId, userId);
+
+    const exact = await this.db
+      .select()
+      .from(schema.manualAssetSnapshots)
+      .where(
+        and(
+          eq(schema.manualAssetSnapshots.manualAssetId, assetId),
+          eq(schema.manualAssetSnapshots.snapshotMonth, month),
+        ),
+      )
+      .limit(1);
+    if (exact[0]) {
+      return {
+        snapshotMonth: month,
+        valueCents: exact[0].valueCents,
+        source: exact[0].source,
+        notes: exact[0].notes,
+        asOfMonth: month,
+        isCarriedForward: false,
+      };
+    }
+
+    const prior = await this.db
+      .select()
+      .from(schema.manualAssetSnapshots)
+      .where(
+        and(
+          eq(schema.manualAssetSnapshots.manualAssetId, assetId),
+          lte(schema.manualAssetSnapshots.snapshotMonth, month),
+        ),
+      )
+      .orderBy(desc(schema.manualAssetSnapshots.snapshotMonth))
+      .limit(1);
+    if (!prior[0]) return null;
+
+    return {
+      snapshotMonth: month,
+      valueCents: prior[0].valueCents,
+      source: prior[0].source,
+      notes: prior[0].notes,
+      asOfMonth: prior[0].snapshotMonth,
+      isCarriedForward: true,
+    };
+  }
+
+  /** Upsert the value for one month, keyed on (asset, month) per the unique index. */
+  async upsertSnapshot(assetId: string, userId: string, month: string, input: PutManualAssetSnapshotInput) {
+    await this.requireOwned(assetId, userId);
+
+    const rows = await this.db
+      .insert(schema.manualAssetSnapshots)
+      .values({
+        manualAssetId: assetId,
+        snapshotMonth: month,
+        valueCents: input.valueCents,
+        source: input.source,
+        notes: input.notes ?? null,
+      })
+      .onConflictDoUpdate({
+        target: [schema.manualAssetSnapshots.manualAssetId, schema.manualAssetSnapshots.snapshotMonth],
+        set: {
+          valueCents: input.valueCents,
+          source: input.source,
+          notes: input.notes ?? null,
+          updatedAt: new Date(),
+        },
+      })
+      .returning();
+    return rows[0];
+  }
+}

--- a/packages/shared/src/validation/index.ts
+++ b/packages/shared/src/validation/index.ts
@@ -480,11 +480,15 @@ export type UpdatePaycheckProfileInput = z.infer<typeof updatePaycheckProfileSch
 // ── Monthly Close: Manual Assets, Loan Balance Snapshots, Monthly Financial
 // Snapshots (13.1) ────────────────────────────────────────────
 
+// If omitted, the service fills liquidityClass/isDepreciating in from the asset-type
+// defaults in the spec (home=illiquid/not-depreciating, car=illiquid/depreciating,
+// gold=semi_liquid/not-depreciating, other=illiquid/not-depreciating) — callers may
+// still override either field explicitly.
 export const createManualAssetSchema = z.object({
   name: z.string().min(1).max(120),
   assetType: z.enum(['home', 'car', 'gold', 'other']),
-  liquidityClass: z.enum(['liquid', 'semi_liquid', 'illiquid']),
-  isDepreciating: z.boolean().default(false),
+  liquidityClass: z.enum(['liquid', 'semi_liquid', 'illiquid']).optional(),
+  isDepreciating: z.boolean().optional(),
   notes: z.string().max(2000).nullable().optional(),
 });
 


### PR DESCRIPTION
Committed successfully.

## Summary

Implemented issue #162 (13.4): CRUD + snapshot APIs for manual assets and loan balance snapshots, building on the schema/types/validation already landed in 13.1.

**Manual assets** (`apps/api/src/monthly-close/manual-assets.{controller,service,module}.ts`):
- Full user-scoped CRUD (list/create/update/soft-delete) plus `GET .../:id/snapshots` and `PUT .../:id/snapshots/:month`.
- Server-side default classification (home/car/gold/other → liquidity class + depreciating flag per the spec table), applied only when the caller doesn't supply an explicit override.
- Carry-forward read semantics: a month lookup with no explicit snapshot returns the most recent earlier snapshot, tagged with its own "as of" month so callers can flag staleness.
- Relaxed `createManualAssetSchema` (liquidityClass/isDepreciating now optional) so the service can fill in defaults rather than requiring the caller to always pass them.

**Loan balance snapshots** (extended `apps/api/src/loans/`):
- `GET /loans/:id/balance-snapshots` and `PUT /loans/:id/balance-snapshots/:month`.
- Resolution logic: a `manual_statement` row for the requested month wins; otherwise falls back to an amortized estimate computed via the shared `computeLoanState`, replaying any extra-principal transactions matched by the loan's pattern. The resolved source is always reported back.

Both slices enforce ownership (`NotFoundException` on cross-user access or soft-deleted rows) via the same pattern already used by `LoansService`.

**Tests**: added `manual-assets.service.spec.ts` (classification defaults per asset type, override behavior, ownership errors, carry-forward exact/gap/no-data cases, upsert) and `loan-balance-snapshots.service.spec.ts` (manual-statement precedence, amortized fallback, ownership check, upsert always writing `manual_statement`). Full API test suite (781 tests), lint, and `nest build` all pass; verified the app boots with the new module wired in.

---
### Test evidence
**12 new test case(s) added** (heuristic count):
```
 .../loan-balance-snapshots.service.spec.ts         | 115 +++++++++++++
 .../__tests__/manual-assets.service.spec.ts        | 147 ++++++++++++++++
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
_/learning.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test: [33m[Nest] 80398  - [39m07/27/2026, 2:32:43 PM [33m   WARN[39m [38;5;3m[IngestionProcessor] [39m[33mSkipping outbox enqueue for transaction id-1: ALIAS_SECRET must be set for sync alias mapping[39m
@moneypulse/api:test: [33m[Nest] 80398  - [39m07/27/2026, 2:32:43 PM [33m   WARN[39m [38;5;3m[IngestionProcessor] [39m[33mSkipping outbox enqueue for transaction id-1: alias error on first call[39m
@moneypulse/api:test: [33m[Nest] 80398  - [39m07/27/2026, 2:32:43 PM [33m   WARN[39m [38;5;3m[IngestionProcessor] [39m[33mSkipping outbox enqueue for transaction id-1: DB connection lost[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/ingestion.processor.sync.spec.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 5[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/next-loan-due-date.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m93 passed[39m[22m[90m (93)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m781 passed[39m[22m[90m (781)[39m
@moneypulse/api:test: [2m   Start at [22m 14:32:33
@moneypulse/api:test: [2m   Duration [22m 9.54s[2m (transform 2.91s, setup 0ms, import 49.89s, tests 1.88s, environment 6ms)[22m
@moneypulse/api:test: 

 Tasks:    2 successful, 2 total
Cached:    0 cached, 2 total
  Time:    10.643s
```
</details>

### Review
**Review verdict:** approve

Findings (advisory — did not block landing):
- [low/advisory] apps/api/src/monthly-close/manual-assets.controller.ts:68 — The :month path param is unvalidated and flows directly into date-typed DB queries/inserts; a malformed value (e.g. 'june') produces a 500 instead of a 400. Adding a YYYY-MM-01 format check on the param would harden the boundary. Same applies to loans.controller.ts upsertBalanceSnapshot.

---
Dispatched via coxd (`MyMoney-13-4-manual-assets-loan-bala-1785162395`) · cost $2.116 · 🤖 coxd