### PR TITLE
13.5 Monthly-close API + auto-draft cron + freshness nudge

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -30,6 +30,7 @@ import { MarketDataModule } from './market-data/market-data.module';
 import { RateWatchlistModule } from './rate-watchlist/rate-watchlist.module';
 import { SuitabilitySettingsModule } from './suitability-settings/suitability-settings.module';
 import { ManualAssetsModule } from './monthly-close/manual-assets.module';
+import { MonthlyCloseModule } from './monthly-close/monthly-close.module';
 
 @Module({
   imports: [
@@ -81,6 +82,7 @@ import { ManualAssetsModule } from './monthly-close/manual-assets.module';
     RateWatchlistModule,
     SuitabilitySettingsModule,
     ManualAssetsModule,
+    MonthlyCloseModule,
     HealthModule,
   ],
   providers: [

--- a/apps/api/src/jobs/__tests__/monthly-close-cron.spec.ts
+++ b/apps/api/src/jobs/__tests__/monthly-close-cron.spec.ts
@@ -1,0 +1,25 @@
+import { AlertCronProcessor } from '../alert-cron.processor';
+
+/** 13.5 decision #8 explicitly calls out that a prior phase's cron job was
+ *  registered but never actually invoked its service — this test guards against
+ *  that regression by asserting the 'monthly-close-auto-draft' job name really
+ *  dispatches to MonthlyCloseService.runAutoDraftForAllUsers, not just that the
+ *  scheduler upsert exists. */
+describe('AlertCronProcessor — monthly-close-auto-draft', () => {
+  it('invokes MonthlyCloseService.runAutoDraftForAllUsers', async () => {
+    const monthlyCloseService = {
+      runAutoDraftForAllUsers: vi.fn().mockResolvedValue({ usersProcessed: 3, closesCreated: 2 }),
+    };
+    const noop = {} as any;
+    const processor = new AlertCronProcessor(
+      noop, noop, noop, noop, noop, noop, noop, noop, noop, noop,
+      noop, noop, noop, noop, noop, noop, noop, noop,
+      monthlyCloseService as any,
+      { add: vi.fn() } as any,
+    );
+
+    await processor.process({ name: 'monthly-close-auto-draft', data: {} } as any);
+
+    expect(monthlyCloseService.runAutoDraftForAllUsers).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/jobs/alert-cron.processor.ts
+++ b/apps/api/src/jobs/alert-cron.processor.ts
@@ -19,6 +19,7 @@ import { CashManagerService } from '../recommendations/cash-manager.service';
 import { InvestmentCoachService } from '../recommendations/investment-coach.service';
 import { SavingsCoachService } from '../recommendations/savings-coach.service';
 import { RateWatchlistService } from '../rate-watchlist/rate-watchlist.service';
+import { MonthlyCloseService } from '../monthly-close/monthly-close.service';
 
 const MARKET_DATA_JITTER_MAX_MS = 15 * 60_000; // spread load on the free EIA/FRED tiers
 
@@ -49,6 +50,7 @@ export class AlertCronProcessor extends WorkerHost {
     private readonly investmentCoachService: InvestmentCoachService,
     private readonly savingsCoachService: SavingsCoachService,
     private readonly rateWatchlistService: RateWatchlistService,
+    private readonly monthlyCloseService: MonthlyCloseService,
     @InjectQueue('alerts') private readonly alertsQueue: Queue,
   ) {
     super();
@@ -238,6 +240,16 @@ export class AlertCronProcessor extends WorkerHost {
       case 'savings-coach-check':
         await this.savingsCoachService.runForAllUsers();
         break;
+
+      // 13.5 Monthly Close auto-draft — creates/refreshes the previous month's draft
+      // for every active user, backfilling history on first run.
+      case 'monthly-close-auto-draft': {
+        const result = await this.monthlyCloseService.runAutoDraftForAllUsers();
+        this.logger.log(
+          `Monthly-close auto-draft: ${result.usersProcessed} user(s) processed, ${result.closesCreated} close(s) created`,
+        );
+        break;
+      }
 
       default:
         this.logger.warn(`Unknown alert job: ${job.name}`);

--- a/apps/api/src/jobs/jobs.module.ts
+++ b/apps/api/src/jobs/jobs.module.ts
@@ -13,6 +13,7 @@ import { LoansModule } from '../loans/loans.module';
 import { MarketDataModule } from '../market-data/market-data.module';
 import { RecommendationsModule } from '../recommendations/recommendations.module';
 import { RateWatchlistModule } from '../rate-watchlist/rate-watchlist.module';
+import { MonthlyCloseModule } from '../monthly-close/monthly-close.module';
 
 @Module({
   imports: [
@@ -28,6 +29,7 @@ import { RateWatchlistModule } from '../rate-watchlist/rate-watchlist.module';
     MarketDataModule,
     RecommendationsModule,
     RateWatchlistModule,
+    MonthlyCloseModule,
   ],
   providers: [AlertCronProcessor, ReminderProcessor, SyncDeliveryProcessor],
 })
@@ -232,6 +234,17 @@ export class JobsModule implements OnModuleInit {
         'monthly-savings-coach-check',
         { pattern: '30 11 2 * *' },
         { name: 'savings-coach-check' },
+      ),
+
+      // 13.5 Monthly Close auto-draft (decision #8) — 1st of month, 8:00 UTC (before
+      // the other 1st/2nd-of-month sweeps above so its own draft feeds them if they
+      // ever need it). Creates/refreshes the previous month's draft close for every
+      // active user, backfilling history on first run (decision #11) and rate-limited
+      // freshness-nudging per decision #3.
+      this.alertsQueue.upsertJobScheduler(
+        'monthly-close-auto-draft',
+        { pattern: '0 8 1 * *' },
+        { name: 'monthly-close-auto-draft' },
       ),
 
       // Frequent sync delivery sweep for outbox events.

--- a/apps/api/src/monthly-close/__tests__/monthly-close.service.spec.ts
+++ b/apps/api/src/monthly-close/__tests__/monthly-close.service.spec.ts
@@ -1,0 +1,151 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { MonthlyCloseService } from '../monthly-close.service';
+import { DATABASE_CONNECTION } from '../../db/db.module';
+import { ManualAssetsService } from '../manual-assets.service';
+import { InvestmentsService } from '../../investments/investments.service';
+import { LoansService } from '../../loans/loans.service';
+import { NotificationsService } from '../../notifications/notifications.service';
+
+/** A chainable query-builder stub: every fluent method returns itself, and it's
+ *  awaitable (via `.then`) resolving to `result` — matches how the service calls
+ *  Drizzle both with and without a trailing `.limit()`. */
+function makeChain(result: any[]) {
+  const chain: any = {};
+  chain.from = () => chain;
+  chain.where = () => chain;
+  chain.orderBy = () => chain;
+  chain.limit = () => Promise.resolve(result);
+  chain.then = (resolve: any) => resolve(result);
+  return chain;
+}
+
+describe('MonthlyCloseService', () => {
+  let service: MonthlyCloseService;
+  let mockDb: any;
+  let notificationsService: { createAndDispatch: any };
+
+  const draftRow = { id: 'snap-1', userId: 'user-1', snapshotMonth: '2026-06-01', status: 'draft' };
+
+  beforeEach(async () => {
+    mockDb = {
+      select: vi.fn(() => makeChain([])),
+      execute: vi.fn().mockResolvedValue({ rows: [] }),
+      insert: vi.fn().mockReturnThis(),
+      values: vi.fn().mockReturnThis(),
+      update: vi.fn().mockReturnThis(),
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      returning: vi.fn().mockResolvedValue([draftRow]),
+    };
+
+    notificationsService = { createAndDispatch: vi.fn().mockResolvedValue({}) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MonthlyCloseService,
+        { provide: DATABASE_CONNECTION, useValue: mockDb },
+        { provide: ManualAssetsService, useValue: { findAll: vi.fn().mockResolvedValue([]) } },
+        {
+          provide: InvestmentsService,
+          useValue: {
+            getPortfolioValue: vi.fn().mockResolvedValue({ totalCents: 0, holdings: [], staleFound: false, missingPriceFound: false }),
+          },
+        },
+        { provide: LoansService, useValue: { getBalanceForMonth: vi.fn() } },
+        { provide: NotificationsService, useValue: notificationsService },
+      ],
+    }).compile();
+
+    service = module.get<MonthlyCloseService>(MonthlyCloseService);
+  });
+
+  describe('gatherInputs + draft — end-to-end against an empty fixture', () => {
+    it('produces a calculable, all-zero close and persists it', async () => {
+      const input = await service.gatherInputs('user-1', '2026-06');
+      expect(input.month).toBe('2026-06-01');
+      expect(input.takeHomeIncomeCents).toBe(0);
+      expect(input.transactions).toEqual([]);
+      expect(input.freshness).toEqual({ missingManualAssets: [], staleAccounts: [], unverifiedLoans: [] });
+
+      const saved = await service.draft('user-1', '2026-06');
+      expect(saved).toEqual(draftRow);
+      // No existing row (select resolves []) -> insert path, not update.
+      expect(mockDb.insert).toHaveBeenCalledWith(expect.anything());
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('recalculate throws NotFoundException when no close exists yet', async () => {
+      await expect(service.recalculate('user-1', '2026-06')).rejects.toThrow(NotFoundException);
+    });
+
+    it('patch on a confirmed close stamps edited_at + is_edited', async () => {
+      mockDb.select = vi.fn(() => makeChain([{ ...draftRow, status: 'confirmed' }]));
+      await service.patch('user-1', '2026-06', { notes: 'Adjusted' });
+
+      const setArg = mockDb.set.mock.calls.at(-1)[0];
+      expect(setArg.isEdited).toBe(true);
+      expect(setArg.editedAt).toBeInstanceOf(Date);
+      expect(setArg.notes).toBe('Adjusted');
+    });
+
+    it('patch on a draft close does not stamp the audit fields', async () => {
+      mockDb.select = vi.fn(() => makeChain([{ ...draftRow, status: 'draft' }]));
+      await service.patch('user-1', '2026-06', { notes: 'wip' });
+
+      const setArg = mockDb.set.mock.calls.at(-1)[0];
+      expect(setArg.isEdited).toBeUndefined();
+      expect(setArg.editedAt).toBeUndefined();
+    });
+
+    it('confirm sets status=confirmed + confirmedAt', async () => {
+      mockDb.select = vi.fn(() => makeChain([draftRow]));
+      await service.confirm('user-1', '2026-06');
+      const setArg = mockDb.set.mock.calls.at(-1)[0];
+      expect(setArg.status).toBe('confirmed');
+      expect(setArg.confirmedAt).toBeInstanceOf(Date);
+    });
+
+    it('reopen sets status back to draft', async () => {
+      mockDb.select = vi.fn(() => makeChain([{ ...draftRow, status: 'confirmed' }]));
+      await service.reopen('user-1', '2026-06');
+      const setArg = mockDb.set.mock.calls.at(-1)[0];
+      expect(setArg.status).toBe('draft');
+    });
+
+    it('confirm on a missing close throws NotFoundException', async () => {
+      await expect(service.confirm('user-1', '2026-06')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('freshness nudge cap (decision #3)', () => {
+    it('skips the nudge when the close is complete', async () => {
+      mockDb.select = vi.fn(() => makeChain([{ ...draftRow, freshness: { isComplete: true } }]));
+      const sent = await (service as any).maybeNudgeFreshness('user-1', '2026-06-01');
+      expect(sent).toBe(false);
+      expect(notificationsService.createAndDispatch).not.toHaveBeenCalled();
+    });
+
+    it('sends a nudge when incomplete and no recent nudge exists', async () => {
+      mockDb.select = vi.fn(() =>
+        makeChain([{ ...draftRow, freshness: { isComplete: false, missingManualAssets: ['Home'], staleAccounts: [], unverifiedLoans: [] } }]),
+      );
+      mockDb.execute = vi.fn().mockResolvedValue({ rows: [{ last_at: null }] });
+      const sent = await (service as any).maybeNudgeFreshness('user-1', '2026-06-01');
+      expect(sent).toBe(true);
+      expect(notificationsService.createAndDispatch).toHaveBeenCalledTimes(1);
+    });
+
+    it('suppresses a second nudge within the 2-month cooldown', async () => {
+      mockDb.select = vi.fn(() =>
+        makeChain([{ ...draftRow, freshness: { isComplete: false, missingManualAssets: ['Home'], staleAccounts: [], unverifiedLoans: [] } }]),
+      );
+      const recentNudge = new Date(Date.now() - 20 * 24 * 3600_000).toISOString(); // 20 days ago
+      mockDb.execute = vi.fn().mockResolvedValue({ rows: [{ last_at: recentNudge }] });
+      const sent = await (service as any).maybeNudgeFreshness('user-1', '2026-06-01');
+      expect(sent).toBe(false);
+      expect(notificationsService.createAndDispatch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/monthly-close/__tests__/monthly-close.service.spec.ts
+++ b/apps/api/src/monthly-close/__tests__/monthly-close.service.spec.ts
@@ -119,6 +119,23 @@ describe('MonthlyCloseService', () => {
     });
   });
 
+  describe('auto-draft guards confirmed closes', () => {
+    it('does not overwrite a close that is already confirmed', async () => {
+      mockDb.select = vi.fn(() => makeChain([{ ...draftRow, status: 'confirmed' }]));
+      const drafted = await (service as any).draftUnlessConfirmed('user-1', '2026-06-01');
+      expect(drafted).toBe(false);
+      expect(mockDb.insert).not.toHaveBeenCalled();
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+
+    it('drafts a close that does not exist yet', async () => {
+      mockDb.select = vi.fn(() => makeChain([]));
+      const drafted = await (service as any).draftUnlessConfirmed('user-1', '2026-06-01');
+      expect(drafted).toBe(true);
+      expect(mockDb.insert).toHaveBeenCalled();
+    });
+  });
+
   describe('freshness nudge cap (decision #3)', () => {
     it('skips the nudge when the close is complete', async () => {
       mockDb.select = vi.fn(() => makeChain([{ ...draftRow, freshness: { isComplete: true } }]));

--- a/apps/api/src/monthly-close/monthly-close.controller.ts
+++ b/apps/api/src/monthly-close/monthly-close.controller.ts
@@ -1,0 +1,62 @@
+import { Controller, Get, Post, Patch, Param, Body, Query, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { MonthlyCloseService } from './monthly-close.service';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
+import { patchMonthlyCloseSchema } from '@moneypulse/shared';
+import type { AuthTokenPayload, PatchMonthlyCloseInput } from '@moneypulse/shared';
+
+@ApiTags('Monthly Close')
+@Controller('monthly-close')
+@UseGuards(JwtAuthGuard)
+export class MonthlyCloseController {
+  constructor(private readonly monthlyCloseService: MonthlyCloseService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List recent monthly closes (6–12 month grid)' })
+  async findAll(@CurrentUser() user: AuthTokenPayload, @Query('months') months?: string) {
+    const parsed = months ? parseInt(months, 10) : 12;
+    return { data: await this.monthlyCloseService.findAll(user.sub, Number.isFinite(parsed) ? parsed : 12) };
+  }
+
+  @Get(':month')
+  @ApiOperation({ summary: 'Get one month\'s close' })
+  async findOne(@Param('month') month: string, @CurrentUser() user: AuthTokenPayload) {
+    return { data: await this.monthlyCloseService.findOne(user.sub, month) };
+  }
+
+  @Post(':month/draft')
+  @ApiOperation({ summary: 'Compute and persist a draft close for the month' })
+  async draft(@Param('month') month: string, @CurrentUser() user: AuthTokenPayload) {
+    return { data: await this.monthlyCloseService.draft(user.sub, month) };
+  }
+
+  @Post(':month/recalculate')
+  @ApiOperation({ summary: 'Recompute an existing close against current data' })
+  async recalculate(@Param('month') month: string, @CurrentUser() user: AuthTokenPayload) {
+    return { data: await this.monthlyCloseService.recalculate(user.sub, month) };
+  }
+
+  @Patch(':month')
+  @ApiOperation({ summary: 'Edit notes/fixed-expense/variable-expense on a close' })
+  async patch(
+    @Param('month') month: string,
+    @CurrentUser() user: AuthTokenPayload,
+    @Body(new ZodValidationPipe(patchMonthlyCloseSchema)) body: PatchMonthlyCloseInput,
+  ) {
+    return { data: await this.monthlyCloseService.patch(user.sub, month, body) };
+  }
+
+  @Post(':month/confirm')
+  @ApiOperation({ summary: 'Confirm the close for the month' })
+  async confirm(@Param('month') month: string, @CurrentUser() user: AuthTokenPayload) {
+    return { data: await this.monthlyCloseService.confirm(user.sub, month) };
+  }
+
+  @Post(':month/reopen')
+  @ApiOperation({ summary: 'Reopen a confirmed close back to draft' })
+  async reopen(@Param('month') month: string, @CurrentUser() user: AuthTokenPayload) {
+    return { data: await this.monthlyCloseService.reopen(user.sub, month) };
+  }
+}

--- a/apps/api/src/monthly-close/monthly-close.module.ts
+++ b/apps/api/src/monthly-close/monthly-close.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { MonthlyCloseService } from './monthly-close.service';
+import { MonthlyCloseController } from './monthly-close.controller';
+import { ManualAssetsModule } from './manual-assets.module';
+import { InvestmentsModule } from '../investments/investments.module';
+import { LoansModule } from '../loans/loans.module';
+import { NotificationsModule } from '../notifications/notifications.module';
+
+@Module({
+  imports: [ManualAssetsModule, InvestmentsModule, LoansModule, NotificationsModule],
+  providers: [MonthlyCloseService],
+  controllers: [MonthlyCloseController],
+  exports: [MonthlyCloseService],
+})
+export class MonthlyCloseModule {}

--- a/apps/api/src/monthly-close/monthly-close.service.ts
+++ b/apps/api/src/monthly-close/monthly-close.service.ts
@@ -1,0 +1,620 @@
+import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { and, desc, eq, gte, isNull, lt, lte, sql } from 'drizzle-orm';
+import { DATABASE_CONNECTION } from '../db/db.module';
+import * as schema from '../db/schema';
+import {
+  calculateMonthlyClose,
+  MonthlyCloseCalculatorInput,
+  MonthlyCloseTransactionLine,
+} from './monthly-close-calculator';
+import { ManualAssetsService } from './manual-assets.service';
+import { InvestmentsService } from '../investments/investments.service';
+import { LoansService } from '../loans/loans.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import type { PatchMonthlyCloseInput } from '@moneypulse/shared';
+
+const PAY_PERIODS_PER_YEAR: Record<string, number> = {
+  weekly: 52,
+  biweekly: 26,
+  semi_monthly: 24,
+  monthly: 12,
+};
+
+/** Nudge rate-limit (epic #158 decision #3): at most one freshness nudge per user
+ *  every 2 calendar months. */
+export const FRESHNESS_NUDGE_COOLDOWN_MONTHS = 2;
+const FRESHNESS_NUDGE_NOTIFICATION_TYPE = 'monthly_close_freshness_nudge';
+
+/** How many months of history to attempt to backfill on first run (decision #11).
+ *  Bounded so a very old account doesn't trigger an unbounded loop of empty closes. */
+const MAX_BACKFILL_MONTHS = 24;
+
+function toMonthStart(month: string): string {
+  // Accept either 'YYYY-MM' or 'YYYY-MM-01' and normalize to the first-of-month date
+  // the schema/unique index expects.
+  const [y, m] = month.split('-');
+  return `${y}-${m}-01`;
+}
+
+function addMonths(month: string, delta: number): string {
+  const [y, m] = toMonthStart(month).split('-').map(Number);
+  const d = new Date(Date.UTC(y, m - 1 + delta, 1));
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-01`;
+}
+
+function endOfMonth(month: string): string {
+  const [y, m] = toMonthStart(month).split('-').map(Number);
+  // Day 0 of next month == last day of this month.
+  const last = new Date(Date.UTC(y, m, 0));
+  return last.toISOString().slice(0, 10);
+}
+
+function monthDiff(a: string, b: string): number {
+  const [ay, am] = toMonthStart(a).split('-').map(Number);
+  const [by, bm] = toMonthStart(b).split('-').map(Number);
+  return (ay - by) * 12 + (am - bm);
+}
+
+export interface DraftResult {
+  snapshot: any;
+  freshnessNudgeSent: boolean;
+}
+
+/**
+ * 13.5 — wires the 13.2 pure calculator to real data and owns the monthly-close
+ * lifecycle (draft/recalculate/confirm/reopen/edit/list). User-scoped only, no
+ * household plumbing (epic #158 decision #5).
+ */
+@Injectable()
+export class MonthlyCloseService {
+  private readonly logger = new Logger(MonthlyCloseService.name);
+
+  constructor(
+    @Inject(DATABASE_CONNECTION) private readonly db: any,
+    private readonly manualAssetsService: ManualAssetsService,
+    private readonly investmentsService: InvestmentsService,
+    private readonly loansService: LoansService,
+    private readonly notificationsService: NotificationsService,
+  ) {}
+
+  // ── Reads ──────────────────────────────────────────────────
+
+  async findAll(userId: string, months: number) {
+    const rows = await this.db
+      .select()
+      .from(schema.monthlyFinancialSnapshots)
+      .where(eq(schema.monthlyFinancialSnapshots.userId, userId))
+      .orderBy(desc(schema.monthlyFinancialSnapshots.snapshotMonth))
+      .limit(Math.max(1, Math.min(months, 60)));
+    return rows;
+  }
+
+  async findOne(userId: string, month: string) {
+    const snapshotMonth = toMonthStart(month);
+    const rows = await this.db
+      .select()
+      .from(schema.monthlyFinancialSnapshots)
+      .where(
+        and(
+          eq(schema.monthlyFinancialSnapshots.userId, userId),
+          eq(schema.monthlyFinancialSnapshots.snapshotMonth, snapshotMonth),
+        ),
+      )
+      .limit(1);
+    if (!rows[0]) throw new NotFoundException('Monthly close not found');
+    return rows[0];
+  }
+
+  private async findRow(userId: string, snapshotMonth: string) {
+    const rows = await this.db
+      .select()
+      .from(schema.monthlyFinancialSnapshots)
+      .where(
+        and(
+          eq(schema.monthlyFinancialSnapshots.userId, userId),
+          eq(schema.monthlyFinancialSnapshots.snapshotMonth, snapshotMonth),
+        ),
+      )
+      .limit(1);
+    return rows[0] ?? null;
+  }
+
+  // ── Input gathering ────────────────────────────────────────
+
+  /**
+   * Assembles one month's calculator input from real data: paycheck-profile net
+   * (decision #1), month transactions (joined to category bucket/isTransfer, and
+   * flagged for debt-principal exclusion via each active loan's lender/extra-principal
+   * merchant patterns), month-end account balances, holdings-else-snapshot investment
+   * pricing (decision #2), manual-asset carry-forward (decision #3), and
+   * statement-wins loan balances.
+   */
+  async gatherInputs(userId: string, month: string): Promise<MonthlyCloseCalculatorInput> {
+    const snapshotMonth = toMonthStart(month);
+    const firstDay = snapshotMonth;
+    const lastDay = endOfMonth(snapshotMonth);
+    const nextMonthFirstDay = addMonths(snapshotMonth, 1);
+    const prevMonth = addMonths(snapshotMonth, -1);
+
+    // ── Paycheck profile: most recent effective as of month-end, monthly-scaled. ──
+    const profileRows = await this.db
+      .select()
+      .from(schema.paycheckProfiles)
+      .where(
+        and(
+          eq(schema.paycheckProfiles.userId, userId),
+          isNull(schema.paycheckProfiles.deletedAt),
+          lte(schema.paycheckProfiles.effectiveDate, lastDay),
+        ),
+      )
+      .orderBy(desc(schema.paycheckProfiles.effectiveDate))
+      .limit(1);
+    const profile = profileRows[0];
+    const payPeriodsPerYear = profile ? (PAY_PERIODS_PER_YEAR[profile.payFrequency] ?? 12) : 12;
+    const scale = payPeriodsPerYear / 12;
+    const monthlyGrossCents = profile ? Math.round(profile.grossPayCents * scale) : 0;
+    const monthlyDeductionsCents = profile
+      ? Math.round(
+          (profile.federalTaxCents +
+            profile.stateTaxCents +
+            profile.socialSecurityCents +
+            profile.medicareCents +
+            profile.pretax401kCents +
+            profile.hsaCents +
+            profile.medicalPremiumCents +
+            profile.dentalPremiumCents +
+            profile.visionPremiumCents +
+            profile.commuterCents +
+            profile.parkingCents +
+            profile.otherPretaxCents +
+            profile.supplementalLifeCents +
+            profile.legalCents +
+            profile.accidentInsuranceCents +
+            profile.otherPosttaxCents +
+            profile.esppContributionCents) *
+            scale,
+        )
+      : 0;
+    const takeHomeIncomeCents = profile ? Math.max(0, monthlyGrossCents - monthlyDeductionsCents) : 0;
+    const monthly401kHsaCents = profile
+      ? Math.round((profile.pretax401kCents + profile.hsaCents) * scale)
+      : 0;
+
+    // ── Active loans: statement-wins balance + lender/extra-principal patterns for
+    // classifying transaction lines as debt-principal (excluded from expenses). ──
+    const loanRows = await this.db
+      .select()
+      .from(schema.loans)
+      .where(and(eq(schema.loans.userId, userId), isNull(schema.loans.deletedAt), eq(schema.loans.isActive, true)));
+
+    const debtPatterns: string[] = [];
+    let loanLiabilityCents = 0;
+    let requiredMonthlyDebtPaymentCents = 0;
+    let debtPrincipalPaidCents = 0;
+    const unverifiedLoans: string[] = [];
+    for (const loan of loanRows) {
+      debtPatterns.push(loan.lenderPattern.toLowerCase());
+      if (loan.extraPrincipalPattern) debtPatterns.push(loan.extraPrincipalPattern.toLowerCase());
+      requiredMonthlyDebtPaymentCents += loan.scheduledPaymentCents;
+
+      const current = await this.loansService.getBalanceForMonth(loan.id, userId, snapshotMonth);
+      const prior = await this.loansService.getBalanceForMonth(loan.id, userId, prevMonth);
+      loanLiabilityCents += current.balanceCents;
+      debtPrincipalPaidCents += Math.max(0, prior.balanceCents - current.balanceCents);
+      if (current.source === 'amortized') unverifiedLoans.push(loan.name);
+    }
+    const extraDebtPrincipalPaidCents = Math.max(
+      0,
+      debtPrincipalPaidCents - requiredMonthlyDebtPaymentCents,
+    );
+
+    // ── Month transactions, joined to category bucket/isTransfer. ──
+    const txnResult = await this.db.execute(sql`
+      SELECT
+        t.id, t.amount_cents, t.is_credit, t.is_split_parent, t.deleted_at,
+        t.merchant_name, t.normalized_merchant_name, t.description,
+        c.is_transfer AS category_is_transfer, c.bucket AS category_bucket
+      FROM ${schema.transactions} t
+      LEFT JOIN ${schema.categories} c ON t.category_id = c.id
+      WHERE t.user_id = ${userId}
+        AND t.date >= ${firstDay}
+        AND t.date <= ${lastDay}
+    `);
+    const txnRows = (txnResult.rows ?? txnResult) as any[];
+
+    const transactions: MonthlyCloseTransactionLine[] = txnRows.map((r) => {
+      const haystack = `${r.merchant_name ?? ''} ${r.normalized_merchant_name ?? ''} ${r.description ?? ''}`.toLowerCase();
+      const isDebtPrincipalTransfer =
+        !r.is_credit && debtPatterns.some((p) => p && haystack.includes(p));
+      return {
+        id: r.id,
+        amountCents: Math.abs(Number(r.amount_cents)),
+        direction: r.is_credit ? 'credit' : 'debit',
+        isTransfer: !!r.category_is_transfer,
+        isSplitParent: !!r.is_split_parent,
+        isDeleted: !!r.deleted_at,
+        isDebtPrincipalTransfer,
+        categoryBucket: r.category_bucket ?? null,
+      };
+    });
+
+    // ── Investment-contribution transfers this month: transfer-flagged debits into
+    // an investment account, on top of the paycheck's own 401k/HSA deductions
+    // (decision #4). ──
+    const investmentTransferResult = await this.db.execute(sql`
+      SELECT COALESCE(SUM(t.amount_cents), 0) AS total_cents
+      FROM ${schema.transactions} t
+      JOIN ${schema.accounts} a ON a.id = t.account_id
+      LEFT JOIN ${schema.categories} c ON t.category_id = c.id
+      WHERE t.user_id = ${userId}
+        AND t.date >= ${firstDay} AND t.date <= ${lastDay}
+        AND t.deleted_at IS NULL
+        AND t.is_split_parent = false
+        AND t.is_credit = false
+        AND c.is_transfer = true
+        AND a.account_type IN ('brokerage', 'edu_529')
+    `);
+    const investmentTransferRows = (investmentTransferResult.rows ?? investmentTransferResult) as any[];
+    const investmentContributionCents =
+      monthly401kHsaCents + (Number(investmentTransferRows[0]?.total_cents) || 0);
+
+    // ── Month-end account balances (checking/savings/cash_sweep = liquid;
+    // brokerage/edu_529 = regular-account investment; credit_card = liability). ──
+    const accountRows = await this.db
+      .select({
+        id: schema.accounts.id,
+        accountType: schema.accounts.accountType,
+        startingBalanceCents: schema.accounts.startingBalanceCents,
+      })
+      .from(schema.accounts)
+      .where(and(eq(schema.accounts.userId, userId), isNull(schema.accounts.deletedAt)));
+
+    let liquidAssetCents = 0;
+    let regularInvestmentAssetCents = 0;
+    let creditCardLiabilityCents = 0;
+    const staleAccounts: string[] = [];
+    for (const acct of accountRows) {
+      const snapRows = await this.db
+        .select()
+        .from(schema.accountBalanceSnapshots)
+        .where(
+          and(
+            eq(schema.accountBalanceSnapshots.accountId, acct.id),
+            lte(schema.accountBalanceSnapshots.snapshotDate, lastDay),
+          ),
+        )
+        .orderBy(desc(schema.accountBalanceSnapshots.snapshotDate))
+        .limit(1);
+      const snap = snapRows[0];
+      const balanceCents = snap ? snap.balanceCents : acct.startingBalanceCents;
+      if (!snap || snap.snapshotDate < firstDay) staleAccounts.push(acct.id);
+
+      if (acct.accountType === 'checking' || acct.accountType === 'savings' || acct.accountType === 'cash_sweep') {
+        liquidAssetCents += balanceCents;
+      } else if (acct.accountType === 'brokerage' || acct.accountType === 'edu_529') {
+        regularInvestmentAssetCents += balanceCents;
+      } else if (acct.accountType === 'credit_card') {
+        creditCardLiabilityCents += Math.abs(balanceCents);
+      }
+    }
+
+    // ── Investments: holdings x latest EOD close when holdings exist, else the
+    // manual investment_snapshots value for the month — never both (decision #2). ──
+    const portfolio = await this.investmentsService.getPortfolioValue(userId);
+    let investmentAssetCents = regularInvestmentAssetCents;
+    if (portfolio.holdings.length > 0) {
+      investmentAssetCents += portfolio.totalCents;
+    } else {
+      const snapshotResult = await this.db.execute(sql`
+        SELECT COALESCE(SUM(s.balance_cents), 0) AS total_cents
+        FROM ${schema.investmentSnapshots} s
+        JOIN ${schema.investmentAccounts} ia ON ia.id = s.investment_account_id
+        WHERE ia.user_id = ${userId} AND ia.deleted_at IS NULL
+          AND s.date <= ${lastDay}
+          AND s.date = (
+            SELECT MAX(s2.date) FROM ${schema.investmentSnapshots} s2
+            WHERE s2.investment_account_id = s.investment_account_id AND s2.date <= ${lastDay}
+          )
+      `);
+      const snapshotRows = (snapshotResult.rows ?? snapshotResult) as any[];
+      investmentAssetCents += Number(snapshotRows[0]?.total_cents) || 0;
+    }
+
+    // ── Manual assets: carry-forward per-asset, summed (decision #3). ──
+    const manualAssets = await this.manualAssetsService.findAll(userId);
+    let manualAssetCents = 0;
+    const missingManualAssets: string[] = [];
+    for (const asset of manualAssets) {
+      const snap = await this.manualAssetsService.getSnapshotForMonth(asset.id, userId, snapshotMonth);
+      if (!snap) {
+        missingManualAssets.push(asset.name);
+        continue;
+      }
+      manualAssetCents += snap.valueCents;
+    }
+
+    // ── Cash savings: liquid-balance growth this month, floored at zero. ──
+    const priorLiquidResult = await this.gatherLiquidBalance(userId, prevMonth);
+    const cashSavingsCents = Math.max(0, liquidAssetCents - priorLiquidResult);
+
+    const cashSavingsAccounts = accountRows.filter(
+      (a: any) => a.accountType === 'checking' || a.accountType === 'savings',
+    );
+    const emergencyFundMonths =
+      cashSavingsAccounts.length > 0 && takeHomeIncomeCents > 0
+        ? Number((liquidAssetCents / takeHomeIncomeCents).toFixed(2))
+        : null;
+
+    return {
+      month: snapshotMonth,
+      takeHomeIncomeCents,
+      grossIncomeCents: profile ? monthlyGrossCents : null,
+      transactions,
+      cashSavingsCents,
+      investmentContributionCents,
+      debtPrincipalPaidCents,
+      extraDebtPrincipalPaidCents,
+      requiredMonthlyDebtPaymentCents,
+      liquidAssetCents,
+      investmentAssetCents,
+      manualAssetCents,
+      creditCardLiabilityCents,
+      loanLiabilityCents,
+      emergencyFundMonths,
+      hasHighInterestDebt: false,
+      employerMatch: { available: false, captured: null },
+      freshness: { missingManualAssets, staleAccounts, unverifiedLoans },
+    };
+  }
+
+  /** Liquid balance (checking/savings/cash_sweep) as of a given month's end — used
+   *  only to derive this month's savings delta, so it doesn't need the full
+   *  staleness bookkeeping `gatherInputs` does for the current month. */
+  private async gatherLiquidBalance(userId: string, month: string): Promise<number> {
+    const lastDay = endOfMonth(toMonthStart(month));
+    const accountRows = await this.db
+      .select({ id: schema.accounts.id, accountType: schema.accounts.accountType, startingBalanceCents: schema.accounts.startingBalanceCents })
+      .from(schema.accounts)
+      .where(
+        and(
+          eq(schema.accounts.userId, userId),
+          isNull(schema.accounts.deletedAt),
+          sql`${schema.accounts.accountType} IN ('checking', 'savings', 'cash_sweep')`,
+        ),
+      );
+    let total = 0;
+    for (const acct of accountRows) {
+      const snapRows = await this.db
+        .select()
+        .from(schema.accountBalanceSnapshots)
+        .where(
+          and(
+            eq(schema.accountBalanceSnapshots.accountId, acct.id),
+            lte(schema.accountBalanceSnapshots.snapshotDate, lastDay),
+          ),
+        )
+        .orderBy(desc(schema.accountBalanceSnapshots.snapshotDate))
+        .limit(1);
+      total += snapRows[0] ? snapRows[0].balanceCents : acct.startingBalanceCents;
+    }
+    return total;
+  }
+
+  // ── Lifecycle ──────────────────────────────────────────────
+
+  private toFreeze(result: ReturnType<typeof calculateMonthlyClose>) {
+    return {
+      takeHomeIncomeCents: result.takeHomeIncomeCents,
+      grossIncomeCents: result.grossIncomeCents,
+      expenseCents: result.expenseCents,
+      cashSavingsCents: result.cashSavingsCents,
+      investmentContributionCents: result.investmentContributionCents,
+      debtPrincipalPaidCents: result.debtPrincipalPaidCents,
+      extraDebtPrincipalPaidCents: result.extraDebtPrincipalPaidCents,
+      liquidAssetCents: result.liquidAssetCents,
+      investmentAssetCents: result.investmentAssetCents,
+      manualAssetCents: result.manualAssetCents,
+      totalAssetCents: result.totalAssetCents,
+      creditCardLiabilityCents: result.creditCardLiabilityCents,
+      loanLiabilityCents: result.loanLiabilityCents,
+      totalLiabilityCents: result.totalLiabilityCents,
+      netWorthCents: result.netWorthCents,
+      savingsRateBps: result.savingsRateBps,
+      investingRateBps: result.investingRateBps,
+      debtPaydownRateBps: result.debtPaydownRateBps,
+      wealthBuildingRateBps: result.wealthBuildingRateBps,
+      expenseRatioBps: result.expenseRatioBps,
+      liquidNetWorthRatioBps: result.liquidNetWorthRatioBps,
+      debtAssetRatioBps: result.debtAssetRatioBps,
+      debtPaymentIncomeRatioBps: result.debtPaymentIncomeRatioBps,
+      targetStatus: result.targetStatus,
+      freshness: result.freshness,
+      calculationVersion: result.calculationVersion,
+      updatedAt: new Date(),
+    };
+  }
+
+  /** Compute + persist a draft snapshot. Creates the row if missing; if it already
+   *  exists (draft OR confirmed), overwrites the frozen aggregates but preserves
+   *  status/notes/edit-audit fields — same computation path `recalculate` uses. */
+  async draft(userId: string, month: string) {
+    const snapshotMonth = toMonthStart(month);
+    const input = await this.gatherInputs(userId, snapshotMonth);
+    const result = calculateMonthlyClose(input);
+    const existing = await this.findRow(userId, snapshotMonth);
+
+    if (!existing) {
+      const rows = await this.db
+        .insert(schema.monthlyFinancialSnapshots)
+        .values({ userId, snapshotMonth, status: 'draft', ...this.toFreeze(result) })
+        .returning();
+      return rows[0];
+    }
+
+    const rows = await this.db
+      .update(schema.monthlyFinancialSnapshots)
+      .set(this.toFreeze(result))
+      .where(eq(schema.monthlyFinancialSnapshots.id, existing.id))
+      .returning();
+    return rows[0];
+  }
+
+  /** Recompute against current data. Identical mechanics to `draft` — kept as a
+   *  separate endpoint per the spec since callers use it to mean "re-run, I know
+   *  it already exists" (e.g. after entering a missing manual-asset value). */
+  async recalculate(userId: string, month: string) {
+    const snapshotMonth = toMonthStart(month);
+    const existing = await this.findRow(userId, snapshotMonth);
+    if (!existing) throw new NotFoundException('Monthly close not found');
+    return this.draft(userId, snapshotMonth);
+  }
+
+  async patch(userId: string, month: string, input: PatchMonthlyCloseInput) {
+    const snapshotMonth = toMonthStart(month);
+    const existing = await this.findRow(userId, snapshotMonth);
+    if (!existing) throw new NotFoundException('Monthly close not found');
+
+    const patch: Record<string, unknown> = { ...input, updatedAt: new Date() };
+    // Lightweight audit trail (decision #6): editing a confirmed close stamps
+    // edited_at + is_edited rather than mutating history silently.
+    if (existing.status === 'confirmed') {
+      patch.editedAt = new Date();
+      patch.isEdited = true;
+    }
+
+    const rows = await this.db
+      .update(schema.monthlyFinancialSnapshots)
+      .set(patch)
+      .where(eq(schema.monthlyFinancialSnapshots.id, existing.id))
+      .returning();
+    return rows[0];
+  }
+
+  async confirm(userId: string, month: string) {
+    const snapshotMonth = toMonthStart(month);
+    const existing = await this.findRow(userId, snapshotMonth);
+    if (!existing) throw new NotFoundException('Monthly close not found');
+    const rows = await this.db
+      .update(schema.monthlyFinancialSnapshots)
+      .set({ status: 'confirmed', confirmedAt: new Date(), updatedAt: new Date() })
+      .where(eq(schema.monthlyFinancialSnapshots.id, existing.id))
+      .returning();
+    return rows[0];
+  }
+
+  async reopen(userId: string, month: string) {
+    const snapshotMonth = toMonthStart(month);
+    const existing = await this.findRow(userId, snapshotMonth);
+    if (!existing) throw new NotFoundException('Monthly close not found');
+    const rows = await this.db
+      .update(schema.monthlyFinancialSnapshots)
+      .set({ status: 'draft', updatedAt: new Date() })
+      .where(eq(schema.monthlyFinancialSnapshots.id, existing.id))
+      .returning();
+    return rows[0];
+  }
+
+  // ── Cron (13.5 decision #8/#11) ────────────────────────────
+
+  private async activeUsers(): Promise<Array<{ id: string }>> {
+    return this.db.select({ id: schema.users.id }).from(schema.users).where(isNull(schema.users.deletedAt));
+  }
+
+  /** Earliest month this user has any transaction, or null if none. Bounds how far
+   *  back backfill reaches (decision #11 — "as many prior months as data allows"). */
+  private async earliestActivityMonth(userId: string): Promise<string | null> {
+    const result = await this.db.execute(sql`
+      SELECT MIN(date)::text AS min_date FROM ${schema.transactions} WHERE user_id = ${userId}
+    `);
+    const rows = (result.rows ?? result) as any[];
+    const minDate = rows[0]?.min_date;
+    return minDate ? toMonthStart(String(minDate).slice(0, 7)) : null;
+  }
+
+  /**
+   * On the 1st of each month, drafts/refreshes the previous month's close for every
+   * active user, and — on first run (no prior closes exist for that user) — backfills
+   * as many earlier months as transaction history allows (decision #11), bounded by
+   * MAX_BACKFILL_MONTHS. After each draft, sends a freshness nudge if required facts
+   * are stale and the user hasn't been nudged in the last 2 months (decision #3).
+   */
+  async runAutoDraftForAllUsers(referenceMonth?: string): Promise<{ usersProcessed: number; closesCreated: number }> {
+    const targetMonth = addMonths(referenceMonth ?? new Date().toISOString().slice(0, 7), -1);
+    let closesCreated = 0;
+
+    for (const user of await this.activeUsers()) {
+      try {
+        const created = await this.runAutoDraftForUser(user.id, targetMonth);
+        closesCreated += created;
+      } catch (err: any) {
+        this.logger.error(`Monthly-close auto-draft failed for user ${user.id}: ${err.message}`, err.stack);
+      }
+    }
+    return { usersProcessed: (await this.activeUsers()).length, closesCreated };
+  }
+
+  private async runAutoDraftForUser(userId: string, targetMonth: string): Promise<number> {
+    const hasAnyClose = (await this.findAll(userId, 1)).length > 0;
+    let created = 0;
+
+    if (!hasAnyClose) {
+      const earliest = await this.earliestActivityMonth(userId);
+      const backfillStart = earliest
+        ? addMonths(targetMonth, -Math.min(MAX_BACKFILL_MONTHS, Math.max(0, monthDiff(targetMonth, earliest))))
+        : targetMonth;
+      let month = backfillStart;
+      while (monthDiff(targetMonth, month) >= 0) {
+        await this.draft(userId, month);
+        created += 1;
+        await this.maybeNudgeFreshness(userId, month);
+        month = addMonths(month, 1);
+      }
+      return created;
+    }
+
+    const existing = await this.findRow(userId, targetMonth);
+    await this.draft(userId, targetMonth);
+    if (!existing) created += 1;
+    await this.maybeNudgeFreshness(userId, targetMonth);
+    return created;
+  }
+
+  /** Freshness nudge, capped to once every 2 months per user (decision #3). Uses the
+   *  existing notifications path with a dedupe key scoped to the cooldown window so
+   *  re-running the cron mid-window is a no-op, not a duplicate send. */
+  private async maybeNudgeFreshness(userId: string, month: string): Promise<boolean> {
+    const row = await this.findRow(userId, month);
+    if (!row) return false;
+    const freshness = row.freshness as { isComplete?: boolean; missingManualAssets?: string[]; staleAccounts?: string[]; unverifiedLoans?: string[] } | null;
+    if (!freshness || freshness.isComplete) return false;
+
+    const lastNudgeResult = await this.db.execute(sql`
+      SELECT MAX(created_at)::text AS last_at FROM ${schema.notifications}
+      WHERE user_id = ${userId} AND type = ${FRESHNESS_NUDGE_NOTIFICATION_TYPE}
+    `);
+    const lastRows = (lastNudgeResult.rows ?? lastNudgeResult) as any[];
+    const lastAt = lastRows[0]?.last_at ? new Date(lastRows[0].last_at) : null;
+    if (lastAt) {
+      const monthsSince =
+        (Date.now() - lastAt.getTime()) / (30.44 * 24 * 3600_000);
+      if (monthsSince < FRESHNESS_NUDGE_COOLDOWN_MONTHS) return false;
+    }
+
+    const staleItems = [
+      ...(freshness.missingManualAssets ?? []),
+      ...(freshness.staleAccounts ?? []),
+      ...(freshness.unverifiedLoans ?? []),
+    ];
+    await this.notificationsService.createAndDispatch({
+      userId,
+      type: FRESHNESS_NUDGE_NOTIFICATION_TYPE,
+      title: `Your ${month.slice(0, 7)} close needs a few updates`,
+      message: `${staleItems.length} item(s) are missing or stale (manual assets, account balances, or loan statements) — update them for an accurate close.`,
+      severity: 'info',
+      source: 'freshness',
+      data: { month, ...freshness },
+      dedupeKey: `monthly-close-freshness-${userId}-${month}`,
+    });
+    return true;
+  }
+}

--- a/apps/api/src/monthly-close/monthly-close.service.ts
+++ b/apps/api/src/monthly-close/monthly-close.service.ts
@@ -540,9 +540,10 @@ export class MonthlyCloseService {
    */
   async runAutoDraftForAllUsers(referenceMonth?: string): Promise<{ usersProcessed: number; closesCreated: number }> {
     const targetMonth = addMonths(referenceMonth ?? new Date().toISOString().slice(0, 7), -1);
+    const users = await this.activeUsers();
     let closesCreated = 0;
 
-    for (const user of await this.activeUsers()) {
+    for (const user of users) {
       try {
         const created = await this.runAutoDraftForUser(user.id, targetMonth);
         closesCreated += created;
@@ -550,7 +551,18 @@ export class MonthlyCloseService {
         this.logger.error(`Monthly-close auto-draft failed for user ${user.id}: ${err.message}`, err.stack);
       }
     }
-    return { usersProcessed: (await this.activeUsers()).length, closesCreated };
+    return { usersProcessed: users.length, closesCreated };
+  }
+
+  /** Draft/refresh `month` for one user unless it's already confirmed — a confirmed
+   *  close is user-signed-off history; the auto-draft cron must never silently
+   *  clobber it (only the explicit recalculate/patch endpoints may touch it, and
+   *  patch applies the isEdited/editedAt audit stamp `draft()` does not). */
+  private async draftUnlessConfirmed(userId: string, month: string): Promise<boolean> {
+    const existing = await this.findRow(userId, month);
+    if (existing?.status === 'confirmed') return false;
+    await this.draft(userId, month);
+    return true;
   }
 
   private async runAutoDraftForUser(userId: string, targetMonth: string): Promise<number> {
@@ -564,8 +576,9 @@ export class MonthlyCloseService {
         : targetMonth;
       let month = backfillStart;
       while (monthDiff(targetMonth, month) >= 0) {
-        await this.draft(userId, month);
-        created += 1;
+        const wasMissing = !(await this.findRow(userId, month));
+        const drafted = await this.draftUnlessConfirmed(userId, month);
+        if (drafted && wasMissing) created += 1;
         await this.maybeNudgeFreshness(userId, month);
         month = addMonths(month, 1);
       }
@@ -573,8 +586,8 @@ export class MonthlyCloseService {
     }
 
     const existing = await this.findRow(userId, targetMonth);
-    await this.draft(userId, targetMonth);
-    if (!existing) created += 1;
+    const drafted = await this.draftUnlessConfirmed(userId, targetMonth);
+    if (drafted && !existing) created += 1;
     await this.maybeNudgeFreshness(userId, targetMonth);
     return created;
   }


### PR DESCRIPTION
## Summary

Addressed the review findings on the 13.5 monthly-close cron:

- **Medium (contract integrity):** the auto-draft cron's `runAutoDraftForUser` called `draft()` unconditionally on the target month, which overwrites frozen aggregates on any existing row — including one the user had already `confirm()`-ed. Added `draftUnlessConfirmed()`, which checks the row's status first and skips (returns `false`, no insert/update) when it's `confirmed`; both the steady-state re-draft path and the first-run backfill loop now go through it. This also preserves the intended contract that only `recalculate`/`patch` may touch a confirmed close (and `patch` applies the `isEdited`/`editedAt` audit stamp, which the cron path never did).
- **Low (advisory):** `runAutoDraftForAllUsers` queried `activeUsers()` twice (once to iterate, once to size the returned count) — now caches the list once, so the reported `usersProcessed` can't drift from the set actually processed.
- Left the third (investment valuation using today's holdings price for backfilled historical months) as a documented advisory limitation per triage instructions — it's a pre-existing data-availability constraint (no historical holdings-value table), not a regression, and fixing it would require a larger data-model change out of scope for this pass.

Added two unit tests (`draftUnlessConfirmed` skips a confirmed row / drafts a missing one) alongside the existing suite. Ran `pnpm --filter @moneypulse/api test monthly-close` — all 39 tests pass (up from 37). Committed as a follow-up fix commit; not pushed.

---
### Test evidence
**13 new test case(s) added** (heuristic count):
```
 .../src/jobs/__tests__/monthly-close-cron.spec.ts  |  25 +
 .../__tests__/monthly-close.service.spec.ts        | 168 ++++++
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

### Review
**Review verdict:** fix

Findings (advisory — did not block landing):
- [med/contract] apps/api/src/monthly-close/monthly-close.service.ts:471 — Monthly cron re-drafts the previous month via draft(), which overwrites frozen aggregates even when that close is already status='confirmed', silently clobbering user-confirmed historical figures (and without the isEdited/editedAt audit stamp patch() applies). runAutoDraftForUser should skip/guard confirmed closes.
- [low/advisory] apps/api/src/monthly-close/monthly-close.service.ts:399 — runAutoDraftForAllUsers calls activeUsers() twice (once to iterate, once for the returned usersProcessed count); the count can drift from the set actually processed and is an extra query. Cache the list once.
- [low/advisory] apps/api/src/monthly-close/monthly-close.service.ts:259 — getPortfolioValue(userId) returns current portfolio value and is applied to every backfilled historical month, so past-month closes use today's holdings valuation rather than the month-end value.

---
Dispatched via coxd (`MyMoney-13-5-monthly-close-api-auto-1785163688`) · cost $2.728 · 🤖 coxd