### PR TITLE
Add home value tracking + split Net Worth into Total vs. Liquid

### DIFF
--- a/apps/api/src/analytics/__tests__/analytics.service.spec.ts
+++ b/apps/api/src/analytics/__tests__/analytics.service.spec.ts
@@ -443,6 +443,69 @@ describe('AnalyticsService', () => {
       expect(result.liabilities).toBeLessThan(10000000);
     });
 
+    it('liquidNetWorth equals netWorth when no illiquid manual asset or mortgage exists (#198)', async () => {
+      mockNetWorthQueries({
+        acct: [acctRow({ account_type: 'checking', balance_cents: '500000' })],
+      });
+
+      const result = await service.netWorth(TEST_USER_ID, { household: false });
+
+      expect(result.liquidNetWorth).toBe(result.netWorth);
+    });
+
+    it('liquidNetWorth excludes an illiquid home asset and its mortgage, but includes a semi_liquid asset and a non-mortgage loan (#198)', async () => {
+      mockNetWorthQueries({
+        acct: [acctRow({ account_type: 'checking', balance_cents: '500000' })],
+        manualAsset: [
+          {
+            id: 'ma-home',
+            name: 'Home',
+            asset_type: 'home',
+            liquidity_class: 'illiquid',
+            value_cents: '40000000',
+          },
+          {
+            id: 'ma-gold',
+            name: 'Gold',
+            asset_type: 'gold',
+            liquidity_class: 'semi_liquid',
+            value_cents: '100000',
+          },
+        ],
+        loans: [
+          {
+            id: 'loan-mortgage',
+            name: 'Mortgage',
+            loan_type: 'mortgage',
+            original_balance_cents: '30000000',
+            apr_bps: '400',
+            scheduled_payment_cents: '150000',
+            start_date: '2020-01-01',
+            manual_balance_cents: '29000000',
+            latest_source: 'manual_statement',
+          },
+          {
+            id: 'loan-auto',
+            name: 'Auto Loan',
+            loan_type: 'auto',
+            original_balance_cents: '2000000',
+            apr_bps: '500',
+            scheduled_payment_cents: '30000',
+            start_date: '2024-01-01',
+            manual_balance_cents: '1500000',
+            latest_source: 'manual_statement',
+          },
+        ],
+      });
+
+      const result = await service.netWorth(TEST_USER_ID, { household: false });
+
+      // Total: (500000 liquid + 40000000 home + 100000 gold) - (29000000 mortgage + 1500000 auto)
+      expect(result.netWorth).toBe(500000 + 40000000 + 100000 - 29000000 - 1500000);
+      // Liquid: home and mortgage both excluded; gold (semi_liquid) and the auto loan remain.
+      expect(result.liquidNetWorth).toBe(500000 + 100000 - 1500000);
+    });
+
     it('always equals the sum of netWorthBreakdown()\'s own line items (invariant, #192)', async () => {
       mockNetWorthQueries({
         acct: [

--- a/apps/api/src/analytics/analytics.service.ts
+++ b/apps/api/src/analytics/analytics.service.ts
@@ -27,6 +27,8 @@ export interface LineItem {
    * computed from priced holdings only (see #184).
    */
   stale?: boolean;
+  /** Only set for `source: 'manual_asset'` items — liquid | semi_liquid | illiquid. */
+  liquidityClass?: string;
 }
 
 /** Net-worth totals, expressed as the line items that sum to each of `netWorth()`'s figures. */
@@ -368,11 +370,28 @@ export class AnalyticsService {
     const assets = liquidCents + investmentCents + manualAssetCents;
     const liabilities = creditCardLiabilityCents + loanLiabilityCents;
 
+    // "Liquid Net Worth" (#198): excludes illiquid manual assets (e.g. a home) from the
+    // asset side, and excludes mortgage-type loans from the liability side — a mortgage
+    // is virtually always tied to the illiquid home it excludes, so netting one without
+    // the other would double-count/omit. Non-mortgage debt (auto, personal, student
+    // loans, credit cards) still counts against liquid net worth. When no illiquid
+    // manual asset or mortgage exists, this equals `netWorth` exactly (no behavior
+    // change for users who haven't entered a home yet).
+    const liquidManualAssetCents = sum(
+      breakdown.assets.manualAssets.filter((i) => i.liquidityClass !== 'illiquid'),
+    );
+    const nonMortgageLoanLiabilityCents = sum(
+      breakdown.liabilities.loans.filter((i) => i.accountType !== 'mortgage'),
+    );
+    const liquidAssets = liquidCents + investmentCents + liquidManualAssetCents;
+    const liquidLiabilities = creditCardLiabilityCents + nonMortgageLoanLiabilityCents;
+
     return {
       assets,
       liabilities,
       investments: investmentCents,
       netWorth: assets - liabilities,
+      liquidNetWorth: liquidAssets - liquidLiabilities,
     };
   }
 
@@ -529,7 +548,7 @@ export class AnalyticsService {
 
     // Manual assets (home/car/gold/other): latest carry-forward value per asset.
     const manualAssetRows = await this.db.execute(sql`
-      SELECT ma.id, ma.name, ma.asset_type, latest.value_cents
+      SELECT ma.id, ma.name, ma.asset_type, ma.liquidity_class, latest.value_cents
       FROM ${schema.manualAssets} ma
       LEFT JOIN LATERAL (
         SELECT value_cents
@@ -549,6 +568,7 @@ export class AnalyticsService {
         accountType: r.asset_type,
         balanceCents: Number(r.value_cents ?? 0),
         source: 'manual_asset' as const,
+        liquidityClass: r.liquidity_class,
       }),
     );
 

--- a/apps/web/src/app/(protected)/page.tsx
+++ b/apps/web/src/app/(protected)/page.tsx
@@ -148,6 +148,7 @@ export default function DashboardPage() {
           liabilities={nw.liabilities}
           investments={nw.investments}
           netWorth={nw.netWorth}
+          liquidNetWorth={nw.liquidNetWorth}
           onClickAssets={() => setDrilldown('assets')}
           onClickLiabilities={() => setDrilldown('liabilities')}
           onClickInvestments={() => setDrilldown('investments')}

--- a/apps/web/src/components/charts/NetWorthCard.tsx
+++ b/apps/web/src/components/charts/NetWorthCard.tsx
@@ -7,6 +7,8 @@ interface NetWorthCardProps {
   liabilities: number;
   investments: number;
   netWorth: number;
+  /** Excludes illiquid manual assets (e.g. a home) and mortgage-type loans — see #198. */
+  liquidNetWorth?: number;
   onClickAssets?: () => void;
   onClickLiabilities?: () => void;
   onClickInvestments?: () => void;
@@ -18,11 +20,16 @@ export function NetWorthCard({
   liabilities,
   investments,
   netWorth,
+  liquidNetWorth,
   onClickAssets,
   onClickLiabilities,
   onClickInvestments,
 }: NetWorthCardProps) {
   const isPositive = netWorth >= 0;
+  // "Liquid Net Worth" is a secondary/supporting figure (Monarch/Empower two-number
+  // pattern) — only worth surfacing once it actually diverges from the headline total,
+  // i.e. once an illiquid manual asset (a home) or a mortgage has been entered.
+  const showLiquid = liquidNetWorth !== undefined && liquidNetWorth !== netWorth;
 
   return (
     <div className="relative overflow-hidden rounded-2xl bg-[var(--surface-container-low)] p-6">
@@ -42,6 +49,15 @@ export function NetWorthCard({
         </span>
         {!isPositive && (
           <p className="mt-1 text-xs text-[var(--destructive)]">Negative net worth</p>
+        )}
+        {showLiquid && (
+          <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+            Liquid Net Worth:{' '}
+            <span className="font-semibold tabular-nums">
+              {liquidNetWorth! < 0 ? '-' : ''}
+              {formatCents(Math.abs(liquidNetWorth!))}
+            </span>
+          </p>
         )}
       </div>
 

--- a/apps/web/src/lib/hooks/useAnalytics.ts
+++ b/apps/web/src/lib/hooks/useAnalytics.ts
@@ -66,6 +66,8 @@ export interface NetWorthLineItem {
   /** True when this row's value may be incomplete/outdated (e.g. an unpriced
    *  holding was backfilled from a manual snapshot or a partial priced total). */
   stale?: boolean;
+  /** Only set for `source: 'manual_asset'` items — liquid | semi_liquid | illiquid. */
+  liquidityClass?: string;
 }
 
 /** Line-item detail behind each `net-worth` total — see `useNetWorth`. */
@@ -87,6 +89,8 @@ export interface NetWorthData {
   liabilities: number;
   investments: number;
   netWorth: number;
+  /** Excludes illiquid manual assets (e.g. a home) and mortgage-type loans — see #198. */
+  liquidNetWorth: number;
 }
 
 /** Top merchant row. */


### PR DESCRIPTION
Committed successfully.

## Summary

**Root cause:** Since #161 correctly started counting the mortgage as a net-worth liability, users who hadn't yet entered their home as a `manual_assets` row saw Net Worth swing deeply negative — the counterbalancing asset was missing. Even once a home is entered, blending it into a single Net Worth number obscures the "liquid/investable" picture, since a home is typically the largest, least-liquid asset a household holds.

**Fix:**
- `AnalyticsService.netWorth()` now returns a second field, `liquidNetWorth`, computed from the same `netWorthBreakdown()` line items but excluding manual assets with `liquidityClass === 'illiquid'` (e.g. a home) and loans with `loanType === 'mortgage'` from the asset/liability sums respectively. Other debt (auto/personal/student loans, credit cards) and semi-liquid assets still count. `netWorthBreakdown()`'s manual-asset line items now also carry `liquidityClass` so this filtering doesn't require an extra query.
- Dashboard: `NetWorthCard` accepts an optional `liquidNetWorth` prop and renders it as a smaller secondary line under the primary Net Worth headline — only when it actually diverges from the total, so users without a home/mortgage entered see no visual change.
- Confirmed the existing `/health` monthly-close manual-asset form and its "Stale — carried forward" staleness badge (built in #162/#164, powered by the #100 freshness infrastructure) already support adding/tracking a `home`-type asset at full market value with a last-updated nudge — no changes needed there.
- Added unit tests covering: `liquidNetWorth === netWorth` when no illiquid asset/mortgage exists, and correct exclusion of an illiquid home + its mortgage while still including a semi-liquid asset and a non-mortgage loan.

**Verification:** Ran the API's `analytics.service.spec.ts` (45 tests, all passing) and the web `monthly-close.spec.tsx` suite (9 tests, passing); confirmed via `tsc --noEmit` that neither the API nor the touche

_(summary truncated)_

---
### Test evidence
**2 new test case(s) added** (heuristic count):
```
 .../analytics/__tests__/analytics.service.spec.ts  | 63 ++++++++++++++++++++++
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
2m6 tests[22m[2m)[22m[32m 5[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/categorization/__tests__/learning.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/sync-delivery.processor.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 4[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/next-loan-due-date.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test: [32m[Nest] 13245  - [39m07/28/2026, 12:56:11 AM [32m    LOG[39m [38;5;3m[AlertCronProcessor] [39m[32mProcessing alert job: monthly-close-auto-draft[39m
@moneypulse/api:test: [32m[Nest] 13245  - [39m07/28/2026, 12:56:11 AM [32m    LOG[39m [38;5;3m[AlertCronProcessor] [39m[32mMonthly-close auto-draft: 3 user(s) processed, 2 close(s) created[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/monthly-close-cron.spec.ts [2m([22m[2m1 test[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m95 passed[39m[22m[90m (95)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m797 passed[39m[22m[90m (797)[39m
@moneypulse/api:test: [2m   Start at [22m 00:55:56
@moneypulse/api:test: [2m   Duration [22m 14.59s[2m (transform 5.24s, setup 0ms, import 79.01s, tests 2.90s, environment 6ms)[22m
@moneypulse/api:test: 

 Tasks:    3 successful, 3 total
Cached:    1 cached, 3 total
  Time:    15.161s
```
</details>

### Review
**Review verdict:** approve

Findings (advisory — did not block landing):
- [low/advisory] apps/api/src/analytics/analytics.service.ts:381 — Mortgage exclusion relies on the magic string 'mortgage' matching loan_type in accountType; a shared loan-type constant would be more robust against future renames, but this is validated by the added test and is non-blocking.

---
Dispatched via coxd (`MyMoney-add-home-value-tracking-spli-1785199832`) · cost $1.427 · 🤖 coxd