### PR TITLE
subscriptionTotal() throws on every call — ANY() built with a parenthe

### DIFF
--- a/apps/api/src/analytics/__tests__/analytics.service.spec.ts
+++ b/apps/api/src/analytics/__tests__/analytics.service.spec.ts
@@ -1,3 +1,4 @@
+import { PgDialect } from 'drizzle-orm/pg-core';
 import { AnalyticsService } from '../analytics.service';
 
 const TEST_USER_ID = 'user-test-123';
@@ -944,6 +945,42 @@ describe('AnalyticsService', () => {
       const result = await service.subscriptionTotal(TEST_USER_ID);
       expect(result).toEqual({ monthlyTotalCents: 0, activeCount: 0, trend: [] });
       expect(mockDb.execute).toHaveBeenCalledTimes(1);
+    });
+
+    it('builds the trend query merchant-name filter as a real Postgres array, not a parenthesized list (#202)', async () => {
+      // Regression for #202: `= ANY(($2, $3, ...))` is a row/list expression, not an array
+      // literal, and Postgres rejects it with "op ANY/ALL (array) requires array on right
+      // side" once there's more than one element. A 1-2 merchant fixture wouldn't catch this
+      // (ANY((x)) degenerates and "accidentally" works), so use a realistic 12-merchant list.
+      const merchantNames = [
+        'aws', 'hulu', 'verizon', 'github inc', 'dominion energy', 'netflix',
+        'spotify', 'gym', 'insurance', 'comcast', 'planet fitness', 'adobe',
+      ];
+      mockDb.execute
+        .mockResolvedValueOnce({
+          rows: merchantNames.map((name) => ({
+            normalized_name: name,
+            expected_amount_cents: '1000',
+            frequency: 'monthly',
+          })),
+        })
+        .mockResolvedValueOnce({ rows: [] });
+
+      await service.subscriptionTotal(TEST_USER_ID);
+
+      const trendQuery = mockDb.execute.mock.calls[1][0];
+      const { sql: sqlText, params } = new PgDialect().sqlToQuery(trendQuery);
+
+      // Must be a genuine array literal cast to text[], e.g. ANY(ARRAY[$2, $3, ...]::text[]),
+      // never a bare parenthesized list like ANY(($2, $3, ...)).
+      expect(sqlText).toMatch(/=\s*ANY\(ARRAY\[[^\]]*\]::text\[\]\)/);
+      expect(sqlText).not.toMatch(/=\s*ANY\(\(\$/);
+
+      // Every merchant name must actually be bound as a param (userId + 12 names).
+      expect(params).toHaveLength(1 + merchantNames.length);
+      for (const name of merchantNames) {
+        expect(params).toContain(name);
+      }
     });
   });
 });

--- a/apps/api/src/analytics/analytics.service.ts
+++ b/apps/api/src/analytics/analytics.service.ts
@@ -1092,6 +1092,16 @@ export class AnalyticsService {
     const normalizedNames = bills.map((b: any) => b.normalized_name as string);
     let trend: Array<{ month: string; totalCents: number }> = [];
     if (normalizedNames.length > 0) {
+      // Build a real Postgres array literal (ARRAY[$1, $2, ...]::text[]) rather than
+      // interpolating the JS array directly into ANY(...) — the latter renders as a
+      // parenthesized list/row expression `($1, $2, ...)`, which Postgres accepts as
+      // ANY(...) only in the degenerate single-element case and rejects with
+      // "op ANY/ALL (array) requires array on right side" once there's more than one
+      // name (see #202).
+      const normalizedNamesArray = sql.join(
+        normalizedNames.map((name) => sql`${name}`),
+        sql.raw(', '),
+      );
       const trendRows = await this.db.execute(sql`
         SELECT
           to_char(date_trunc('month', t.date), 'YYYY-MM') AS month,
@@ -1101,7 +1111,7 @@ export class AnalyticsService {
           AND t.is_split_parent = false
           AND t.deleted_at IS NULL
           AND t.is_credit = false
-          AND t.normalized_merchant_name = ANY(${normalizedNames})
+          AND t.normalized_merchant_name = ANY(ARRAY[${normalizedNamesArray}]::text[])
           AND t.date >= date_trunc('month', CURRENT_DATE) - INTERVAL '11 months'
         GROUP BY date_trunc('month', t.date)
         ORDER BY month ASC


### PR DESCRIPTION
Committed successfully.

## Summary

**Root cause:** `AnalyticsService.subscriptionTotal()` built its merchant filter by interpolating a JS array directly into `ANY(${normalizedNames})`. Drizzle's `sql` tag doesn't turn a JS array into a Postgres array literal — it expands each element into its own placeholder, producing `ANY(($2, $3, $4, ...))`, a parenthesized row/list expression rather than an array. Postgres only tolerates that degenerate form for a single element; with 2+ recurring bills (the normal case) it throws `op ANY/ALL (array) requires array on right side` on every call, breaking the subscriptions total dashboard.

**Fix:** Build a genuine array literal — `ANY(ARRAY[$2, $3, ...]::text[])` — via `sql.join(names.map(n => sql\`${n}\`), sql.raw(', '))`, keeping every value parameterized (no injection risk). I initially tried Drizzle's `inArray()` helper (the "cleaner" option suggested in the issue) but verified via `PgDialect().sqlToQuery()` that it renders the column using the table's real name rather than the query's `t` alias, which would break this specific query since the FROM clause aliases `transactions` as `t`; the `ARRAY[...]::text[]` approach avoids that.

**Verification:**
- Added a regression test with 12 synthetic merchant names that compiles the trend query via `PgDialect` and asserts the SQL contains a proper `ANY(ARRAY[...]::text[])` cast (not the buggy parenthesized-list pattern) and that all names are bound as params.
- Confirmed the new test fails against the pre-fix code with the exact reported error pattern (`ANY(($2, $3, ..., $13))`), and passes after the fix.
- Full `analytics` test suite (145 tests) and `tsc --noEmit` both pass.

---
### Test evidence
**1 new test case(s) added** (heuristic count):
```
 .../analytics/__tests__/analytics.service.spec.ts  | 37 ++++++++++++++++++++++
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 4[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/audit/audit.service.spec.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 8[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/next-loan-due-date.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/categorization/__tests__/learning.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test: [32m[Nest] 26771  - [39m07/28/2026, 1:16:54 AM [32m    LOG[39m [38;5;3m[AlertCronProcessor] [39m[32mProcessing alert job: monthly-close-auto-draft[39m
@moneypulse/api:test: [32m[Nest] 26771  - [39m07/28/2026, 1:16:54 AM [32m    LOG[39m [38;5;3m[AlertCronProcessor] [39m[32mMonthly-close auto-draft: 3 user(s) processed, 2 close(s) created[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/monthly-close-cron.spec.ts [2m([22m[2m1 test[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m95 passed[39m[22m[90m (95)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m803 passed[39m[22m[90m (803)[39m
@moneypulse/api:test: [2m   Start at [22m 01:16:44
@moneypulse/api:test: [2m   Duration [22m 10.41s[2m (transform 3.16s, setup 0ms, import 55.03s, tests 2.02s, environment 7ms)[22m
@moneypulse/api:test: 

 Tasks:    2 successful, 2 total
Cached:    1 cached, 2 total
  Time:    10.915s
```
</details>

### Review
**Review verdict:** approve

---
Dispatched via coxd (`MyMoney-subscriptiontotal-throws-on-1785201125`) · cost $0.998 · 🤖 coxd