### PR TITLE
security-prices-refresh cron runs but writes zero rows, ever

### DIFF
--- a/apps/api/src/market-data/__tests__/alphavantage.client.spec.ts
+++ b/apps/api/src/market-data/__tests__/alphavantage.client.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Logger } from '@nestjs/common';
 import { AlphaVantageClient } from '../alphavantage.client';
 
 function makeConfig(overrides: Record<string, string> = {}) {
@@ -27,6 +28,12 @@ describe('AlphaVantageClient', () => {
     const point = await client.fetchLatestClose('VTSAX');
     expect(point).toBeNull();
     expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('warns loudly at construction time when unconfigured, not just per-call', () => {
+    const warnSpy = vi.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    new AlphaVantageClient(makeConfig());
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('ALPHAVANTAGE_API_KEY'));
   });
 
   it('parses the latest close from a recorded fixture', async () => {

--- a/apps/api/src/market-data/__tests__/stooq.client.spec.ts
+++ b/apps/api/src/market-data/__tests__/stooq.client.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Logger } from '@nestjs/common';
 import { StooqClient, parseStooqCsv } from '../stooq.client';
 
 // Recorded fixture — a trimmed real-shaped Stooq CSV response for a synthetic
@@ -53,5 +54,22 @@ describe('StooqClient', () => {
     const client = new StooqClient();
     const point = await client.fetchLatestClose('VTI');
     expect(point).toBeNull();
+  });
+
+  it('returns null (and logs distinctly) on a 200 OK HTML anti-bot challenge page', async () => {
+    // Reproduces Stooq's current behavior for this endpoint: HTTP 200 with an HTML
+    // "verify your browser" proof-of-work interstitial instead of CSV, for every
+    // ticker — must not be silently treated the same as a legitimate empty/N-D body.
+    const errorSpy = vi.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () =>
+        '<!DOCTYPE html><html><head></head><body><noscript>This site requires JavaScript' +
+        ' to verify your browser.</noscript><script>/* PoW challenge */</script></body></html>',
+    }) as any;
+    const client = new StooqClient();
+    const point = await client.fetchLatestClose('VTI');
+    expect(point).toBeNull();
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('non-CSV'));
   });
 });

--- a/apps/api/src/market-data/alphavantage.client.ts
+++ b/apps/api/src/market-data/alphavantage.client.ts
@@ -19,6 +19,17 @@ export class AlphaVantageClient {
 
   constructor(private readonly config: ConfigService) {
     this.apiKey = this.config.get<string>('ALPHAVANTAGE_API_KEY') || undefined;
+    if (!this.apiKey) {
+      // Loud at boot, not just per-ticker: without this key, every ticker Stooq
+      // can't price (mutual-fund NAVs) — and, if Stooq itself is unreachable/blocked,
+      // *every* ticker — silently never gets a security_prices row, with no single
+      // log line ever calling out the missing config as the cause.
+      this.logger.warn(
+        'ALPHAVANTAGE_API_KEY is not configured — Alpha Vantage fallback is fully ' +
+          'disabled, so any ticker Stooq fails to price (mutual-fund NAVs, or all ' +
+          'tickers during a Stooq outage) will never get a security_prices row',
+      );
+    }
   }
 
   get isConfigured(): boolean {

--- a/apps/api/src/market-data/security-prices.service.ts
+++ b/apps/api/src/market-data/security-prices.service.ts
@@ -43,11 +43,20 @@ export class SecurityPricesService {
     const refreshed: string[] = [];
     const failed: string[] = [];
 
+    this.logger.log(`Security price refresh starting for ${tickers.length} held ticker(s)`);
     for (const ticker of tickers) {
       try {
         const wrote = await this.refreshOne(ticker);
-        if (wrote) refreshed.push(ticker);
-        else failed.push(ticker); // both providers came back empty (outage / unknown ticker)
+        if (wrote) {
+          refreshed.push(ticker);
+        } else {
+          // Both providers came back empty (outage / unknown ticker / missing
+          // Alpha Vantage config) — StooqClient/AlphaVantageClient already log the
+          // specific reason per-provider; this line ties it back to the ticker so
+          // "which tickers failed and why" is visible from the aggregate log alone.
+          this.logger.warn(`security price refresh: no price obtained for ${ticker}`);
+          failed.push(ticker);
+        }
       } catch (err: any) {
         this.logger.error(`security price refresh failed for ${ticker}: ${err.message}`);
         failed.push(ticker);

--- a/apps/api/src/market-data/stooq.client.ts
+++ b/apps/api/src/market-data/stooq.client.ts
@@ -39,7 +39,25 @@ export class StooqClient {
         return null;
       }
       const text = await res.text();
-      return parseStooqCsv(text);
+      // Stooq's endpoint can 200 with an HTML anti-bot/JS-challenge page instead of
+      // real CSV (e.g. a proof-of-work "verify your browser" interstitial) — that
+      // response is neither valid CSV nor Stooq's own "N/D" unknown-ticker body, and
+      // parseStooqCsv would otherwise swallow it as an indistinguishable silent null,
+      // hiding a total-outage condition behind the same code path as a routine
+      // unknown-ticker miss. Surface it loudly so an outage is visible in logs.
+      const trimmed = text.trimStart();
+      if (trimmed.startsWith('<') || /^\s*<!doctype/i.test(trimmed)) {
+        this.logger.error(
+          `Stooq ${ticker}: got a non-CSV (HTML) response — likely a bot-check/` +
+            `anti-scraping wall on Stooq's side rather than an unknown ticker`,
+        );
+        return null;
+      }
+      const point = parseStooqCsv(text);
+      if (!point) {
+        this.logger.warn(`Stooq ${ticker}: no price data (unknown ticker or empty feed)`);
+      }
+      return point;
     } catch (err: any) {
       this.logger.error(`Stooq ${ticker} fetch failed: ${err.message}`);
       return null;


### PR DESCRIPTION
Committed cleanly. Summary below.

## Root cause

`security_prices` was empty not because of a missed cron run or a parsing bug, but because both price providers were silently dead-ending on **every** ticker, **every** run, with no error-level signal at all:

1. **Stooq** — its free CSV endpoint (`stooq.com/q/d/l/`) now responds `200 OK` with an HTML "verify your browser" proof-of-work anti-bot challenge page instead of CSV data, for every ticker. I reproduced this directly against `stooq.com` outside the container, so it isn't an egress/DNS issue specific to the NAS. `StooqClient.fetchLatestClose` only checked `res.ok` (true) and then handed the HTML straight to `parseStooqCsv`, which returned `null` — indistinguishable from Stooq's legitimate "N/D" unknown-ticker response. A total outage was being swallowed as a routine, silent miss.
2. **Alpha Vantage** (the documented fallback for cases Stooq can't cover) has never had `ALPHAVANTAGE_API_KEY` configured on the API container, confirmed via the reported `docker exec ... env` check. It also no-ops on every ticker, previously only logged as a quiet per-call `warn`.

With both providers returning `null` every time and no distinguishing error signal, `refreshAll()` completed "successfully" with `0 refreshed` — which explains why no rows were ever written and why nothing useful showed up in the logs.

## Fix

- `StooqClient` now detects the HTML challenge body and logs it as a distinct `error` ("non-CSV / bot-check") instead of returning an unremarkable `null`, and logs a `warn` for genuine empty/unknown-ticker misses.
- `AlphaVantageClient` now warns loudly at construction time when unconfigured, not just per call, so the missing-key gap is visible immediately at boot rather than buried in per-ticker noise.
- `SecurityPricesService.refreshAll()` now logs a start line and a per-ticker reason on failure, so a `0 refreshed` aggregate is traceable to specific tickers/causes.

Added unit tests reproducing the HTML-challenge

_(summary truncated)_

---
### Test evidence
**2 new test case(s) added** (heuristic count):
```
 .../__tests__/alphavantage.client.spec.ts            |  7 +++++++
 .../src/market-data/__tests__/stooq.client.spec.ts   | 18 ++++++++++++++++++
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
[2m2 tests[22m[2m)[22m[32m 15[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/sync-delivery.processor.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 5[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/categorization/__tests__/learning.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/next-loan-due-date.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test: [32m[Nest] 7777  - [39m07/28/2026, 12:48:07 AM [32m    LOG[39m [38;5;3m[AlertCronProcessor] [39m[32mProcessing alert job: monthly-close-auto-draft[39m
@moneypulse/api:test: [32m[Nest] 7777  - [39m07/28/2026, 12:48:07 AM [32m    LOG[39m [38;5;3m[AlertCronProcessor] [39m[32mMonthly-close auto-draft: 3 user(s) processed, 2 close(s) created[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/monthly-close-cron.spec.ts [2m([22m[2m1 test[22m[2m)[22m[32m 5[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m95 passed[39m[22m[90m (95)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m797 passed[39m[22m[90m (797)[39m
@moneypulse/api:test: [2m   Start at [22m 00:47:55
@moneypulse/api:test: [2m   Duration [22m 12.58s[2m (transform 4.17s, setup 0ms, import 67.53s, tests 2.34s, environment 6ms)[22m
@moneypulse/api:test: 

 Tasks:    2 successful, 2 total
Cached:    1 cached, 2 total
  Time:    13.15s
```
</details>

### Review
**Review verdict:** approve

Findings (advisory — did not block landing):
- [low/advisory] apps/api/src/market-data/stooq.client.ts:48 — Redundant HTML check: text is already trimStart()-ed and `trimmed.startsWith('<')` already matches `<!doctype`, so the extra `/^\s*<!doctype/i` regex is dead/duplicate logic.

---
Dispatched via coxd (`MyMoney-security-prices-refresh-cron-1785199314`) · cost $1.405 · 🤖 coxd