### PR TITLE
netWorth() silently zeros unpriced/stale holdings instead of falling b

### DIFF
--- a/apps/api/src/analytics/__tests__/analytics.service.spec.ts
+++ b/apps/api/src/analytics/__tests__/analytics.service.spec.ts
@@ -521,6 +521,67 @@ describe('AnalyticsService', () => {
       );
       expect(nw.assets - nw.liabilities).toBe(nw.netWorth);
     });
+
+    it('flags a holdings-priced investment account stale and surfaces it in the breakdown (#184)', async () => {
+      // The investment_accounts query itself decides, per row, whether any holding was
+      // missing a securityPrices match; the service just has to trust and propagate that
+      // flag rather than silently treating the fallback/partial total as fully priced.
+      mockNetWorthQueries({
+        investment: [
+          {
+            investment_account_id: 'inv-1',
+            nickname: 'Brokerage',
+            institution: 'Vanguard',
+            account_type: 'brokerage',
+            balance_cents: '150000', // e.g. fell back to the account's latest manual snapshot
+            stale: true,
+          },
+        ],
+      });
+
+      const breakdown = await service.netWorthBreakdown(TEST_USER_ID, { household: false });
+
+      expect(breakdown.assets.investments).toHaveLength(1);
+      expect(breakdown.assets.investments[0]).toMatchObject({
+        id: 'inv-1',
+        balanceCents: 150000,
+        stale: true,
+      });
+    });
+
+    it('does not set stale on a fully-priced investment account row', async () => {
+      mockNetWorthQueries({
+        investment: [
+          {
+            investment_account_id: 'inv-1',
+            nickname: 'Brokerage',
+            institution: 'Vanguard',
+            account_type: 'brokerage',
+            balance_cents: '300000',
+            stale: false,
+          },
+        ],
+      });
+
+      const breakdown = await service.netWorthBreakdown(TEST_USER_ID, { household: false });
+
+      expect(breakdown.assets.investments[0].stale).toBeUndefined();
+    });
+
+    it('builds the investment-account query so an unpriced holding falls back to the account\'s ' +
+      'latest snapshot (or, absent one, the priced-holdings-only partial total) instead of ' +
+      'silently zeroing that holding\'s contribution (#184)', async () => {
+      mockNetWorthQueries({});
+      await service.netWorthBreakdown(TEST_USER_ID, { household: false });
+
+      // Call order: 1=accounts, 2=investment_accounts.
+      const queryText = toSqlText(mockDb.execute.mock.calls[1][0]);
+      expect(queryText).toMatch(/missing_price_count/);
+      expect(queryText).toMatch(/latest_snapshot/);
+      // Zero unpriced holdings must not always resolve to a bare 0 anymore: the CASE must
+      // consult the snapshot fallback before it can fall through to COALESCE(hv.value_cents, 0).
+      expect(queryText).toMatch(/snap\.balance_cents IS NOT NULL/);
+    });
   });
 
   describe('topMerchants', () => {

--- a/apps/api/src/analytics/analytics.service.ts
+++ b/apps/api/src/analytics/analytics.service.ts
@@ -19,6 +19,14 @@ export interface LineItem {
   accountType: string;
   balanceCents: number;
   source: 'account' | 'investment_account' | 'manual_asset' | 'loan';
+  /**
+   * True when `balanceCents` may be incomplete/outdated: e.g. one or more
+   * holdings in this investment account had no matching `securityPrices` row
+   * (new ticker, delisted, or a price-feed gap) and the account's value was
+   * either backfilled from its latest manual snapshot or, absent a snapshot,
+   * computed from priced holdings only (see #184).
+   */
+  stale?: boolean;
 }
 
 /** Net-worth totals, expressed as the line items that sum to each of `netWorth()`'s figures. */
@@ -461,9 +469,10 @@ export class AnalyticsService {
           AND ${invUserScope}
       ),
       holdings_value AS (
-        SELECT ih.investment_account_id, SUM(
-          ih.share_count * COALESCE(sp.close_cents, 0)
-        ) AS value_cents
+        SELECT
+          ih.investment_account_id,
+          SUM(ih.share_count * COALESCE(sp.close_cents, 0)) AS value_cents,
+          COUNT(*) FILTER (WHERE sp.close_cents IS NULL) AS missing_price_count
         FROM ${schema.investmentHoldings} ih
         JOIN acct ON acct.id = ih.investment_account_id AND acct.has_holdings
         LEFT JOIN LATERAL (
@@ -474,6 +483,12 @@ export class AnalyticsService {
           LIMIT 1
         ) sp ON true
         GROUP BY ih.investment_account_id
+      ),
+      latest_snapshot AS (
+        SELECT DISTINCT ON (s.investment_account_id)
+          s.investment_account_id, s.balance_cents
+        FROM ${schema.investmentSnapshots} s
+        ORDER BY s.investment_account_id, s.date DESC, s.created_at DESC
       )
       SELECT
         acct.id AS investment_account_id,
@@ -481,17 +496,24 @@ export class AnalyticsService {
         acct.institution,
         acct.account_type,
         CASE
+          -- Fully priced holdings: use the priced total, nothing stale.
+          WHEN acct.has_holdings AND COALESCE(hv.missing_price_count, 0) = 0
+            THEN COALESCE(hv.value_cents, 0)
+          -- Holdings with at least one unpriced ticker: prefer the account's
+          -- latest manual snapshot over silently zeroing the unpriced shares.
+          WHEN acct.has_holdings AND snap.balance_cents IS NOT NULL
+            THEN snap.balance_cents
+          -- Holdings with missing prices and no snapshot to fall back on:
+          -- best-effort partial total from priced holdings only (flagged stale).
           WHEN acct.has_holdings THEN COALESCE(hv.value_cents, 0)
-          ELSE COALESCE((
-            SELECT s.balance_cents
-            FROM ${schema.investmentSnapshots} s
-            WHERE s.investment_account_id = acct.id
-            ORDER BY s.date DESC, s.created_at DESC
-            LIMIT 1
-          ), 0)
-        END AS balance_cents
+          ELSE COALESCE(snap.balance_cents, 0)
+        END AS balance_cents,
+        (
+          acct.has_holdings AND COALESCE(hv.missing_price_count, 0) > 0
+        ) AS stale
       FROM acct
       LEFT JOIN holdings_value hv ON hv.investment_account_id = acct.id
+      LEFT JOIN latest_snapshot snap ON snap.investment_account_id = acct.id
     `);
     const investmentAccountItems: LineItem[] = this.extractRows(investmentRows).map(
       (r: any) => ({
@@ -501,6 +523,7 @@ export class AnalyticsService {
         accountType: r.account_type,
         balanceCents: Number(r.balance_cents),
         source: 'investment_account' as const,
+        ...(r.stale ? { stale: true } : {}),
       }),
     );
 

--- a/apps/web/src/components/NetWorthDrilldown.tsx
+++ b/apps/web/src/components/NetWorthDrilldown.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { X, Wallet, CreditCard, LineChart, TrendingUp, ExternalLink } from 'lucide-react';
+import { X, Wallet, CreditCard, LineChart, TrendingUp, ExternalLink, AlertTriangle } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { formatCents } from '@/lib/format';
 import type { NetWorthBreakdown, NetWorthLineItem } from '@/lib/hooks/useAnalytics';
@@ -137,7 +137,17 @@ export function NetWorthDrilldown({ type, breakdown, onClose, from, to }: NetWor
                 >
                   <div className="flex items-center justify-between">
                     <div className="min-w-0">
-                      <p className="font-semibold text-sm truncate">{item.nickname}</p>
+                      <p className="font-semibold text-sm truncate flex items-center gap-1.5">
+                        {item.nickname}
+                        {item.stale ? (
+                          <span
+                            title="Value may be incomplete: one or more holdings had no current price and this total was backfilled from the latest manual snapshot."
+                            className="inline-flex shrink-0 text-[var(--warning,#b45309)]"
+                          >
+                            <AlertTriangle className="h-3.5 w-3.5" />
+                          </span>
+                        ) : null}
+                      </p>
                       <p className="text-xs text-[var(--muted-foreground)] capitalize mt-0.5">
                         {item.institution ? `${item.institution} · ` : ''}
                         {typeLabel(item.accountType)}

--- a/apps/web/src/lib/hooks/useAnalytics.ts
+++ b/apps/web/src/lib/hooks/useAnalytics.ts
@@ -63,6 +63,9 @@ export interface NetWorthLineItem {
   accountType: string;
   balanceCents: number;
   source: 'account' | 'investment_account' | 'manual_asset' | 'loan';
+  /** True when this row's value may be incomplete/outdated (e.g. an unpriced
+   *  holding was backfilled from a manual snapshot or a partial priced total). */
+  stale?: boolean;
 }
 
 /** Line-item detail behind each `net-worth` total — see `useNetWorth`. */


### PR DESCRIPTION
Committed successfully.

## Summary

`AnalyticsService.netWorthBreakdown()` valued each holdings-priced investment account as `SUM(share_count * COALESCE(close_cents, 0))`. When a holding had no matching `securityPrices` row — a new ticker before the EOD sync, a delisted/unsupported symbol, or a price-feed gap — that holding's price was silently treated as $0, understating the account's total and the net-worth headline figure with no indication anything was missing.

**Fix:** the investment-account query now tracks, per account, whether any holding was missing a price match. When holdings are fully priced, behavior is unchanged. When one or more holdings lack a price:
1. Fall back to the account's latest manual `investment_snapshots` value for the whole account (rather than partially zeroing the unpriced shares), matching the existing holdings-vs-snapshot mutual-exclusion pattern.
2. If no snapshot exists either, use the best-effort total from priced holdings only.
3. In both fallback cases, the line item is marked `stale: true` in the `netWorthBreakdown()` response so callers (and the drill-down UI, updated here) can flag the value as potentially incomplete rather than trusting a silently-zeroed number.

Added unit tests covering: the `stale` flag propagating through to breakdown items, a fully-priced row not being flagged, and the generated SQL containing the new missing-price/snapshot-fallback logic. Verified the fix and existing net-worth invariant tests (46 total) pass, and typechecked both the API and the two edited web files.

---
### Test evidence
**3 new test case(s) added** (heuristic count):
```
 .../analytics/__tests__/analytics.service.spec.ts  | 61 ++++++++++++++++++++++
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
[2m2 tests[22m[2m)[22m[32m 9[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/sync-delivery.processor.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 4[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/categorization/__tests__/learning.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/next-loan-due-date.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test: [32m[Nest] 5632  - [39m07/28/2026, 12:45:02 AM [32m    LOG[39m [38;5;3m[AlertCronProcessor] [39m[32mProcessing alert job: monthly-close-auto-draft[39m
@moneypulse/api:test: [32m[Nest] 5632  - [39m07/28/2026, 12:45:02 AM [32m    LOG[39m [38;5;3m[AlertCronProcessor] [39m[32mMonthly-close auto-draft: 3 user(s) processed, 2 close(s) created[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/monthly-close-cron.spec.ts [2m([22m[2m1 test[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m95 passed[39m[22m[90m (95)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m798 passed[39m[22m[90m (798)[39m
@moneypulse/api:test: [2m   Start at [22m 00:44:47
@moneypulse/api:test: [2m   Duration [22m 14.72s[2m (transform 4.70s, setup 0ms, import 81.29s, tests 3.16s, environment 9ms)[22m
@moneypulse/api:test: 

 Tasks:    3 successful, 3 total
Cached:    1 cached, 3 total
  Time:    15.275s
```
</details>

### Review
**Review verdict:** approve

Findings (advisory — did not block landing):
- [low/advisory] apps/web/src/components/NetWorthDrilldown.tsx:145 — The stale-icon tooltip claims the total was 'backfilled from the latest manual snapshot', but the backend sets stale even when there is no snapshot and the value is a partial priced-holdings-only total, so the tooltip can be inaccurate in that case.

---
Dispatched via coxd (`MyMoney-networth-silently-zeros-unpr-1785199290`) · cost $1.066 · 🤖 coxd