### PR TITLE
deploy-to-nas.sh api/web/all doesn't run pending DB migrations

### DIFF
--- a/deploy-to-nas.sh
+++ b/deploy-to-nas.sh
@@ -2,11 +2,15 @@
 # deploy-to-nas.sh — Sync local MoneyPulse repo to NAS and rebuild containers
 #
 # Usage:
-#   ./deploy-to-nas.sh              # Rebuild & deploy API + Web
-#   ./deploy-to-nas.sh api          # Rebuild & deploy API only
-#   ./deploy-to-nas.sh web          # Rebuild & deploy Web only
-#   ./deploy-to-nas.sh sync-only    # Just sync code, no rebuild
-#   ./deploy-to-nas.sh db:migrate   # Sync + run Drizzle migrations on NAS DB
+#   ./deploy-to-nas.sh              # Rebuild & deploy API + Web, then run pending DB migrations
+#   ./deploy-to-nas.sh api          # Rebuild & deploy API only, then run pending DB migrations
+#   ./deploy-to-nas.sh web          # Rebuild & deploy Web only, then run pending DB migrations
+#   ./deploy-to-nas.sh sync-only    # Just sync code, no rebuild, no migrations
+#   ./deploy-to-nas.sh db:migrate   # Sync + rebuild API + run Drizzle migrations on NAS DB
+#
+# Migrations are run automatically (idempotent — Drizzle skips already-applied
+# migrations) so the DB schema never silently drifts from db/migrations after a
+# normal deploy. See https://github.com/ManikantaR/MoneyPulse/issues/191
 
 set -euo pipefail
 
@@ -164,10 +168,12 @@ case "$TARGET" in
     api)
         sync_code
         build_and_deploy api
+        run_migrations
         ;;
     web)
         sync_code
         build_and_deploy web
+        run_migrations
         ;;
     db:migrate)
         sync_code
@@ -177,6 +183,7 @@ case "$TARGET" in
     all)
         sync_code
         build_and_deploy api
+        run_migrations
         build_and_deploy web
         ;;
     *)


### PR DESCRIPTION
Committed. 

## Summary

`deploy-to-nas.sh`'s `api`, `web`, and `all` targets built and redeployed containers but never invoked `run_migrations()` — that only happened via the separate `db:migrate` target. Because it's easy to forget the extra manual step, API code depending on new columns/tables could go live for hours before the schema caught up, causing runtime "column/table does not exist" errors instead of a clear deploy-time failure.

## Fix

Added a `run_migrations` call to the `api`, `web`, and `all` targets (after the api container is deployed for the targets that redeploy it), so every deploy path now leaves the DB schema in sync with `db/migrations` without a separate manual step. This is safe to run unconditionally since Drizzle's migrator skips migrations that are already applied. Updated the script's usage header to describe the new behavior.

Verified with `bash -n` for syntax correctness and by reviewing the target logic to confirm each path (`api`, `web`, `all`, `db:migrate`) now runs migrations exactly once per deploy.

---
### Test evidence
_No test files were added or modified in this change._

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
• Packages in scope: //
   • Running test in 1 packages
   • Remote caching disabled, using shared worktree cache


 Tasks:    0 successful, 0 total
Cached:    0 cached, 0 total
  Time:    79ms
```
</details>

### Review
**Review verdict:** approve

---
Dispatched via coxd (`MyMoney-deploy-to-nas-sh-api-web-all-1785197002`) · cost $0.201 · 🤖 coxd