### PR TITLE
Dashboard Net Worth drill-down doesn't tally with header; investments 

### DIFF
--- a/apps/api/src/analytics/__tests__/analytics.service.spec.ts
+++ b/apps/api/src/analytics/__tests__/analytics.service.spec.ts
@@ -266,48 +266,52 @@ describe('AnalyticsService', () => {
   });
 
   describe('netWorth', () => {
-    /** netWorth() issues 4 sequential db.execute calls in this order:
-     *  1. accounts (liquid / regular-account investments / credit-card liabilities)
-     *  2. investment_accounts (holdings-x-price else snapshot)
-     *  3. manual_assets (carry-forward)
-     *  4. loans (manual-statement else amortized)
+    /** netWorth() is built entirely from netWorthBreakdown()'s line items (see #192), which
+     *  issues 4 sequential db.execute calls in this order:
+     *  1. accounts (one row per checking/savings/cash_sweep/brokerage/edu_529/credit_card account)
+     *  2. investment_accounts (one row per account: holdings-x-price else snapshot)
+     *  3. manual_assets (one row per asset, carry-forward value)
+     *  4. loans (one row per loan: manual-statement else amortized)
      */
     function mockNetWorthQueries(overrides: {
-      acct?: any;
-      investment?: any;
-      manualAsset?: any;
+      acct?: any[];
+      investment?: any[];
+      manualAsset?: any[];
       loans?: any[];
     }) {
       mockDb.execute
-        .mockResolvedValueOnce({
-          rows: [
-            {
-              liquid_cents: '0',
-              regular_investment_cents: '0',
-              liabilities_cents: '0',
-              ...overrides.acct,
-            },
-          ],
-        })
-        .mockResolvedValueOnce({
-          rows: [
-            {
-              holdings_total_cents: '0',
-              snapshot_total_cents: '0',
-              ...overrides.investment,
-            },
-          ],
-        })
-        .mockResolvedValueOnce({
-          rows: [{ manual_asset_total_cents: '0', ...overrides.manualAsset }],
-        })
+        .mockResolvedValueOnce({ rows: overrides.acct ?? [] })
+        .mockResolvedValueOnce({ rows: overrides.investment ?? [] })
+        .mockResolvedValueOnce({ rows: overrides.manualAsset ?? [] })
         .mockResolvedValueOnce({ rows: overrides.loans ?? [] });
+    }
+
+    function acctRow(overrides: any) {
+      return {
+        account_id: 'acct-1',
+        nickname: 'Test Account',
+        institution: 'Test Bank',
+        account_type: 'checking',
+        balance_cents: '0',
+        ...overrides,
+      };
     }
 
     it('should calculate net worth with camelCase keys', async () => {
       mockNetWorthQueries({
-        acct: { liquid_cents: '800000', liabilities_cents: '150000' },
-        investment: { snapshot_total_cents: '200000' },
+        acct: [
+          acctRow({ account_type: 'checking', balance_cents: '800000' }),
+          acctRow({ account_id: 'acct-2', account_type: 'credit_card', balance_cents: '-150000' }),
+        ],
+        investment: [
+          {
+            investment_account_id: 'inv-1',
+            nickname: 'Brokerage',
+            institution: 'Vanguard',
+            account_type: 'brokerage',
+            balance_cents: '200000',
+          },
+        ],
       });
 
       const result = await service.netWorth(TEST_USER_ID, { household: false });
@@ -329,15 +333,12 @@ describe('AnalyticsService', () => {
     });
 
     it('should handle missing investment data', async () => {
-      mockDb.execute
-        .mockResolvedValueOnce({
-          rows: [
-            { liquid_cents: '500000', regular_investment_cents: '0', liabilities_cents: '100000' },
-          ],
-        })
-        .mockResolvedValueOnce({ rows: [{}] })
-        .mockResolvedValueOnce({ rows: [{}] })
-        .mockResolvedValueOnce({ rows: [] });
+      mockNetWorthQueries({
+        acct: [
+          acctRow({ account_type: 'checking', balance_cents: '500000' }),
+          acctRow({ account_id: 'acct-2', account_type: 'credit_card', balance_cents: '-100000' }),
+        ],
+      });
 
       const result = await service.netWorth(TEST_USER_ID, { household: false });
 
@@ -347,7 +348,10 @@ describe('AnalyticsService', () => {
 
     it('includes brokerage/edu_529 regular-account balances in investments, never double-counted', async () => {
       mockNetWorthQueries({
-        acct: { liquid_cents: '100000', regular_investment_cents: '50000' },
+        acct: [
+          acctRow({ account_type: 'checking', balance_cents: '100000' }),
+          acctRow({ account_id: 'acct-2', account_type: 'brokerage', balance_cents: '50000' }),
+        ],
       });
 
       const result = await service.netWorth(TEST_USER_ID, { household: false });
@@ -357,12 +361,19 @@ describe('AnalyticsService', () => {
     });
 
     it('uses holdings x price when holdings exist, ignoring any snapshot for that same total', async () => {
-      // Even if a snapshot total were non-zero, the service's holdings_total_cents
-      // and snapshot_total_cents come from mutually exclusive per-account SQL CTEs
-      // (an account contributes to exactly one), so summing both here is safe and
-      // reflects that no account is counted twice.
+      // The service's per-investment-account balance comes from a SQL CASE that picks
+      // holdings-value when holdings exist, else the latest snapshot — never both — so
+      // a single row's balance_cents already reflects that exclusivity.
       mockNetWorthQueries({
-        investment: { holdings_total_cents: '300000', snapshot_total_cents: '0' },
+        investment: [
+          {
+            investment_account_id: 'inv-1',
+            nickname: 'Brokerage',
+            institution: 'Vanguard',
+            account_type: 'brokerage',
+            balance_cents: '300000',
+          },
+        ],
       });
 
       const result = await service.netWorth(TEST_USER_ID, { household: false });
@@ -372,8 +383,8 @@ describe('AnalyticsService', () => {
 
     it('includes manual assets (home/car/gold/other) in total assets', async () => {
       mockNetWorthQueries({
-        acct: { liquid_cents: '100000' },
-        manualAsset: { manual_asset_total_cents: '400000' },
+        acct: [acctRow({ account_type: 'checking', balance_cents: '100000' })],
+        manualAsset: [{ id: 'ma-1', name: 'Home', asset_type: 'home', value_cents: '400000' }],
       });
 
       const result = await service.netWorth(TEST_USER_ID, { household: false });
@@ -384,9 +395,12 @@ describe('AnalyticsService', () => {
 
     it('subtracts loan liabilities: manual-statement balance wins over amortized calc', async () => {
       mockNetWorthQueries({
-        acct: { liquid_cents: '1000000' },
+        acct: [acctRow({ account_type: 'checking', balance_cents: '1000000' })],
         loans: [
           {
+            id: 'loan-1',
+            name: 'Mortgage',
+            loan_type: 'mortgage',
             original_balance_cents: '10000000',
             apr_bps: '400',
             scheduled_payment_cents: '50000',
@@ -405,9 +419,12 @@ describe('AnalyticsService', () => {
 
     it('falls back to amortized loan balance when no manual statement snapshot exists', async () => {
       mockNetWorthQueries({
-        acct: { liquid_cents: '1000000' },
+        acct: [acctRow({ account_type: 'checking', balance_cents: '1000000' })],
         loans: [
           {
+            id: 'loan-1',
+            name: 'Mortgage',
+            loan_type: 'mortgage',
             original_balance_cents: '10000000',
             apr_bps: '400',
             scheduled_payment_cents: '50000',
@@ -424,6 +441,85 @@ describe('AnalyticsService', () => {
       // less than the original balance (payments have been applied) but still positive.
       expect(result.liabilities).toBeGreaterThan(0);
       expect(result.liabilities).toBeLessThan(10000000);
+    });
+
+    it('always equals the sum of netWorthBreakdown()\'s own line items (invariant, #192)', async () => {
+      mockNetWorthQueries({
+        acct: [
+          acctRow({ account_type: 'checking', balance_cents: '800000' }),
+          acctRow({ account_id: 'acct-2', account_type: 'brokerage', balance_cents: '50000' }),
+          acctRow({ account_id: 'acct-3', account_type: 'credit_card', balance_cents: '-150000' }),
+        ],
+        investment: [
+          {
+            investment_account_id: 'inv-1',
+            nickname: 'Brokerage',
+            institution: 'Vanguard',
+            account_type: 'brokerage',
+            balance_cents: '200000',
+          },
+        ],
+        manualAsset: [{ id: 'ma-1', name: 'Home', asset_type: 'home', value_cents: '400000' }],
+        loans: [
+          {
+            id: 'loan-1',
+            name: 'Mortgage',
+            loan_type: 'mortgage',
+            original_balance_cents: '10000000',
+            apr_bps: '400',
+            scheduled_payment_cents: '50000',
+            start_date: '2020-01-01',
+            manual_balance_cents: '9500000',
+            latest_source: 'manual_statement',
+          },
+        ],
+      });
+      const nw = await service.netWorth(TEST_USER_ID, { household: false });
+
+      mockNetWorthQueries({
+        acct: [
+          acctRow({ account_type: 'checking', balance_cents: '800000' }),
+          acctRow({ account_id: 'acct-2', account_type: 'brokerage', balance_cents: '50000' }),
+          acctRow({ account_id: 'acct-3', account_type: 'credit_card', balance_cents: '-150000' }),
+        ],
+        investment: [
+          {
+            investment_account_id: 'inv-1',
+            nickname: 'Brokerage',
+            institution: 'Vanguard',
+            account_type: 'brokerage',
+            balance_cents: '200000',
+          },
+        ],
+        manualAsset: [{ id: 'ma-1', name: 'Home', asset_type: 'home', value_cents: '400000' }],
+        loans: [
+          {
+            id: 'loan-1',
+            name: 'Mortgage',
+            loan_type: 'mortgage',
+            original_balance_cents: '10000000',
+            apr_bps: '400',
+            scheduled_payment_cents: '50000',
+            start_date: '2020-01-01',
+            manual_balance_cents: '9500000',
+            latest_source: 'manual_statement',
+          },
+        ],
+      });
+      const breakdown = await service.netWorthBreakdown(TEST_USER_ID, { household: false });
+      const sum = (items: Array<{ balanceCents: number }>) =>
+        items.reduce((s, i) => s + i.balanceCents, 0);
+
+      expect(
+        sum(breakdown.assets.liquid) +
+          sum(breakdown.assets.investments) +
+          sum(breakdown.assets.manualAssets),
+      ).toBe(nw.assets);
+      expect(sum(breakdown.assets.investments)).toBe(nw.investments);
+      expect(sum(breakdown.liabilities.creditCards) + sum(breakdown.liabilities.loans)).toBe(
+        nw.liabilities,
+      );
+      expect(nw.assets - nw.liabilities).toBe(nw.netWorth);
     });
   });
 

--- a/apps/api/src/analytics/analytics.controller.ts
+++ b/apps/api/src/analytics/analytics.controller.ts
@@ -178,6 +178,31 @@ export class AnalyticsController {
   }
 
   /**
+   * GET /analytics/net-worth-breakdown — Line-item detail behind each `net-worth` total,
+   * so the dashboard's drill-down panel can show exactly the accounts/assets/loans that
+   * sum to the hero card's assets/liabilities/investments figures (see #192).
+   * Scoped to the authenticated user or their household.
+   *
+   * @param query - Validated household filter parameter.
+   * @param user - JWT token payload containing user identity.
+   * @returns `{ data: NetWorthBreakdown }`
+   * @throws {UnauthorizedException} If the request is not authenticated.
+   */
+  @Get('net-worth-breakdown')
+  @ApiOperation({ summary: 'Net worth breakdown (line items)' })
+  async netWorthBreakdown(
+    @Query(new ZodValidationPipe(analyticsQuerySchema)) query: AnalyticsQuery,
+    @CurrentUser() user: AuthTokenPayload,
+  ) {
+    const data = await this.analyticsService.netWorthBreakdown(
+      user.sub,
+      { household: query.household },
+      user.householdId,
+    );
+    return { data };
+  }
+
+  /**
    * GET /analytics/net-worth-deltas — 30/90/365-day net-worth deltas from stored snapshots.
    *
    * @param user - JWT token payload containing user identity.

--- a/apps/api/src/analytics/analytics.service.ts
+++ b/apps/api/src/analytics/analytics.service.ts
@@ -11,6 +11,29 @@ import type {
 import { annualCostCents } from '../bills/bills.service';
 import { computeLoanState } from '@moneypulse/shared';
 
+/** A single contributing row in the net-worth breakdown (one account/asset/loan). */
+export interface LineItem {
+  id: string;
+  nickname: string;
+  institution: string | null;
+  accountType: string;
+  balanceCents: number;
+  source: 'account' | 'investment_account' | 'manual_asset' | 'loan';
+}
+
+/** Net-worth totals, expressed as the line items that sum to each of `netWorth()`'s figures. */
+export interface NetWorthBreakdown {
+  assets: {
+    liquid: LineItem[];
+    investments: LineItem[];
+    manualAssets: LineItem[];
+  };
+  liabilities: {
+    creditCards: LineItem[];
+    loans: LineItem[];
+  };
+}
+
 @Injectable()
 export class AnalyticsService {
   constructor(@Inject(DATABASE_CONNECTION) private readonly db: any) {}
@@ -324,6 +347,46 @@ export class AnalyticsService {
     query: Pick<AnalyticsQuery, 'household'>,
     householdId?: string | null,
   ) {
+    const breakdown = await this.netWorthBreakdown(userId, query, householdId);
+    const sum = (items: Array<{ balanceCents: number }>) =>
+      items.reduce((s, i) => s + i.balanceCents, 0);
+
+    const liquidCents = sum(breakdown.assets.liquid);
+    const investmentCents = sum(breakdown.assets.investments);
+    const manualAssetCents = sum(breakdown.assets.manualAssets);
+    const creditCardLiabilityCents = sum(breakdown.liabilities.creditCards);
+    const loanLiabilityCents = sum(breakdown.liabilities.loans);
+
+    const assets = liquidCents + investmentCents + manualAssetCents;
+    const liabilities = creditCardLiabilityCents + loanLiabilityCents;
+
+    return {
+      assets,
+      liabilities,
+      investments: investmentCents,
+      netWorth: assets - liabilities,
+    };
+  }
+
+  /**
+   * Returns the same net-worth aggregation as `netWorth()`, but as line items (one row
+   * per contributing account/asset/loan) instead of pre-summed totals. `netWorth()` is
+   * built FROM this method's output (summing each bucket) so the dashboard's hero totals
+   * and the drill-down panel's line items can never drift out of sync with each other —
+   * see #192.
+   *
+   * @param {string} userId - The authenticated user's ID.
+   * @param {Pick<AnalyticsQuery, 'household'>} query - Household flag for scoping.
+   * @param {string | null} [householdId] - Optional household ID for multi-user scoping.
+   * @returns {Promise<NetWorthBreakdown>} Line items grouped into
+   *   assets.{liquid,investments,manualAssets} and liabilities.{creditCards,loans}.
+   * @throws {Error} If the database query fails.
+   */
+  async netWorthBreakdown(
+    userId: string,
+    query: Pick<AnalyticsQuery, 'household'>,
+    householdId?: string | null,
+  ): Promise<NetWorthBreakdown> {
     const acctUserScope = householdId && query.household
       ? sql`a.user_id IN (SELECT id FROM ${schema.users} WHERE household_id = ${householdId})`
       : sql`a.user_id = ${userId}`;
@@ -337,27 +400,15 @@ export class AnalyticsService {
       ? sql`l.user_id IN (SELECT id FROM ${schema.users} WHERE household_id = ${householdId})`
       : sql`l.user_id = ${userId}`;
 
-    // Liquid (checking/savings/cash_sweep), regular-account investments
-    // (brokerage/edu_529 held directly on `accounts`, not via investment_accounts),
-    // and credit-card liabilities — all computed the same way (starting balance +
-    // summed non-deleted transactions).
+    // Regular `accounts` rows (checking/savings/cash_sweep/brokerage/edu_529/credit_card),
+    // one row per account, balance = starting balance + summed non-deleted transactions.
     const acctRows = await this.db.execute(sql`
       SELECT
-        SUM(CASE
-          WHEN a.account_type IN ('checking', 'savings', 'cash_sweep') THEN
-            a.starting_balance_cents + COALESCE(sub.net, 0)
-          ELSE 0
-        END) AS liquid_cents,
-        SUM(CASE
-          WHEN a.account_type IN ('brokerage', 'edu_529') THEN
-            a.starting_balance_cents + COALESCE(sub.net, 0)
-          ELSE 0
-        END) AS regular_investment_cents,
-        SUM(CASE
-          WHEN a.account_type = 'credit_card' THEN
-            ABS(a.starting_balance_cents + COALESCE(sub.net, 0))
-          ELSE 0
-        END) AS liabilities_cents
+        a.id AS account_id,
+        a.nickname,
+        a.institution,
+        a.account_type,
+        a.starting_balance_cents + COALESCE(sub.net, 0) AS balance_cents
       FROM ${schema.accounts} a
       LEFT JOIN LATERAL (
         SELECT SUM(
@@ -371,17 +422,36 @@ export class AnalyticsService {
       WHERE a.deleted_at IS NULL
         AND ${acctUserScope}
     `);
-    const acctRow = this.extractRows(acctRows)[0] || {
-      liquid_cents: 0,
-      regular_investment_cents: 0,
-      liabilities_cents: 0,
-    };
+
+    const liquid: LineItem[] = [];
+    const regularInvestments: LineItem[] = [];
+    const creditCards: LineItem[] = [];
+    for (const r of this.extractRows(acctRows)) {
+      const item: LineItem = {
+        id: r.account_id,
+        nickname: r.nickname,
+        institution: r.institution,
+        accountType: r.account_type,
+        balanceCents:
+          r.account_type === 'credit_card'
+            ? Math.abs(Number(r.balance_cents))
+            : Number(r.balance_cents),
+        source: 'account',
+      };
+      if (['checking', 'savings', 'cash_sweep'].includes(r.account_type)) {
+        liquid.push(item);
+      } else if (['brokerage', 'edu_529'].includes(r.account_type)) {
+        regularInvestments.push(item);
+      } else if (r.account_type === 'credit_card') {
+        creditCards.push(item);
+      }
+    }
 
     // Manual investment_accounts (Phase 8): per account, holdings x latest EOD
     // close when holdings exist, else the latest manual snapshot — never both.
     const investmentRows = await this.db.execute(sql`
       WITH acct AS (
-        SELECT ia.id,
+        SELECT ia.id, ia.nickname, ia.institution, ia.account_type,
           EXISTS (
             SELECT 1 FROM ${schema.investmentHoldings} ih
             WHERE ih.investment_account_id = ia.id
@@ -404,31 +474,39 @@ export class AnalyticsService {
           LIMIT 1
         ) sp ON true
         GROUP BY ih.investment_account_id
-      ),
-      snapshot_value AS (
-        SELECT acct.id AS investment_account_id, snap.balance_cents
-        FROM acct
-        LEFT JOIN LATERAL (
-          SELECT balance_cents
-          FROM ${schema.investmentSnapshots} s
-          WHERE s.investment_account_id = acct.id
-          ORDER BY s.date DESC, s.created_at DESC
-          LIMIT 1
-        ) snap ON true
-        WHERE NOT acct.has_holdings
       )
       SELECT
-        COALESCE((SELECT SUM(value_cents) FROM holdings_value), 0) AS holdings_total_cents,
-        COALESCE((SELECT SUM(balance_cents) FROM snapshot_value), 0) AS snapshot_total_cents
+        acct.id AS investment_account_id,
+        acct.nickname,
+        acct.institution,
+        acct.account_type,
+        CASE
+          WHEN acct.has_holdings THEN COALESCE(hv.value_cents, 0)
+          ELSE COALESCE((
+            SELECT s.balance_cents
+            FROM ${schema.investmentSnapshots} s
+            WHERE s.investment_account_id = acct.id
+            ORDER BY s.date DESC, s.created_at DESC
+            LIMIT 1
+          ), 0)
+        END AS balance_cents
+      FROM acct
+      LEFT JOIN holdings_value hv ON hv.investment_account_id = acct.id
     `);
-    const investmentRow = this.extractRows(investmentRows)[0] || {
-      holdings_total_cents: 0,
-      snapshot_total_cents: 0,
-    };
+    const investmentAccountItems: LineItem[] = this.extractRows(investmentRows).map(
+      (r: any) => ({
+        id: r.investment_account_id,
+        nickname: r.nickname,
+        institution: r.institution,
+        accountType: r.account_type,
+        balanceCents: Number(r.balance_cents),
+        source: 'investment_account' as const,
+      }),
+    );
 
     // Manual assets (home/car/gold/other): latest carry-forward value per asset.
     const manualAssetRows = await this.db.execute(sql`
-      SELECT COALESCE(SUM(latest.value_cents), 0) AS manual_asset_total_cents
+      SELECT ma.id, ma.name, ma.asset_type, latest.value_cents
       FROM ${schema.manualAssets} ma
       LEFT JOIN LATERAL (
         SELECT value_cents
@@ -440,13 +518,23 @@ export class AnalyticsService {
       WHERE ma.deleted_at IS NULL
         AND ${maUserScope}
     `);
-    const manualAssetCents = Number(
-      this.extractRows(manualAssetRows)[0]?.manual_asset_total_cents ?? 0,
+    const manualAssetItems: LineItem[] = this.extractRows(manualAssetRows).map(
+      (r: any) => ({
+        id: r.id,
+        nickname: r.name,
+        institution: null,
+        accountType: r.asset_type,
+        balanceCents: Number(r.value_cents ?? 0),
+        source: 'manual_asset' as const,
+      }),
     );
 
     // Loans: manual-statement-wins else amortized via computeLoanState.
     const loanRows = await this.db.execute(sql`
       SELECT
+        l.id,
+        l.name,
+        l.loan_type,
         l.original_balance_cents,
         l.apr_bps,
         l.scheduled_payment_cents,
@@ -465,11 +553,11 @@ export class AnalyticsService {
         AND l.is_active = true
         AND ${loanUserScope}
     `);
-    const loanLiabilityCents = this.extractRows(loanRows).reduce(
-      (sum: number, l: any) => {
-        if (l.latest_source === 'manual_statement' && l.manual_balance_cents != null) {
-          return sum + Number(l.manual_balance_cents);
-        }
+    const loanItems: LineItem[] = this.extractRows(loanRows).map((l: any) => {
+      let balanceCents: number;
+      if (l.latest_source === 'manual_statement' && l.manual_balance_cents != null) {
+        balanceCents = Number(l.manual_balance_cents);
+      } else {
         const state = computeLoanState(
           {
             originalBalanceCents: Number(l.original_balance_cents),
@@ -479,27 +567,28 @@ export class AnalyticsService {
           },
           [],
         );
-        return sum + state.currentBalanceCents;
-      },
-      0,
-    );
-
-    const liquidCents = Number(acctRow.liquid_cents ?? 0);
-    const regularInvestmentCents = Number(acctRow.regular_investment_cents ?? 0);
-    const creditCardLiabilityCents = Number(acctRow.liabilities_cents ?? 0);
-    const investmentCents =
-      Number(investmentRow.holdings_total_cents ?? 0) +
-      Number(investmentRow.snapshot_total_cents ?? 0) +
-      regularInvestmentCents;
-
-    const assets = liquidCents + investmentCents + manualAssetCents;
-    const liabilities = creditCardLiabilityCents + loanLiabilityCents;
+        balanceCents = state.currentBalanceCents;
+      }
+      return {
+        id: l.id,
+        nickname: l.name,
+        institution: null,
+        accountType: l.loan_type,
+        balanceCents,
+        source: 'loan' as const,
+      };
+    });
 
     return {
-      assets,
-      liabilities,
-      investments: investmentCents,
-      netWorth: assets - liabilities,
+      assets: {
+        liquid,
+        investments: [...investmentAccountItems, ...regularInvestments],
+        manualAssets: manualAssetItems,
+      },
+      liabilities: {
+        creditCards,
+        loans: loanItems,
+      },
     };
   }
 

--- a/apps/web/src/app/(protected)/page.tsx
+++ b/apps/web/src/app/(protected)/page.tsx
@@ -27,6 +27,7 @@ import {
   useAccountBalances,
   useCreditUtilization,
   useNetWorth,
+  useNetWorthBreakdown,
   useTopMerchants,
   useCreditCardPayments,
   useSavingsRate,
@@ -56,7 +57,7 @@ export default function DashboardPage() {
   const trendTo = format(new Date(), 'yyyy-MM-dd');
 
   // Drilldown slide-over state
-  const [drilldown, setDrilldown] = useState<'assets' | 'liabilities' | null>(null);
+  const [drilldown, setDrilldown] = useState<'assets' | 'liabilities' | 'investments' | null>(null);
 
   /** Navigate to transactions page with pre-filled filters for drill-down. */
   const drillTo = useCallback(
@@ -75,6 +76,7 @@ export default function DashboardPage() {
   const { data: balances, isLoading: balLoading } = useAccountBalances(params);
   const { data: credit, isLoading: creditLoading } = useCreditUtilization(params);
   const { data: netWorthData, isLoading: nwLoading } = useNetWorth(params);
+  const { data: netWorthBreakdown } = useNetWorthBreakdown(params);
   const { data: merchants, isLoading: merchLoading } = useTopMerchants(params);
   const { data: ccPayments, isLoading: ccLoading } = useCreditCardPayments(params);
   const { data: upcomingBills } = useUpcomingBills();
@@ -148,6 +150,7 @@ export default function DashboardPage() {
           netWorth={nw.netWorth}
           onClickAssets={() => setDrilldown('assets')}
           onClickLiabilities={() => setDrilldown('liabilities')}
+          onClickInvestments={() => setDrilldown('investments')}
         />
       )}
 
@@ -385,11 +388,11 @@ export default function DashboardPage() {
         </div>
       )}
 
-      {/* Assets / Liabilities drilldown slide-over */}
-      {drilldown && balances?.data && (
+      {/* Assets / Liabilities / Investments drilldown slide-over */}
+      {drilldown && netWorthBreakdown?.data && (
         <NetWorthDrilldown
           type={drilldown}
-          accounts={balances.data}
+          breakdown={netWorthBreakdown.data}
           onClose={() => setDrilldown(null)}
           from={from}
           to={to}

--- a/apps/web/src/components/NetWorthDrilldown.tsx
+++ b/apps/web/src/components/NetWorthDrilldown.tsx
@@ -1,39 +1,78 @@
 'use client';
 
-import { X, Wallet, CreditCard, TrendingUp, ExternalLink } from 'lucide-react';
+import { X, Wallet, CreditCard, LineChart, TrendingUp, ExternalLink } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { formatCents } from '@/lib/format';
-import type { AccountBalanceItem } from '@/lib/hooks/useAnalytics';
+import type { NetWorthBreakdown, NetWorthLineItem } from '@/lib/hooks/useAnalytics';
 
-const ASSET_TYPES = ['checking', 'savings', 'investment'];
-const LIABILITY_TYPES = ['credit_card'];
+export type DrilldownType = 'assets' | 'liabilities' | 'investments';
 
 interface NetWorthDrilldownProps {
-  type: 'assets' | 'liabilities';
-  accounts: AccountBalanceItem[];
+  type: DrilldownType;
+  breakdown: NetWorthBreakdown;
   onClose: () => void;
   from?: string;
   to?: string;
 }
 
-/** Slide-over panel showing per-account breakdown for assets or liabilities. */
-export function NetWorthDrilldown({ type, accounts, onClose, from, to }: NetWorthDrilldownProps) {
-  const router = useRouter();
-  const isAssets = type === 'assets';
-  const filtered = accounts.filter((a) =>
-    isAssets ? ASSET_TYPES.includes(a.accountType) : LIABILITY_TYPES.includes(a.accountType),
-  );
-  const total = filtered.reduce((s, a) => s + a.balanceCents, 0);
+const THEME: Record<DrilldownType, { label: string; icon: typeof Wallet; color: string }> = {
+  assets: { label: 'Total Assets', icon: Wallet, color: 'var(--secondary)' },
+  liabilities: { label: 'Total Liabilities', icon: CreditCard, color: 'var(--destructive)' },
+  investments: { label: 'Total Investments', icon: LineChart, color: 'var(--primary)' },
+};
 
-  function typeLabel(accountType: string) {
-    return accountType.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+/** Returns the line items making up a given drill type, guaranteed (structurally, via the
+ *  shared `netWorthBreakdown()` backend query) to sum to the same total shown on the hero card. */
+function itemsFor(type: DrilldownType, breakdown: NetWorthBreakdown): NetWorthLineItem[] {
+  if (type === 'assets') {
+    return [
+      ...breakdown.assets.liquid,
+      ...breakdown.assets.investments,
+      ...breakdown.assets.manualAssets,
+    ];
   }
+  if (type === 'liabilities') {
+    return [...breakdown.liabilities.creditCards, ...breakdown.liabilities.loans];
+  }
+  return breakdown.assets.investments;
+}
 
-  function viewTransactions(accountId: string, nickname: string) {
-    const params = new URLSearchParams({ accountId, drill: `${nickname} transactions` });
+function typeLabel(accountType: string) {
+  return accountType.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/** Slide-over panel showing per-line-item breakdown for assets, liabilities, or investments. */
+export function NetWorthDrilldown({ type, breakdown, onClose, from, to }: NetWorthDrilldownProps) {
+  const router = useRouter();
+  const items = itemsFor(type, breakdown);
+  const total = items.reduce((s, i) => s + i.balanceCents, 0);
+  const theme = THEME[type];
+  const Icon = theme.icon;
+
+  function viewDetails(item: NetWorthLineItem) {
+    if (item.source === 'loan') {
+      router.push('/loans');
+      return;
+    }
+    if (item.source === 'manual_asset') {
+      router.push('/health');
+      return;
+    }
+    if (item.source === 'investment_account') {
+      router.push('/investments');
+      return;
+    }
+    const params = new URLSearchParams({ accountId: item.id, drill: `${item.nickname} transactions` });
     if (from) params.set('from', from);
     if (to) params.set('to', to);
     router.push(`/transactions?${params.toString()}`);
+  }
+
+  function detailLabel(item: NetWorthLineItem) {
+    if (item.source === 'loan') return 'View loan';
+    if (item.source === 'manual_asset') return 'View details';
+    if (item.source === 'investment_account') return 'View investments';
+    return 'View transactions';
   }
 
   return (
@@ -49,32 +88,20 @@ export function NetWorthDrilldown({ type, accounts, onClose, from, to }: NetWort
       <div
         role="dialog"
         aria-modal="true"
-        aria-label={isAssets ? 'Assets Breakdown' : 'Liabilities Breakdown'}
+        aria-label={theme.label}
         className="fixed inset-y-0 right-0 z-50 flex w-full max-w-sm flex-col bg-[var(--card)] shadow-2xl"
       >
         {/* Header */}
         <div className="flex items-start justify-between border-b border-[var(--border)] p-6">
           <div className="flex items-center gap-3">
-            <div
-              className={`rounded-xl p-2.5 ${
-                isAssets ? 'bg-[var(--secondary)]/10' : 'bg-[var(--destructive)]/10'
-              }`}
-            >
-              {isAssets ? (
-                <Wallet className="h-5 w-5 text-[var(--secondary)]" />
-              ) : (
-                <CreditCard className="h-5 w-5 text-[var(--destructive)]" />
-              )}
+            <div className="rounded-xl p-2.5" style={{ backgroundColor: `color-mix(in srgb, ${theme.color} 10%, transparent)` }}>
+              <Icon className="h-5 w-5" style={{ color: theme.color }} />
             </div>
             <div>
               <p className="text-xs font-bold uppercase tracking-widest text-[var(--muted-foreground)]">
-                {isAssets ? 'Total Assets' : 'Total Liabilities'}
+                {theme.label}
               </p>
-              <p
-                className={`text-2xl font-extrabold tabular-nums ${
-                  isAssets ? 'text-[var(--secondary)]' : 'text-[var(--destructive)]'
-                }`}
-              >
+              <p className="text-2xl font-extrabold tabular-nums" style={{ color: theme.color }}>
                 {formatCents(total)}
               </p>
             </div>
@@ -88,46 +115,46 @@ export function NetWorthDrilldown({ type, accounts, onClose, from, to }: NetWort
           </button>
         </div>
 
-        {/* Account list */}
+        {/* Line item list */}
         <div className="flex-1 overflow-y-auto p-6 space-y-2.5">
-          {filtered.length === 0 ? (
+          {items.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-12 text-center">
               <TrendingUp className="h-10 w-10 text-[var(--muted-foreground)] mb-3 opacity-40" />
               <p className="text-sm font-medium text-[var(--muted-foreground)]">
-                No {isAssets ? 'asset' : 'liability'} accounts found
+                No {type} found
               </p>
               <p className="text-xs text-[var(--muted-foreground)] mt-1 opacity-60">
                 Add accounts on the Accounts page
               </p>
             </div>
           ) : (
-            filtered
+            [...items]
               .sort((a, b) => Math.abs(b.balanceCents) - Math.abs(a.balanceCents))
-              .map((acc) => (
+              .map((item) => (
                 <div
-                  key={acc.accountId}
+                  key={`${item.source}-${item.id}`}
                   className="rounded-xl bg-[var(--surface-container-low)] px-4 py-3.5"
                 >
                   <div className="flex items-center justify-between">
                     <div className="min-w-0">
-                      <p className="font-semibold text-sm truncate">{acc.nickname}</p>
+                      <p className="font-semibold text-sm truncate">{item.nickname}</p>
                       <p className="text-xs text-[var(--muted-foreground)] capitalize mt-0.5">
-                        {acc.institution} · {typeLabel(acc.accountType)}
+                        {item.institution ? `${item.institution} · ` : ''}
+                        {typeLabel(item.accountType)}
                       </p>
                     </div>
                     <p
-                      className={`shrink-0 font-bold tabular-nums text-sm ml-4 ${
-                        isAssets ? 'text-[var(--secondary)]' : 'text-[var(--destructive)]'
-                      }`}
+                      className="shrink-0 font-bold tabular-nums text-sm ml-4"
+                      style={{ color: theme.color }}
                     >
-                      {formatCents(acc.balanceCents)}
+                      {formatCents(item.balanceCents)}
                     </p>
                   </div>
                   <button
-                    onClick={() => viewTransactions(acc.accountId, acc.nickname)}
+                    onClick={() => viewDetails(item)}
                     className="mt-2 flex items-center gap-1 text-xs font-semibold text-[var(--primary)] hover:underline"
                   >
-                    View transactions <ExternalLink className="h-3 w-3" />
+                    {detailLabel(item)} <ExternalLink className="h-3 w-3" />
                   </button>
                 </div>
               ))
@@ -137,7 +164,7 @@ export function NetWorthDrilldown({ type, accounts, onClose, from, to }: NetWort
         {/* Footer */}
         <div className="border-t border-[var(--border)] px-6 py-4">
           <p className="text-xs text-[var(--muted-foreground)]">
-            Balances computed from imported transactions + starting balance.
+            Balances computed the same way as the Net Worth card above — this total always matches.
           </p>
         </div>
       </div>

--- a/apps/web/src/components/charts/NetWorthCard.tsx
+++ b/apps/web/src/components/charts/NetWorthCard.tsx
@@ -9,6 +9,7 @@ interface NetWorthCardProps {
   netWorth: number;
   onClickAssets?: () => void;
   onClickLiabilities?: () => void;
+  onClickInvestments?: () => void;
 }
 
 /** Large summary card showing net worth breakdown with trend indicator. */
@@ -19,6 +20,7 @@ export function NetWorthCard({
   netWorth,
   onClickAssets,
   onClickLiabilities,
+  onClickInvestments,
 }: NetWorthCardProps) {
   const isPositive = netWorth >= 0;
 
@@ -84,16 +86,25 @@ export function NetWorthCard({
           </p>
         </button>
 
-        {/* Investments — static */}
-        <div className="flex flex-col gap-1 rounded-xl p-2 -mx-2">
-          <div className="flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-widest text-[var(--muted-foreground)]">
-            <LineChart className="h-3.5 w-3.5" />
-            Investments
+        {/* Investments — clickable */}
+        <button
+          onClick={onClickInvestments}
+          disabled={!onClickInvestments}
+          className="group flex flex-col gap-1 rounded-xl p-2 -mx-2 text-left transition-colors enabled:hover:bg-[var(--muted)] disabled:cursor-default"
+        >
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-widest text-[var(--muted-foreground)]">
+              <LineChart className="h-3.5 w-3.5" />
+              Investments
+            </div>
+            {onClickInvestments && (
+              <ChevronRight className="h-3.5 w-3.5 text-[var(--muted-foreground)] opacity-0 group-hover:opacity-100 transition-opacity" />
+            )}
           </div>
           <p className="text-lg font-bold text-[var(--primary)] tabular-nums">
             {formatCents(investments)}
           </p>
-        </div>
+        </button>
       </div>
 
       {/* Bottom accent bar */}

--- a/apps/web/src/lib/hooks/useAnalytics.ts
+++ b/apps/web/src/lib/hooks/useAnalytics.ts
@@ -55,6 +55,29 @@ export interface CreditUtilizationItem {
   utilizationPercent: number;
 }
 
+/** A single contributing row behind a net-worth total (one account/asset/loan). */
+export interface NetWorthLineItem {
+  id: string;
+  nickname: string;
+  institution: string | null;
+  accountType: string;
+  balanceCents: number;
+  source: 'account' | 'investment_account' | 'manual_asset' | 'loan';
+}
+
+/** Line-item detail behind each `net-worth` total — see `useNetWorth`. */
+export interface NetWorthBreakdown {
+  assets: {
+    liquid: NetWorthLineItem[];
+    investments: NetWorthLineItem[];
+    manualAssets: NetWorthLineItem[];
+  };
+  liabilities: {
+    creditCards: NetWorthLineItem[];
+    loans: NetWorthLineItem[];
+  };
+}
+
 /** Net worth aggregation. */
 export interface NetWorthData {
   assets: number;
@@ -147,6 +170,15 @@ export function useNetWorth(params: AnalyticsParams = {}) {
     queryKey: ['analytics', 'net-worth', params],
     queryFn: () =>
       api.get<{ data: NetWorthData }>('/analytics/net-worth', { params }),
+  });
+}
+
+/** Fetch line-item detail behind the net-worth totals (for the drill-down panel). */
+export function useNetWorthBreakdown(params: AnalyticsParams = {}) {
+  return useQuery({
+    queryKey: ['analytics', 'net-worth-breakdown', params],
+    queryFn: () =>
+      api.get<{ data: NetWorthBreakdown }>('/analytics/net-worth-breakdown', { params }),
   });
 }
 


### PR DESCRIPTION
Committed successfully.

## Summary

**Root cause:** `NetWorthDrilldown.tsx` predated the #161 `netWorth()` rewrite. It read from `/analytics/account-balances` (regular `accounts` table only) with a stale `LIABILITY_TYPES = ['credit_card']` (loans entirely missing) and `ASSET_TYPES = ['checking','savings','investment']` (`'investment'` isn't a real enum value, so it matched nothing, and `cash_sweep`/manual assets/`investment_accounts` were never included). This meant the panel's own total could never match the hero card whenever a loan existed, and there was no "investments" drill-down at all.

**Fix:**
- Added `AnalyticsService.netWorthBreakdown()`, which returns line items (one row per contributing account / investment_account / manual_asset / loan), and refactored `netWorth()` to *sum those same line items* rather than running an independently-maintained aggregate query — so the header and drill-down totals are now structurally guaranteed to match, not just coincidentally equal.
- Exposed this via a new `GET /analytics/net-worth-breakdown` endpoint.
- Rewrote `NetWorthDrilldown.tsx` to consume the new endpoint with three drill types — **assets**, **liabilities**, **investments** — each item linking to the right detail page (regular accounts → `/transactions`, investment accounts → `/investments`, loans → `/loans`, manual assets → `/health`).
- Made the dashboard's "Investments" hero figure clickable (`NetWorthCard`) the same way Assets/Liabilities already were, wired to the new `investments` drill type.

**Verification:**
- Updated/added unit tests in `analytics.service.spec.ts`, including a new invariant test asserting the sum of each breakdown bucket always equals the corresponding `netWorth()` total (structurally, since both are now derived from the same per-line-item queries).
- Ran the full analytics unit test suite (139 tests passed) and `tsc --noEmit` for both `apps/api` and `apps/web` — no new type errors.

---
### Test evidence
**1 new test case(s) added** (heuristic count):
```
 .../analytics/__tests__/analytics.service.spec.ts  | 198 +++++++++++++-----
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
2m2 tests[22m[2m)[22m[32m 9[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/sync-delivery.processor.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 4[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/next-loan-due-date.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/categorization/__tests__/learning.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test: [32m[Nest] 87086  - [39m07/28/2026, 12:13:41 AM [32m    LOG[39m [38;5;3m[AlertCronProcessor] [39m[32mProcessing alert job: monthly-close-auto-draft[39m
@moneypulse/api:test: [32m[Nest] 87086  - [39m07/28/2026, 12:13:41 AM [32m    LOG[39m [38;5;3m[AlertCronProcessor] [39m[32mMonthly-close auto-draft: 3 user(s) processed, 2 close(s) created[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/monthly-close-cron.spec.ts [2m([22m[2m1 test[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m95 passed[39m[22m[90m (95)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m795 passed[39m[22m[90m (795)[39m
@moneypulse/api:test: [2m   Start at [22m 00:13:27
@moneypulse/api:test: [2m   Duration [22m 14.05s[2m (transform 4.76s, setup 0ms, import 76.91s, tests 3.29s, environment 6ms)[22m
@moneypulse/api:test: 

 Tasks:    3 successful, 3 total
Cached:    1 cached, 3 total
  Time:    14.686s
```
</details>

### Review
**Review verdict:** approve

Findings (advisory — did not block landing):
- [low/advisory] apps/api/src/analytics/analytics.service.ts:350 — Dashboard load now runs the 4-query net-worth aggregation twice: the /net-worth endpoint internally calls netWorthBreakdown, and useNetWorthBreakdown hits /net-worth-breakdown which runs the same 4 queries again. Consider deriving the totals client-side from the breakdown response, or having the frontend not fetch both.

---
Dispatched via coxd (`MyMoney-dashboard-net-worth-drill-do-1785197274`) · cost $2.625 · 🤖 coxd