### PR TITLE
13.6 Web /health — monthly close grid, hero cards, panels, coach overl

### DIFF
--- a/apps/web/src/__tests__/monthly-close.spec.tsx
+++ b/apps/web/src/__tests__/monthly-close.spec.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { MonthlyFinancialSnapshot } from '@moneypulse/shared';
+import { MonthlyCloseHero } from '@/components/monthly-close/MonthlyCloseHero';
+import { MonthlyCloseGrid } from '@/components/monthly-close/MonthlyCloseGrid';
+import { MonthlyCloseMonthCard } from '@/components/monthly-close/MonthlyCloseMonthCard';
+import { CoachOverlayPanel } from '@/components/monthly-close/CoachOverlayPanel';
+
+function makeSnapshot(overrides: Partial<MonthlyFinancialSnapshot> = {}): MonthlyFinancialSnapshot {
+  return {
+    id: 'snap-1',
+    userId: 'user-1',
+    snapshotMonth: '2026-06-01',
+    status: 'draft',
+    takeHomeIncomeCents: 500000,
+    grossIncomeCents: 650000,
+    expenseCents: 320000,
+    fixedExpenseCents: 200000,
+    variableExpenseCents: 120000,
+    cashSavingsCents: 80000,
+    investmentContributionCents: 60000,
+    debtPrincipalPaidCents: 40000,
+    extraDebtPrincipalPaidCents: 0,
+    liquidAssetCents: 1500000,
+    investmentAssetCents: 4000000,
+    manualAssetCents: 3000000,
+    totalAssetCents: 8500000,
+    creditCardLiabilityCents: 50000,
+    loanLiabilityCents: 2500000,
+    totalLiabilityCents: 2550000,
+    netWorthCents: 5950000,
+    savingsRateBps: 1600,
+    investingRateBps: 1200,
+    debtPaydownRateBps: 800,
+    wealthBuildingRateBps: 3600,
+    expenseRatioBps: 6400,
+    liquidNetWorthRatioBps: 2521,
+    debtAssetRatioBps: 3000,
+    debtPaymentIncomeRatioBps: 900,
+    targetStatus: {
+      expense_ratio: 'yellow',
+      savings_rate: 'info',
+      investing_rate: 'info',
+      debt_paydown_rate: 'info',
+      liquid_net_worth_ratio: 'green',
+      debt_asset_ratio: 'green',
+      debt_payment_income_ratio: 'green',
+    },
+    freshness: { isComplete: true, missingManualAssets: [], staleAccounts: [], unverifiedLoans: [] },
+    calculationVersion: 'v1',
+    notes: null,
+    aiReview: null,
+    editedAt: null,
+    isEdited: false,
+    confirmedAt: null,
+    createdAt: '2026-06-01T00:00:00Z',
+    updatedAt: '2026-06-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('MonthlyCloseHero', () => {
+  it('renders Expenses as the headline card', () => {
+    render(<MonthlyCloseHero current={makeSnapshot()} prior={null} history={[]} />);
+    const heroExpenses = screen.getByTestId('hero-expenses');
+    expect(heroExpenses).toHaveTextContent('Expenses');
+    expect(heroExpenses).toHaveTextContent('$3,200.00');
+  });
+
+  it('shows an empty state with no current month', () => {
+    render(<MonthlyCloseHero current={null} prior={null} history={[]} />);
+    expect(screen.getByText(/create a draft/i)).toBeInTheDocument();
+  });
+
+  it('computes prior-month and 3-mo-avg expense deltas', () => {
+    const current = makeSnapshot({ expenseCents: 320000 });
+    const prior = makeSnapshot({ expenseCents: 300000 });
+    const history = [
+      makeSnapshot({ expenseCents: 300000 }),
+      makeSnapshot({ expenseCents: 310000 }),
+      makeSnapshot({ expenseCents: 290000 }),
+    ];
+    render(<MonthlyCloseHero current={current} prior={prior} history={history} />);
+    expect(screen.getByText(/vs prior month/)).toBeInTheDocument();
+    expect(screen.getByText(/vs 3-mo avg/)).toBeInTheDocument();
+  });
+});
+
+describe('MonthlyCloseGrid', () => {
+  it('renders the desktop grid with section headers and Metric/Current columns', () => {
+    render(<MonthlyCloseGrid snapshots={[makeSnapshot()]} />);
+    expect(screen.getByTestId('monthly-close-grid')).toBeInTheDocument();
+    expect(screen.getByText('Metric')).toBeInTheDocument();
+    expect(screen.getByText('Expenses')).toBeInTheDocument();
+    expect(screen.getByText('Total expenses')).toBeInTheDocument();
+  });
+
+  it('does not double-count credit-card payments in the Expenses section', () => {
+    // Expenses row must reflect expenseCents (which the calculator already excludes
+    // debt-principal transfers from), not expenseCents + creditCardLiabilityCents.
+    const snapshot = makeSnapshot({ expenseCents: 320000, creditCardLiabilityCents: 50000 });
+    render(<MonthlyCloseGrid snapshots={[snapshot]} />);
+    const rows = screen.getAllByText('$3,200.00');
+    expect(rows.length).toBeGreaterThan(0);
+    expect(screen.queryByText('$3,700.00')).not.toBeInTheDocument();
+  });
+
+  it('shows an empty state with no snapshots', () => {
+    render(<MonthlyCloseGrid snapshots={[]} />);
+    expect(screen.getByText(/no monthly closes yet/i)).toBeInTheDocument();
+  });
+});
+
+describe('MonthlyCloseMonthCard', () => {
+  it('renders a readable month card grouped by section', () => {
+    render(<MonthlyCloseMonthCard snapshot={makeSnapshot()} />);
+    const card = screen.getByTestId('monthly-close-month-card');
+    expect(card).toHaveTextContent('Expenses');
+    expect(card).toHaveTextContent('Income');
+    expect(card).toHaveTextContent('Net Worth');
+  });
+});
+
+describe('CoachOverlayPanel', () => {
+  it('renders Shashank ratios, Ramit buckets, and the FOO next-dollar step', () => {
+    render(<CoachOverlayPanel snapshot={makeSnapshot()} />);
+    const panel = screen.getByTestId('coach-overlay-panel');
+    expect(panel).toHaveTextContent('Shashank Ratios');
+    expect(panel).toHaveTextContent('Ramit 4-Bucket');
+    expect(panel).toHaveTextContent('Money Guy FOO');
+  });
+
+  it('shows a placeholder when there is no current close', () => {
+    render(<CoachOverlayPanel snapshot={null} />);
+    expect(screen.getByText(/create a draft close/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(protected)/health/page.tsx
+++ b/apps/web/src/app/(protected)/health/page.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Activity, RefreshCw } from 'lucide-react';
+import {
+  useMonthlyCloses,
+  useCreateDraft,
+  useConfirmClose,
+  useReopenClose,
+} from '@/lib/hooks/useMonthlyClose';
+import { MonthlyCloseHero } from '@/components/monthly-close/MonthlyCloseHero';
+import { MonthlyCloseGrid } from '@/components/monthly-close/MonthlyCloseGrid';
+import { MonthlyCloseMonthCard } from '@/components/monthly-close/MonthlyCloseMonthCard';
+import { ManualAssetPanel } from '@/components/monthly-close/ManualAssetPanel';
+import { LoanVerificationPanel } from '@/components/monthly-close/LoanVerificationPanel';
+import { CoachOverlayPanel } from '@/components/monthly-close/CoachOverlayPanel';
+
+function currentMonth(): string {
+  const now = new Date();
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}-01`;
+}
+
+/** NAS-only monthly-close workspace: dense grid on desktop, month cards on mobile.
+ *  Expenses is the deliberate visual headline (epic #158 design intent). */
+export default function HealthPage() {
+  const [range, setRange] = useState<6 | 12>(6);
+  const [month, setMonth] = useState(currentMonth());
+  const { data, isLoading, isFetching } = useMonthlyCloses(range);
+  const createDraft = useCreateDraft();
+  const confirm = useConfirmClose();
+  const reopen = useReopenClose();
+
+  const snapshots = useMemo(() => data?.data ?? [], [data]);
+  const current = snapshots.find((s) => s.snapshotMonth.slice(0, 7) === month.slice(0, 7)) ?? snapshots[0] ?? null;
+  const currentIdx = current ? snapshots.findIndex((s) => s.id === current.id) : -1;
+  const prior = currentIdx >= 0 ? snapshots[currentIdx + 1] ?? null : null;
+  const history = currentIdx >= 0 ? snapshots.slice(currentIdx + 1) : [];
+
+  const busy = createDraft.isPending || confirm.isPending || reopen.isPending;
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <Activity className="h-6 w-6 text-[var(--primary)]" />
+            <h1 className="text-3xl font-extrabold tracking-tight">Health</h1>
+          </div>
+          <p className="text-[var(--muted-foreground)] text-sm">
+            Monthly close: expenses, net worth, savings/investing rates, debt paydown.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <input
+            type="month"
+            value={month.slice(0, 7)}
+            onChange={(e) => setMonth(`${e.target.value}-01`)}
+            className="rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm"
+          />
+          <div className="flex rounded-md border border-[var(--border)] overflow-hidden">
+            {([6, 12] as const).map((r) => (
+              <button
+                key={r}
+                onClick={() => setRange(r)}
+                className={`px-3 py-2 text-sm font-medium ${
+                  range === r ? 'bg-[var(--primary)] text-[var(--primary-foreground)]' : 'hover:bg-[var(--muted)]'
+                }`}
+              >
+                {r}-mo
+              </button>
+            ))}
+          </div>
+          <button
+            onClick={() => createDraft.mutate(month)}
+            disabled={busy}
+            className="rounded-md border border-[var(--border)] px-3 py-2 text-sm font-semibold hover:bg-[var(--muted)] disabled:opacity-50"
+          >
+            Create draft
+          </button>
+          <button
+            onClick={() => confirm.mutate(month)}
+            disabled={busy || !current || current.status === 'confirmed'}
+            className="rounded-md bg-[var(--primary)] px-3 py-2 text-sm font-semibold text-[var(--primary-foreground)] disabled:opacity-50"
+          >
+            Confirm
+          </button>
+          <button
+            onClick={() => reopen.mutate(month)}
+            disabled={busy || !current || current.status !== 'confirmed'}
+            className="rounded-md border border-[var(--border)] px-3 py-2 text-sm font-semibold hover:bg-[var(--muted)] disabled:opacity-50"
+          >
+            Reopen
+          </button>
+          {isFetching && <RefreshCw className="h-4 w-4 animate-spin text-[var(--muted-foreground)]" />}
+        </div>
+      </div>
+
+      {isLoading && <p className="text-sm text-[var(--muted-foreground)] animate-pulse">Loading…</p>}
+
+      <MonthlyCloseHero current={current} prior={prior} history={history} />
+
+      {/* Desktop grid */}
+      <MonthlyCloseGrid snapshots={snapshots} />
+
+      {/* Mobile month cards — grouped by section, never a squeezed table */}
+      <div className="md:hidden space-y-3">
+        {snapshots.length === 0 && (
+          <p className="py-6 text-center text-sm text-[var(--muted-foreground)]">No monthly closes yet.</p>
+        )}
+        {snapshots.map((s) => (
+          <MonthlyCloseMonthCard key={s.id} snapshot={s} />
+        ))}
+      </div>
+
+      <CoachOverlayPanel snapshot={current} />
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <ManualAssetPanel
+          month={month}
+          missingManualAssets={current?.freshness && typeof current.freshness === 'object'
+            ? ((current.freshness as { missingManualAssets?: string[] }).missingManualAssets ?? [])
+            : []}
+        />
+        <LoanVerificationPanel
+          month={month}
+          unverifiedLoans={current?.freshness && typeof current.freshness === 'object'
+            ? ((current.freshness as { unverifiedLoans?: string[] }).unverifiedLoans ?? [])
+            : []}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/monthly-close/CoachOverlayPanel.tsx
+++ b/apps/web/src/components/monthly-close/CoachOverlayPanel.tsx
@@ -1,0 +1,89 @@
+import type { MonthlyFinancialSnapshot } from '@moneypulse/shared';
+import { formatBps, statusFor, STATUS_CHIP_CLASSES, STATUS_LABELS } from './status';
+
+/** Ramit's 4-bucket split (Investments here is the calculator-derived bucket, per
+ *  epic #158 decision #4 — never a separate user-entered figure). Falls back to
+ *  the close's own rates when the calculator's `ramitBuckets` breakdown isn't
+ *  present on the persisted row. */
+function ramitBuckets(snapshot: MonthlyFinancialSnapshot) {
+  const buckets = (snapshot as unknown as { ramitBuckets?: Record<string, number> }).ramitBuckets;
+  if (buckets) return buckets;
+  return {
+    fixed_costs: snapshot.fixedExpenseCents,
+    investments: snapshot.investmentContributionCents,
+    savings: snapshot.cashSavingsCents,
+    guilt_free: snapshot.variableExpenseCents,
+  };
+}
+
+/** Money Guy FOO next-dollar priority — uses the employer-match capture field when
+ *  present on the row (decision #12); degrades to a generic nudge otherwise. */
+function fooStep(snapshot: MonthlyFinancialSnapshot): string {
+  const foo = (snapshot as unknown as { fooRecommendation?: string }).fooRecommendation;
+  if (foo) return foo;
+  if (snapshot.investingRateBps !== null && snapshot.investingRateBps < 1500) {
+    return 'Increase investing rate toward 15% of take-home before extra debt payoff.';
+  }
+  return 'On track — keep following your current priority order.';
+}
+
+/** Coach overlays: Shashank ratio strip, Ramit 4-bucket, Money Guy FOO next-dollar. */
+export function CoachOverlayPanel({ snapshot }: { snapshot: MonthlyFinancialSnapshot | null }) {
+  if (!snapshot) {
+    return (
+      <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4 text-sm text-[var(--muted-foreground)]">
+        Create a draft close to see coach overlays.
+      </div>
+    );
+  }
+
+  const buckets = ramitBuckets(snapshot);
+  const ratioRows = [
+    { key: 'expense_ratio', label: 'Expense ratio', value: snapshot.expenseRatioBps },
+    { key: 'liquid_net_worth_ratio', label: 'Liquid / net worth', value: snapshot.liquidNetWorthRatioBps },
+    { key: 'debt_asset_ratio', label: 'Debt / asset', value: snapshot.debtAssetRatioBps },
+    { key: 'debt_payment_income_ratio', label: 'Debt payment / income', value: snapshot.debtPaymentIncomeRatioBps },
+  ];
+
+  return (
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-3" data-testid="coach-overlay-panel">
+      {/* Shashank ratio strip */}
+      <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4">
+        <h3 className="mb-2 font-bold">Shashank Ratios</h3>
+        <div className="space-y-1">
+          {ratioRows.map((r) => {
+            const status = statusFor(snapshot.targetStatus, r.key);
+            return (
+              <div key={r.key} className="flex items-center justify-between text-sm">
+                <span className="text-[var(--muted-foreground)]">{r.label}</span>
+                <span className="flex items-center gap-2 tabular-nums">
+                  {formatBps(r.value)}
+                  <span className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium ${STATUS_CHIP_CLASSES[status]}`}>
+                    {STATUS_LABELS[status]}
+                  </span>
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Ramit 4-bucket */}
+      <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4">
+        <h3 className="mb-2 font-bold">Ramit 4-Bucket</h3>
+        <ul className="space-y-1 text-sm">
+          <li className="flex justify-between"><span className="text-[var(--muted-foreground)]">Fixed costs</span><span className="tabular-nums font-medium">${(buckets.fixed_costs / 100).toFixed(0)}</span></li>
+          <li className="flex justify-between"><span className="text-[var(--muted-foreground)]">Investments</span><span className="tabular-nums font-medium">${(buckets.investments / 100).toFixed(0)}</span></li>
+          <li className="flex justify-between"><span className="text-[var(--muted-foreground)]">Savings</span><span className="tabular-nums font-medium">${(buckets.savings / 100).toFixed(0)}</span></li>
+          <li className="flex justify-between"><span className="text-[var(--muted-foreground)]">Guilt-free spending</span><span className="tabular-nums font-medium">${(buckets.guilt_free / 100).toFixed(0)}</span></li>
+        </ul>
+      </div>
+
+      {/* Money Guy FOO */}
+      <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4">
+        <h3 className="mb-2 font-bold">Money Guy FOO — Next Dollar</h3>
+        <p className="text-sm text-[var(--muted-foreground)]">{fooStep(snapshot)}</p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/monthly-close/LoanVerificationPanel.tsx
+++ b/apps/web/src/components/monthly-close/LoanVerificationPanel.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useState } from 'react';
+import { formatCents } from '@/lib/format';
+import { computeLoanState } from '@moneypulse/shared';
+import { useLoansForVerification, useUpsertLoanBalanceSnapshot } from '@/lib/hooks/useMonthlyClose';
+
+/** One loan: amortized balance vs an optional manual-statement override, plus
+ *  principal paid this month. */
+function LoanRow({ loanId, month }: { loanId: string; month: string }) {
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState('');
+  const upsert = useUpsertLoanBalanceSnapshot();
+
+  const submit = async () => {
+    const dollars = parseFloat(value);
+    if (!Number.isFinite(dollars) || dollars < 0) return;
+    await upsert.mutateAsync({
+      loanId,
+      month,
+      balanceCents: Math.round(dollars * 100),
+      source: 'manual_statement',
+    });
+    setEditing(false);
+    setValue('');
+  };
+
+  return editing ? (
+    <div className="flex items-center gap-2">
+      <input
+        type="number"
+        inputMode="decimal"
+        autoFocus
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        className="w-28 rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-sm tabular-nums"
+        placeholder="0.00"
+      />
+      <button
+        onClick={submit}
+        disabled={upsert.isPending}
+        className="rounded-md bg-[var(--primary)] px-2 py-1 text-xs font-semibold text-[var(--primary-foreground)] disabled:opacity-50"
+      >
+        Save
+      </button>
+      <button onClick={() => setEditing(false)} className="text-xs text-[var(--muted-foreground)]">
+        Cancel
+      </button>
+    </div>
+  ) : (
+    <button
+      onClick={() => setEditing(true)}
+      className="rounded-md border border-[var(--border)] px-2 py-1 text-xs font-medium hover:bg-[var(--muted)]"
+    >
+      Verify statement balance
+    </button>
+  );
+}
+
+/** Loan verification panel: amortized-vs-manual-statement balance per loan, with
+ *  the source used and this month's principal paid. `unverifiedLoans` comes from
+ *  the close's freshness map. */
+export function LoanVerificationPanel({
+  month,
+  unverifiedLoans,
+}: {
+  month: string;
+  unverifiedLoans: string[];
+}) {
+  const { data, isLoading } = useLoansForVerification();
+  const loans = data?.data ?? [];
+
+  return (
+    <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4" data-testid="loan-verification-panel">
+      <h3 className="mb-2 font-bold">Loan Verification</h3>
+      {isLoading && <p className="text-sm text-[var(--muted-foreground)]">Loading…</p>}
+      {!isLoading && loans.length === 0 && (
+        <p className="text-sm text-[var(--muted-foreground)]">No loans tracked.</p>
+      )}
+      <div className="space-y-3">
+        {loans.map((loan) => {
+          const state = computeLoanState(
+            {
+              originalBalanceCents: loan.originalBalanceCents,
+              aprBps: loan.aprBps,
+              scheduledPaymentCents: loan.scheduledPaymentCents,
+              startDate: loan.startDate,
+            },
+            [],
+          );
+          const unverified = unverifiedLoans.includes(loan.id);
+          return (
+            <div key={loan.id} className="flex items-center justify-between gap-3 border-b border-[var(--border)] pb-2 last:border-0">
+              <div>
+                <p className="text-sm font-medium">{loan.name}</p>
+                <p className="text-xs text-[var(--muted-foreground)]">
+                  Amortized: {formatCents(state.currentBalanceCents)}
+                  {unverified && (
+                    <span className="ml-2 rounded-full bg-yellow-100 px-2 py-0.5 text-[10px] font-medium text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300">
+                      Unverified
+                    </span>
+                  )}
+                </p>
+              </div>
+              <LoanRow loanId={loan.id} month={month} />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/monthly-close/ManualAssetPanel.tsx
+++ b/apps/web/src/components/monthly-close/ManualAssetPanel.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useState } from 'react';
+import { useManualAssets, useUpsertManualAssetSnapshot } from '@/lib/hooks/useMonthlyClose';
+
+/** Inline month editor + staleness badge for one manual asset (home/car/gold/other).
+ *  Carry-forward means a missing month isn't an error — it's just stale (epic #158
+ *  decision #3), so this only warns, it never blocks. */
+function AssetRow({ assetId, name, month }: { assetId: string; name: string; month: string }) {
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState('');
+  const upsert = useUpsertManualAssetSnapshot();
+
+  const submit = async () => {
+    const dollars = parseFloat(value);
+    if (!Number.isFinite(dollars) || dollars < 0) return;
+    await upsert.mutateAsync({
+      assetId,
+      month,
+      valueCents: Math.round(dollars * 100),
+      source: 'manual',
+    });
+    setEditing(false);
+    setValue('');
+  };
+
+  return (
+    <div className="flex items-center justify-between gap-3 border-b border-[var(--border)] py-2 last:border-0">
+      <span className="text-sm font-medium">{name}</span>
+      {editing ? (
+        <div className="flex items-center gap-2">
+          <input
+            type="number"
+            inputMode="decimal"
+            autoFocus
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            className="w-28 rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-sm tabular-nums"
+            placeholder="0.00"
+          />
+          <button
+            onClick={submit}
+            disabled={upsert.isPending}
+            className="rounded-md bg-[var(--primary)] px-2 py-1 text-xs font-semibold text-[var(--primary-foreground)] disabled:opacity-50"
+          >
+            Save
+          </button>
+          <button onClick={() => setEditing(false)} className="text-xs text-[var(--muted-foreground)]">
+            Cancel
+          </button>
+        </div>
+      ) : (
+        <button
+          onClick={() => setEditing(true)}
+          className="rounded-md border border-[var(--border)] px-2 py-1 text-xs font-medium hover:bg-[var(--muted)]"
+        >
+          Edit {month.slice(0, 7)}
+        </button>
+      )}
+    </div>
+  );
+}
+
+/** Manual asset panel: home/car/gold values with inline month editing. Staleness
+ *  (missing months) is surfaced via the close's `freshness.missingManualAssets`,
+ *  not recomputed here. */
+export function ManualAssetPanel({
+  month,
+  missingManualAssets,
+}: {
+  month: string;
+  missingManualAssets: string[];
+}) {
+  const { data, isLoading } = useManualAssets();
+  const assets = data?.data ?? [];
+
+  return (
+    <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4" data-testid="manual-asset-panel">
+      <h3 className="mb-2 font-bold">Manual Assets</h3>
+      {isLoading && <p className="text-sm text-[var(--muted-foreground)]">Loading…</p>}
+      {!isLoading && assets.length === 0 && (
+        <p className="text-sm text-[var(--muted-foreground)]">
+          No manual assets tracked yet (home, car, gold).
+        </p>
+      )}
+      {assets.map((asset) => {
+        const stale = missingManualAssets.includes(asset.id);
+        return (
+          <div key={asset.id}>
+            {stale && (
+              <span className="mb-1 inline-block rounded-full bg-yellow-100 px-2 py-0.5 text-[10px] font-medium text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300">
+                Stale — carried forward
+              </span>
+            )}
+            <AssetRow assetId={asset.id} name={asset.name} month={month} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/monthly-close/MonthlyCloseGrid.tsx
+++ b/apps/web/src/components/monthly-close/MonthlyCloseGrid.tsx
@@ -1,0 +1,185 @@
+import { Fragment } from 'react';
+import Link from 'next/link';
+import type { MonthlyFinancialSnapshot } from '@moneypulse/shared';
+import { formatCents } from '@/lib/format';
+import { STATUS_CHIP_CLASSES, STATUS_LABELS, formatBps, statusFor } from './status';
+
+type Unit = 'cents' | 'bps';
+
+interface RowSpec {
+  key: string;
+  section: string;
+  label: string;
+  unit: Unit;
+  get: (s: MonthlyFinancialSnapshot) => number | null;
+  statusKey?: string;
+  /** Transaction-derived rows drill into /transactions filtered by this section. */
+  drillHref?: string;
+}
+
+const ROWS: RowSpec[] = [
+  { key: 'take_home', section: 'Income', label: 'Take-home income', unit: 'cents', get: (s) => s.takeHomeIncomeCents },
+  { key: 'gross', section: 'Income', label: 'Gross income', unit: 'cents', get: (s) => s.grossIncomeCents },
+
+  // Expenses is the headline section — credit-card principal payments are excluded
+  // from expenseCents by the calculator (folded into Debt Paydown instead), so this
+  // number is never double-counted.
+  { key: 'expenses', section: 'Expenses', label: 'Total expenses', unit: 'cents', get: (s) => s.expenseCents, statusKey: 'expense_ratio', drillHref: '/transactions' },
+  { key: 'fixed', section: 'Expenses', label: 'Fixed', unit: 'cents', get: (s) => s.fixedExpenseCents, drillHref: '/transactions' },
+  { key: 'variable', section: 'Expenses', label: 'Variable', unit: 'cents', get: (s) => s.variableExpenseCents, drillHref: '/transactions' },
+
+  { key: 'cash_savings', section: 'Savings', label: 'Cash savings', unit: 'cents', get: (s) => s.cashSavingsCents, statusKey: 'savings_rate' },
+  { key: 'savings_rate', section: 'Savings', label: 'Savings rate', unit: 'bps', get: (s) => s.savingsRateBps, statusKey: 'savings_rate' },
+
+  { key: 'investment_contrib', section: 'Investments', label: 'Contributions', unit: 'cents', get: (s) => s.investmentContributionCents, statusKey: 'investing_rate' },
+  { key: 'investing_rate', section: 'Investments', label: 'Investing rate', unit: 'bps', get: (s) => s.investingRateBps, statusKey: 'investing_rate' },
+
+  { key: 'debt_paid', section: 'Debt Paydown', label: 'Principal paid', unit: 'cents', get: (s) => s.debtPrincipalPaidCents, statusKey: 'debt_paydown_rate' },
+  { key: 'debt_paid_extra', section: 'Debt Paydown', label: 'Extra principal', unit: 'cents', get: (s) => s.extraDebtPrincipalPaidCents },
+
+  { key: 'liquid_assets', section: 'Assets', label: 'Liquid', unit: 'cents', get: (s) => s.liquidAssetCents },
+  { key: 'investment_assets', section: 'Assets', label: 'Investments', unit: 'cents', get: (s) => s.investmentAssetCents },
+  { key: 'manual_assets', section: 'Assets', label: 'Manual (home/car/gold)', unit: 'cents', get: (s) => s.manualAssetCents },
+  { key: 'total_assets', section: 'Assets', label: 'Total assets', unit: 'cents', get: (s) => s.totalAssetCents },
+
+  { key: 'cc_liability', section: 'Liabilities', label: 'Credit cards', unit: 'cents', get: (s) => s.creditCardLiabilityCents },
+  { key: 'loan_liability', section: 'Liabilities', label: 'Loans', unit: 'cents', get: (s) => s.loanLiabilityCents },
+  { key: 'total_liabilities', section: 'Liabilities', label: 'Total liabilities', unit: 'cents', get: (s) => s.totalLiabilityCents },
+
+  { key: 'net_worth', section: 'Net Worth', label: 'Net worth', unit: 'cents', get: (s) => s.netWorthCents },
+
+  { key: 'expense_ratio', section: 'Ratios', label: 'Expense ratio', unit: 'bps', get: (s) => s.expenseRatioBps, statusKey: 'expense_ratio' },
+  { key: 'liquid_nw_ratio', section: 'Ratios', label: 'Liquid / net worth', unit: 'bps', get: (s) => s.liquidNetWorthRatioBps, statusKey: 'liquid_net_worth_ratio' },
+  { key: 'debt_asset_ratio', section: 'Ratios', label: 'Debt / asset', unit: 'bps', get: (s) => s.debtAssetRatioBps, statusKey: 'debt_asset_ratio' },
+  { key: 'debt_payment_income_ratio', section: 'Ratios', label: 'Debt payment / income', unit: 'bps', get: (s) => s.debtPaymentIncomeRatioBps, statusKey: 'debt_payment_income_ratio' },
+];
+
+const SECTIONS = [
+  'Income',
+  'Expenses',
+  'Savings',
+  'Investments',
+  'Debt Paydown',
+  'Assets',
+  'Liabilities',
+  'Net Worth',
+  'Ratios',
+];
+
+function fmt(unit: Unit, v: number | null): string {
+  if (v === null || v === undefined) return '—';
+  return unit === 'cents' ? formatCents(v) : formatBps(v);
+}
+
+function average(values: (number | null)[]): number | null {
+  const nums = values.filter((v): v is number => v !== null);
+  if (nums.length === 0) return null;
+  return nums.reduce((a, b) => a + b, 0) / nums.length;
+}
+
+/** Tiny inline sparkline — no chart library, just a row of relative-height bars. */
+function Trend({ values }: { values: (number | null)[] }) {
+  const nums = values.filter((v): v is number => v !== null);
+  if (nums.length === 0) return <span className="text-[var(--muted-foreground)]">—</span>;
+  const max = Math.max(...nums.map((v) => Math.abs(v)), 1);
+  return (
+    <div className="flex items-end gap-0.5 h-6" aria-hidden>
+      {values.map((v, i) => (
+        <div
+          key={i}
+          className="w-1.5 rounded-sm bg-[var(--primary)]/60"
+          style={{ height: v === null ? '2px' : `${Math.max(2, (Math.abs(v) / max) * 24)}px` }}
+        />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Dense desktop spreadsheet grid: Metric | Current | Prior | 3M Avg | 6M Trend |
+ * 12M Trend | Target | Status. `snapshots` must be most-recent-first, up to 12
+ * months. Hidden below `md` in favor of MonthlyCloseMonthCard.
+ */
+export function MonthlyCloseGrid({ snapshots }: { snapshots: MonthlyFinancialSnapshot[] }) {
+  const [current, prior, ...rest] = snapshots;
+  const last3 = snapshots.slice(0, 3);
+  const last6 = snapshots.slice(0, 6);
+  const last12 = snapshots.slice(0, 12);
+
+  if (!current) {
+    return (
+      <p className="py-8 text-center text-sm text-[var(--muted-foreground)]">
+        No monthly closes yet.
+      </p>
+    );
+  }
+
+  return (
+    <div className="hidden md:block overflow-auto rounded-lg border border-[var(--border)] max-h-[70vh]">
+      <table className="w-full text-left text-sm" data-testid="monthly-close-grid">
+        <thead className="sticky top-0 z-10 bg-[var(--muted)]/90 backdrop-blur text-xs font-semibold uppercase tracking-wide text-[var(--muted-foreground)]">
+          <tr>
+            <th className="sticky left-0 z-20 bg-[var(--muted)] px-4 py-2">Metric</th>
+            <th className="px-4 py-2">Current</th>
+            <th className="px-4 py-2">Prior</th>
+            <th className="px-4 py-2">3M Avg</th>
+            <th className="px-4 py-2">6M Trend</th>
+            <th className="px-4 py-2">12M Trend</th>
+            <th className="px-4 py-2">Target</th>
+            <th className="px-4 py-2">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {SECTIONS.map((section) => (
+            <Fragment key={section}>
+              <tr className="bg-[var(--muted)]/40">
+                <td colSpan={8} className="sticky left-0 px-4 py-1 text-xs font-bold uppercase tracking-wide text-[var(--muted-foreground)]">
+                  {section}
+                </td>
+              </tr>
+              {ROWS.filter((r) => r.section === section).map((row) => {
+                const currentVal = row.get(current);
+                const priorVal = prior ? row.get(prior) : null;
+                const avg3 = average(last3.map(row.get));
+                const status = row.statusKey ? statusFor(current.targetStatus, row.statusKey) : 'unknown';
+                return (
+                  <tr
+                    key={row.key}
+                    className="border-b border-[var(--border)] hover:bg-[var(--muted)]/20"
+                  >
+                    <td className="sticky left-0 z-10 bg-[var(--card)] px-4 py-2 font-medium">
+                      {row.drillHref ? (
+                        <Link href={row.drillHref} className="hover:underline text-[var(--primary)]">
+                          {row.label}
+                        </Link>
+                      ) : (
+                        row.label
+                      )}
+                    </td>
+                    <td className="px-4 py-2 tabular-nums">{fmt(row.unit, currentVal)}</td>
+                    <td className="px-4 py-2 tabular-nums text-[var(--muted-foreground)]">{fmt(row.unit, priorVal)}</td>
+                    <td className="px-4 py-2 tabular-nums text-[var(--muted-foreground)]">{fmt(row.unit, avg3)}</td>
+                    <td className="px-4 py-2"><Trend values={last6.map(row.get).reverse()} /></td>
+                    <td className="px-4 py-2"><Trend values={last12.map(row.get).reverse()} /></td>
+                    <td className="px-4 py-2 text-xs text-[var(--muted-foreground)]">
+                      {row.statusKey ? 'Target band' : '—'}
+                    </td>
+                    <td className="px-4 py-2">
+                      {row.statusKey ? (
+                        <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${STATUS_CHIP_CLASSES[status]}`}>
+                          {STATUS_LABELS[status]}
+                        </span>
+                      ) : (
+                        '—'
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </Fragment>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/components/monthly-close/MonthlyCloseHero.tsx
+++ b/apps/web/src/components/monthly-close/MonthlyCloseHero.tsx
@@ -1,0 +1,112 @@
+import { formatCents } from '@/lib/format';
+import type { MonthlyFinancialSnapshot } from '@moneypulse/shared';
+import { STATUS_CHIP_CLASSES, STATUS_LABELS, formatBps, formatDelta, statusFor } from './status';
+
+function average(values: number[]): number | null {
+  if (values.length === 0) return null;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+/** Restrained hero row: Expenses is deliberately first / visually largest — it's the
+ *  first number the user should feel, per the epic's design intent. */
+export function MonthlyCloseHero({
+  current,
+  prior,
+  history,
+}: {
+  current: MonthlyFinancialSnapshot | null;
+  prior: MonthlyFinancialSnapshot | null;
+  /** Up to the trailing 3 months (excluding current), most-recent-first, used for the
+   *  3-mo average expense delta on the Expenses card. */
+  history: MonthlyFinancialSnapshot[];
+}) {
+  if (!current) {
+    return (
+      <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-6 text-sm text-[var(--muted-foreground)]">
+        No close for this month yet — create a draft to see hero metrics.
+      </div>
+    );
+  }
+
+  const expenseDelta = prior ? current.expenseCents - prior.expenseCents : null;
+  const threeMoAvgExpense = average(history.slice(0, 3).map((s) => s.expenseCents));
+  const threeMoAvgDelta =
+    threeMoAvgExpense !== null ? current.expenseCents - threeMoAvgExpense : null;
+  const expenseStatus = statusFor(current.targetStatus, 'expense_ratio');
+
+  const cards = [
+    {
+      key: 'net_worth',
+      label: 'Net Worth',
+      value: formatCents(current.netWorthCents),
+      sub: prior ? formatDelta(current.netWorthCents - prior.netWorthCents) + ' vs prior' : undefined,
+    },
+    {
+      key: 'savings_rate',
+      label: 'Savings Rate',
+      value: formatBps(current.savingsRateBps),
+      status: statusFor(current.targetStatus, 'savings_rate'),
+    },
+    {
+      key: 'investing_rate',
+      label: 'Investing Rate',
+      value: formatBps(current.investingRateBps),
+      status: statusFor(current.targetStatus, 'investing_rate'),
+    },
+    {
+      key: 'debt_paydown',
+      label: 'Debt Paydown',
+      value: formatCents(current.debtPrincipalPaidCents),
+      status: statusFor(current.targetStatus, 'debt_paydown_rate'),
+    },
+    {
+      key: 'liquid_pct',
+      label: 'Liquid %',
+      value: formatBps(current.liquidNetWorthRatioBps),
+      status: statusFor(current.targetStatus, 'liquid_net_worth_ratio'),
+    },
+  ] as const;
+
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-6" data-testid="monthly-close-hero">
+      {/* Expenses — the headline card, spans 2 columns on large screens */}
+      <div
+        data-testid="hero-expenses"
+        className="lg:col-span-2 rounded-xl border border-[var(--border)] bg-[var(--card)] p-5 shadow-sm"
+      >
+        <p className="text-xs font-semibold uppercase tracking-wide text-[var(--muted-foreground)]">
+          Expenses
+        </p>
+        <p className="mt-1 text-4xl font-extrabold tabular-nums">{formatCents(current.expenseCents)}</p>
+        <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-[var(--muted-foreground)]">
+          <span>{formatDelta(expenseDelta)} vs prior month</span>
+          <span>{formatDelta(threeMoAvgDelta)} vs 3-mo avg</span>
+          <span
+            className={`rounded-full px-2 py-0.5 font-medium ${STATUS_CHIP_CLASSES[expenseStatus]}`}
+          >
+            {STATUS_LABELS[expenseStatus]}
+          </span>
+        </div>
+      </div>
+
+      {cards.map((card) => (
+        <div key={card.key} className="rounded-xl border border-[var(--border)] bg-[var(--card)] p-4">
+          <p className="text-xs font-semibold uppercase tracking-wide text-[var(--muted-foreground)]">
+            {card.label}
+          </p>
+          <p className="mt-1 text-2xl font-bold tabular-nums">{card.value}</p>
+          {'status' in card && card.status && (
+            <span
+              className={`mt-1 inline-block rounded-full px-2 py-0.5 text-[10px] font-medium ${STATUS_CHIP_CLASSES[card.status]}`}
+            >
+              {STATUS_LABELS[card.status]}
+            </span>
+          )}
+          {'sub' in card && card.sub && (
+            <p className="mt-1 text-xs text-[var(--muted-foreground)]">{card.sub}</p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/monthly-close/MonthlyCloseMonthCard.tsx
+++ b/apps/web/src/components/monthly-close/MonthlyCloseMonthCard.tsx
@@ -1,0 +1,113 @@
+import type { MonthlyFinancialSnapshot } from '@moneypulse/shared';
+import { formatCents } from '@/lib/format';
+import { STATUS_CHIP_CLASSES, STATUS_LABELS, formatBps, formatMonthLabel, statusFor } from './status';
+
+interface FieldSpec {
+  label: string;
+  unit: 'cents' | 'bps';
+  get: (s: MonthlyFinancialSnapshot) => number | null;
+  statusKey?: string;
+}
+
+const SECTIONS: { title: string; fields: FieldSpec[] }[] = [
+  {
+    title: 'Income',
+    fields: [{ label: 'Take-home', unit: 'cents', get: (s) => s.takeHomeIncomeCents }],
+  },
+  {
+    title: 'Expenses',
+    fields: [
+      { label: 'Total', unit: 'cents', get: (s) => s.expenseCents, statusKey: 'expense_ratio' },
+      { label: 'Fixed', unit: 'cents', get: (s) => s.fixedExpenseCents },
+      { label: 'Variable', unit: 'cents', get: (s) => s.variableExpenseCents },
+    ],
+  },
+  {
+    title: 'Savings',
+    fields: [{ label: 'Cash savings', unit: 'cents', get: (s) => s.cashSavingsCents, statusKey: 'savings_rate' }],
+  },
+  {
+    title: 'Investments',
+    fields: [{ label: 'Contributions', unit: 'cents', get: (s) => s.investmentContributionCents, statusKey: 'investing_rate' }],
+  },
+  {
+    title: 'Debt Paydown',
+    fields: [{ label: 'Principal paid', unit: 'cents', get: (s) => s.debtPrincipalPaidCents, statusKey: 'debt_paydown_rate' }],
+  },
+  {
+    title: 'Assets',
+    fields: [
+      { label: 'Liquid', unit: 'cents', get: (s) => s.liquidAssetCents },
+      { label: 'Investments', unit: 'cents', get: (s) => s.investmentAssetCents },
+      { label: 'Manual', unit: 'cents', get: (s) => s.manualAssetCents },
+    ],
+  },
+  {
+    title: 'Liabilities',
+    fields: [
+      { label: 'Credit cards', unit: 'cents', get: (s) => s.creditCardLiabilityCents },
+      { label: 'Loans', unit: 'cents', get: (s) => s.loanLiabilityCents },
+    ],
+  },
+  {
+    title: 'Net Worth',
+    fields: [{ label: 'Net worth', unit: 'cents', get: (s) => s.netWorthCents }],
+  },
+  {
+    title: 'Ratios',
+    fields: [
+      { label: 'Savings rate', unit: 'bps', get: (s) => s.savingsRateBps, statusKey: 'savings_rate' },
+      { label: 'Investing rate', unit: 'bps', get: (s) => s.investingRateBps, statusKey: 'investing_rate' },
+      { label: 'Liquid / net worth', unit: 'bps', get: (s) => s.liquidNetWorthRatioBps, statusKey: 'liquid_net_worth_ratio' },
+    ],
+  },
+];
+
+function fmt(unit: 'cents' | 'bps', v: number | null): string {
+  if (v === null || v === undefined) return '—';
+  return unit === 'cents' ? formatCents(v) : formatBps(v);
+}
+
+/** Mobile view: one card per month, sections stacked as readable label/value rows
+ *  (never a squeezed table). */
+export function MonthlyCloseMonthCard({ snapshot }: { snapshot: MonthlyFinancialSnapshot }) {
+  return (
+    <div
+      className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4 space-y-4"
+      data-testid="monthly-close-month-card"
+    >
+      <div className="flex items-center justify-between">
+        <h3 className="font-bold">{formatMonthLabel(snapshot.snapshotMonth)}</h3>
+        <span className="rounded-full bg-[var(--accent)] px-2 py-0.5 text-[10px] font-medium capitalize text-[var(--primary)]">
+          {snapshot.status}
+        </span>
+      </div>
+
+      {SECTIONS.map((section) => (
+        <div key={section.title}>
+          <p className="text-xs font-semibold uppercase tracking-wide text-[var(--muted-foreground)]">
+            {section.title}
+          </p>
+          <div className="mt-1 space-y-1">
+            {section.fields.map((f) => {
+              const status = f.statusKey ? statusFor(snapshot.targetStatus, f.statusKey) : undefined;
+              return (
+                <div key={f.label} className="flex items-center justify-between text-sm">
+                  <span className="text-[var(--muted-foreground)]">{f.label}</span>
+                  <span className="flex items-center gap-2 tabular-nums font-medium">
+                    {fmt(f.unit, f.get(snapshot))}
+                    {status && (
+                      <span className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium ${STATUS_CHIP_CLASSES[status]}`}>
+                        {STATUS_LABELS[status]}
+                      </span>
+                    )}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/monthly-close/status.ts
+++ b/apps/web/src/components/monthly-close/status.ts
@@ -1,0 +1,46 @@
+import type { TargetStatusLevel } from '@moneypulse/shared';
+
+/** Tailwind classes for a status chip, keyed by the calculator's target-status level. */
+export const STATUS_CHIP_CLASSES: Record<TargetStatusLevel, string> = {
+  green: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
+  yellow: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300',
+  red: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
+  info: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+  unknown: 'bg-[var(--muted)] text-[var(--muted-foreground)]',
+};
+
+export const STATUS_LABELS: Record<TargetStatusLevel, string> = {
+  green: 'On track',
+  yellow: 'Watch',
+  red: 'Off track',
+  info: 'Tracked',
+  unknown: '—',
+};
+
+/** Read a status level out of a snapshot's `targetStatus` map, defaulting to 'unknown'. */
+export function statusFor(
+  targetStatus: Record<string, string> | null | undefined,
+  key: string,
+): TargetStatusLevel {
+  const level = targetStatus?.[key];
+  if (level === 'green' || level === 'yellow' || level === 'red' || level === 'info') return level;
+  return 'unknown';
+}
+
+export function formatBps(bps: number | null | undefined): string {
+  if (bps === null || bps === undefined) return '—';
+  return `${(bps / 100).toFixed(1)}%`;
+}
+
+export function formatDelta(deltaCents: number | null): string {
+  if (deltaCents === null) return '—';
+  const sign = deltaCents > 0 ? '+' : deltaCents < 0 ? '−' : '';
+  return `${sign}$${(Math.abs(deltaCents) / 100).toFixed(0)}`;
+}
+
+/** first-of-month string -> "Mar 2026" */
+export function formatMonthLabel(month: string): string {
+  return new Intl.DateTimeFormat('en-US', { month: 'short', year: 'numeric', timeZone: 'UTC' }).format(
+    new Date(`${month.slice(0, 7)}-01T00:00:00Z`),
+  );
+}

--- a/apps/web/src/lib/hooks/useMonthlyClose.ts
+++ b/apps/web/src/lib/hooks/useMonthlyClose.ts
@@ -1,0 +1,178 @@
+'use client';
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { api } from '../api';
+import type {
+  MonthlyFinancialSnapshot,
+  PatchMonthlyCloseInput,
+  ManualAsset,
+  ManualAssetSnapshot,
+  CreateManualAssetInput,
+  UpdateManualAssetInput,
+  PutManualAssetSnapshotInput,
+  Loan,
+  LoanBalanceSnapshot,
+  PutLoanBalanceSnapshotInput,
+} from '@moneypulse/shared';
+
+const MONTHLY_CLOSE_KEY = ['monthly-close'];
+const MANUAL_ASSETS_KEY = ['manual-assets'];
+
+/** 6/12-month grid of monthly close snapshots, most recent first. */
+export function useMonthlyCloses(months: 6 | 12) {
+  return useQuery({
+    queryKey: [...MONTHLY_CLOSE_KEY, months],
+    queryFn: () =>
+      api.get<{ data: MonthlyFinancialSnapshot[] }>('/monthly-close', { params: { months } }),
+  });
+}
+
+/** One month's close (used after draft/confirm to refresh the active row). */
+export function useMonthlyClose(month: string | null) {
+  return useQuery({
+    queryKey: [...MONTHLY_CLOSE_KEY, 'one', month],
+    queryFn: () => api.get<{ data: MonthlyFinancialSnapshot }>(`/monthly-close/${month}`),
+    enabled: !!month,
+  });
+}
+
+function invalidateAll(queryClient: ReturnType<typeof useQueryClient>) {
+  queryClient.invalidateQueries({ queryKey: MONTHLY_CLOSE_KEY });
+}
+
+export function useCreateDraft() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (month: string) =>
+      api.post<{ data: MonthlyFinancialSnapshot }>(`/monthly-close/${month}/draft`, {}),
+    onSuccess: () => invalidateAll(queryClient),
+  });
+}
+
+export function useRecalculate() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (month: string) =>
+      api.post<{ data: MonthlyFinancialSnapshot }>(`/monthly-close/${month}/recalculate`, {}),
+    onSuccess: () => invalidateAll(queryClient),
+  });
+}
+
+export function usePatchClose() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ month, ...body }: PatchMonthlyCloseInput & { month: string }) =>
+      api.patch<{ data: MonthlyFinancialSnapshot }>(`/monthly-close/${month}`, body),
+    onSuccess: () => invalidateAll(queryClient),
+  });
+}
+
+export function useConfirmClose() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (month: string) =>
+      api.post<{ data: MonthlyFinancialSnapshot }>(`/monthly-close/${month}/confirm`, {}),
+    onSuccess: () => invalidateAll(queryClient),
+  });
+}
+
+export function useReopenClose() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (month: string) =>
+      api.post<{ data: MonthlyFinancialSnapshot }>(`/monthly-close/${month}/reopen`, {}),
+    onSuccess: () => invalidateAll(queryClient),
+  });
+}
+
+// ── Manual assets (home/car/gold) ───────────────────────────────
+
+export function useManualAssets() {
+  return useQuery({
+    queryKey: MANUAL_ASSETS_KEY,
+    queryFn: () => api.get<{ data: ManualAsset[] }>('/manual-assets'),
+  });
+}
+
+export function useManualAssetSnapshots(assetId: string | null) {
+  return useQuery({
+    queryKey: [...MANUAL_ASSETS_KEY, assetId, 'snapshots'],
+    queryFn: () =>
+      api.get<{ data: ManualAssetSnapshot[] }>(`/manual-assets/${assetId}/snapshots`),
+    enabled: !!assetId,
+  });
+}
+
+export function useCreateManualAsset() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: CreateManualAssetInput) =>
+      api.post<{ data: ManualAsset }>('/manual-assets', body),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: MANUAL_ASSETS_KEY }),
+  });
+}
+
+export function useUpdateManualAsset() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, ...body }: UpdateManualAssetInput & { id: string }) =>
+      api.patch<{ data: ManualAsset }>(`/manual-assets/${id}`, body),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: MANUAL_ASSETS_KEY }),
+  });
+}
+
+export function useUpsertManualAssetSnapshot() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      assetId,
+      month,
+      ...body
+    }: PutManualAssetSnapshotInput & { assetId: string; month: string }) =>
+      api.put<{ data: ManualAssetSnapshot }>(
+        `/manual-assets/${assetId}/snapshots/${month}`,
+        body,
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: MANUAL_ASSETS_KEY });
+      invalidateAll(queryClient);
+    },
+  });
+}
+
+// ── Loan verification (amortized vs manual statement balance) ───
+
+export function useLoanBalanceSnapshots(loanId: string | null) {
+  return useQuery({
+    queryKey: ['loans', loanId, 'balance-snapshots'],
+    queryFn: () =>
+      api.get<{ data: LoanBalanceSnapshot[] }>(`/loans/${loanId}/balance-snapshots`),
+    enabled: !!loanId,
+  });
+}
+
+export function useUpsertLoanBalanceSnapshot() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      loanId,
+      month,
+      ...body
+    }: PutLoanBalanceSnapshotInput & { loanId: string; month: string }) =>
+      api.put<{ data: LoanBalanceSnapshot }>(
+        `/loans/${loanId}/balance-snapshots/${month}`,
+        body,
+      ),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['loans', variables.loanId, 'balance-snapshots'] });
+      invalidateAll(queryClient);
+    },
+  });
+}
+
+export function useLoansForVerification() {
+  return useQuery({
+    queryKey: ['loans'],
+    queryFn: () => api.get<{ data: Loan[] }>('/loans'),
+  });
+}

--- a/apps/web/src/lib/nav-items.ts
+++ b/apps/web/src/lib/nav-items.ts
@@ -17,6 +17,7 @@ import {
   HandCoins,
   LayoutGrid,
   Percent,
+  Activity,
 } from 'lucide-react';
 
 export interface NavItem {
@@ -34,6 +35,7 @@ export const navItems: NavItem[] = [
   { href: '/bills', label: 'Bills', icon: CalendarClock, placement: 'tab' },
   // Drawer items
   { href: '/overview', label: 'Overview', icon: LayoutGrid, placement: 'drawer' },
+  { href: '/health', label: 'Health', icon: Activity, placement: 'drawer' },
   { href: '/accounts', label: 'Accounts', icon: Landmark, placement: 'drawer' },
   { href: '/loans', label: 'Loans', icon: HandCoins, placement: 'drawer' },
   { href: '/rate-watchlist', label: 'Rate Watchlist', icon: Percent, placement: 'drawer' },


### PR DESCRIPTION
Committed successfully. Working tree is clean and one commit ahead of origin/main.

## Summary

Implemented 13.6 — the `/health` monthly-close workspace on top of the existing 13.5 API:

- **`useMonthlyClose.ts`**: React Query hooks for the monthly-close grid (list/one/draft/recalculate/patch/confirm/reopen), manual assets (list/create/update/snapshot upsert), and loan balance verification (list/upsert snapshot).
- **`components/monthly-close/`**: `MonthlyCloseHero` (Expenses as the visual headline plus Net Worth/Savings/Investing/Debt Paydown/Liquid % cards), `MonthlyCloseGrid` (dense desktop table with sticky header/first column, tabular-nums, section grouping, inline sparkline trends, status chips, drill links from transaction-derived rows), `MonthlyCloseMonthCard` (mobile per-month card grouped by section instead of a squeezed table), `ManualAssetPanel` and `LoanVerificationPanel` (inline month editors that PUT to the manual-assets/loan-balance-snapshot endpoints, with staleness/unverified badges sourced from the close's freshness map), and `CoachOverlayPanel` (Shashank ratio strip, Ramit 4-bucket, Money Guy FOO next-dollar step, degrading gracefully when calculator-derived fields aren't present on the persisted row).
- **`app/(protected)/health/page.tsx`**: wires it all together with month picker, 6/12-month segmented control, and create-draft/confirm/reopen controls.
- Added a `Health` drawer nav item (`Activity` icon).
- Expenses total in the grid reflects the calculator's `expenseCents`, which already excludes credit-card/debt-principal transfers, so payments aren't double-counted — verified with a synthetic-data test asserting the Expenses row doesn't include the credit-card liability figure.

Verification: `pnpm --filter @moneypulse/web test monthly-close` (9/9 passing) and `pnpm --filter @moneypulse/web build` (after building the `@moneypulse/shared` workspace dependency) both succeed, with `/health` appearing in the generated route list.

---
### Test evidence
**9 new test case(s) added** (heuristic count):
```
 apps/web/src/__tests__/monthly-close.spec.tsx      | 137 +++++++++++++++
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
web:test:  [32m✓[39m src/__tests__/investment-holdings.spec.tsx [2m([22m[2m4 tests[22m[2m)[22m[33m 409[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/mobile-card.spec.tsx [2m([22m[2m8 tests[22m[2m)[22m[32m 198[2mms[22m[39m
@moneypulse/web:test: Not implemented: navigation to another Document
@moneypulse/web:test:  [32m✓[39m src/__tests__/api.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 10[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/format.spec.ts [2m([22m[2m13 tests[22m[2m)[22m[32m 18[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/split-transaction.spec.tsx [2m([22m[2m10 tests[22m[2m)[22m[33m 1015[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/add-transaction.spec.tsx [2m([22m[2m9 tests[22m[2m)[22m[33m 1103[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/pwa.spec.tsx [2m([22m[2m5 tests[22m[2m)[22m[32m 11[2mms[22m[39m
@moneypulse/web:test: 
@moneypulse/web:test: [2m Test Files [22m [1m[32m11 passed[39m[22m[90m (11)[39m
@moneypulse/web:test: [2m      Tests [22m [1m[32m87 passed[39m[22m[2m | [22m[33m3 skipped[39m[90m (90)[39m
@moneypulse/web:test: [2m   Start at [22m 12:40:15
@moneypulse/web:test: [2m   Duration [22m 2.40s[2m (transform 572ms, setup 523ms, import 2.38s, tests 3.59s, environment 7.13s)[22m
@moneypulse/web:test: 

 Tasks:    2 successful, 2 total
Cached:    0 cached, 2 total
  Time:    3.521s
```
</details>

### Review
**Review verdict:** approve

Findings (advisory — did not block landing):
- [low/correctness] apps/web/src/app/(protected)/health/page.tsx:42 — Confirm/Reopen buttons mutate on the selected `month`, but their disabled state and `current` are derived from a fallback snapshot (`snapshots[0]`) that may belong to a different month, so actions can target a month with no close.
- [low/advisory] apps/web/src/app/(protected)/health/page.tsx:63 — Clearing the native month input sets `month` to `'-01'`, producing an invalid month string passed to mutations; not a crash but should be guarded.

---
Dispatched via coxd (`MyMoney-13-6-web-health-monthly-clos-1785170029`) · cost $2.240 · 🤖 coxd