### PR TITLE
Health page: no UI to create a manual asset; Loan Verification never s

### DIFF
--- a/apps/web/src/app/(protected)/health/page.tsx
+++ b/apps/web/src/app/(protected)/health/page.tsx
@@ -122,12 +122,7 @@ export default function HealthPage() {
             ? ((current.freshness as { missingManualAssets?: string[] }).missingManualAssets ?? [])
             : []}
         />
-        <LoanVerificationPanel
-          month={month}
-          unverifiedLoans={current?.freshness && typeof current.freshness === 'object'
-            ? ((current.freshness as { unverifiedLoans?: string[] }).unverifiedLoans ?? [])
-            : []}
-        />
+        <LoanVerificationPanel month={month} />
       </div>
     </div>
   );

--- a/apps/web/src/components/monthly-close/LoanVerificationPanel.tsx
+++ b/apps/web/src/components/monthly-close/LoanVerificationPanel.tsx
@@ -3,20 +3,47 @@
 import { useState } from 'react';
 import { formatCents } from '@/lib/format';
 import { computeLoanState } from '@moneypulse/shared';
-import { useLoansForVerification, useUpsertLoanBalanceSnapshot } from '@/lib/hooks/useMonthlyClose';
+import type { Loan } from '@moneypulse/shared';
+import {
+  useLoansForVerification,
+  useUpsertLoanBalanceSnapshot,
+  useLoanBalanceSnapshots,
+} from '@/lib/hooks/useMonthlyClose';
 
-/** One loan: amortized balance vs an optional manual-statement override, plus
- *  principal paid this month. */
-function LoanRow({ loanId, month }: { loanId: string; month: string }) {
+/** One loan: the verified (manual_statement) balance when one exists for the
+ *  current month — or, failing that, the most recent manual_statement on file —
+ *  shown as the primary figure, with the amortized estimate as a secondary
+ *  comparison. Falls back to the amortized estimate alone when no manual
+ *  statement has ever been recorded. */
+function LoanRow({ loan, month }: { loan: Loan; month: string }) {
   const [editing, setEditing] = useState(false);
   const [value, setValue] = useState('');
   const upsert = useUpsertLoanBalanceSnapshot();
+  const { data: snapshotsData, isLoading: snapshotsLoading } = useLoanBalanceSnapshots(loan.id);
+  const snapshots = snapshotsData?.data ?? [];
+
+  // `listBalanceSnapshots` is ordered by snapshotMonth desc, so the first match
+  // for the current month (if any) is exact; otherwise the first row overall is
+  // the most recent manual statement on file.
+  const currentMonthSnapshot = snapshots.find((s) => s.snapshotMonth.slice(0, 7) === month.slice(0, 7));
+  const latestSnapshot = currentMonthSnapshot ?? snapshots[0] ?? null;
+  const verifiedThisMonth = !!currentMonthSnapshot;
+
+  const amortized = computeLoanState(
+    {
+      originalBalanceCents: loan.originalBalanceCents,
+      aprBps: loan.aprBps,
+      scheduledPaymentCents: loan.scheduledPaymentCents,
+      startDate: loan.startDate,
+    },
+    [],
+  );
 
   const submit = async () => {
     const dollars = parseFloat(value);
     if (!Number.isFinite(dollars) || dollars < 0) return;
     await upsert.mutateAsync({
-      loanId,
+      loanId: loan.id,
       month,
       balanceCents: Math.round(dollars * 100),
       source: 'manual_statement',
@@ -25,48 +52,73 @@ function LoanRow({ loanId, month }: { loanId: string; month: string }) {
     setValue('');
   };
 
-  return editing ? (
-    <div className="flex items-center gap-2">
-      <input
-        type="number"
-        inputMode="decimal"
-        autoFocus
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        className="w-28 rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-sm tabular-nums"
-        placeholder="0.00"
-      />
-      <button
-        onClick={submit}
-        disabled={upsert.isPending}
-        className="rounded-md bg-[var(--primary)] px-2 py-1 text-xs font-semibold text-[var(--primary-foreground)] disabled:opacity-50"
-      >
-        Save
-      </button>
-      <button onClick={() => setEditing(false)} className="text-xs text-[var(--muted-foreground)]">
-        Cancel
-      </button>
+  return (
+    <div className="flex items-center justify-between gap-3 border-b border-[var(--border)] pb-2 last:border-0">
+      <div>
+        <p className="text-sm font-medium">{loan.name}</p>
+        <p className="text-xs text-[var(--muted-foreground)]">
+          {latestSnapshot ? (
+            <>
+              Verified: {formatCents(latestSnapshot.balanceCents)}
+              <span className="ml-2 text-[10px] opacity-70">
+                (amortized est. {formatCents(amortized.currentBalanceCents)})
+              </span>
+            </>
+          ) : (
+            <>Amortized: {formatCents(amortized.currentBalanceCents)}</>
+          )}
+          {!snapshotsLoading && !verifiedThisMonth && (
+            <span className="ml-2 rounded-full bg-yellow-100 px-2 py-0.5 text-[10px] font-medium text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300">
+              Unverified
+            </span>
+          )}
+          {verifiedThisMonth && (
+            <span className="ml-2 rounded-full bg-green-100 px-2 py-0.5 text-[10px] font-medium text-green-800 dark:bg-green-900/30 dark:text-green-300">
+              Verified
+            </span>
+          )}
+        </p>
+      </div>
+      {editing ? (
+        <div className="flex items-center gap-2">
+          <input
+            type="number"
+            inputMode="decimal"
+            autoFocus
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            className="w-28 rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-sm tabular-nums"
+            placeholder="0.00"
+          />
+          <button
+            onClick={submit}
+            disabled={upsert.isPending}
+            className="rounded-md bg-[var(--primary)] px-2 py-1 text-xs font-semibold text-[var(--primary-foreground)] disabled:opacity-50"
+          >
+            Save
+          </button>
+          <button onClick={() => setEditing(false)} className="text-xs text-[var(--muted-foreground)]">
+            Cancel
+          </button>
+        </div>
+      ) : (
+        <button
+          onClick={() => setEditing(true)}
+          className="rounded-md border border-[var(--border)] px-2 py-1 text-xs font-medium hover:bg-[var(--muted)]"
+        >
+          Verify statement balance
+        </button>
+      )}
     </div>
-  ) : (
-    <button
-      onClick={() => setEditing(true)}
-      className="rounded-md border border-[var(--border)] px-2 py-1 text-xs font-medium hover:bg-[var(--muted)]"
-    >
-      Verify statement balance
-    </button>
   );
 }
 
-/** Loan verification panel: amortized-vs-manual-statement balance per loan, with
- *  the source used and this month's principal paid. `unverifiedLoans` comes from
- *  the close's freshness map. */
-export function LoanVerificationPanel({
-  month,
-  unverifiedLoans,
-}: {
-  month: string;
-  unverifiedLoans: string[];
-}) {
+/** Loan verification panel: verified (manual-statement) balance per loan when one
+ *  exists, with the amortized estimate as a secondary comparison figure, and this
+ *  month's principal paid. Each row fetches its own balance-snapshot history so a
+ *  statement entered previously (e.g. via API/support tooling) is reflected
+ *  immediately, not just ones entered through this exact session. */
+export function LoanVerificationPanel({ month }: { month: string }) {
   const { data, isLoading } = useLoansForVerification();
   const loans = data?.data ?? [];
 
@@ -78,34 +130,9 @@ export function LoanVerificationPanel({
         <p className="text-sm text-[var(--muted-foreground)]">No loans tracked.</p>
       )}
       <div className="space-y-3">
-        {loans.map((loan) => {
-          const state = computeLoanState(
-            {
-              originalBalanceCents: loan.originalBalanceCents,
-              aprBps: loan.aprBps,
-              scheduledPaymentCents: loan.scheduledPaymentCents,
-              startDate: loan.startDate,
-            },
-            [],
-          );
-          const unverified = unverifiedLoans.includes(loan.id);
-          return (
-            <div key={loan.id} className="flex items-center justify-between gap-3 border-b border-[var(--border)] pb-2 last:border-0">
-              <div>
-                <p className="text-sm font-medium">{loan.name}</p>
-                <p className="text-xs text-[var(--muted-foreground)]">
-                  Amortized: {formatCents(state.currentBalanceCents)}
-                  {unverified && (
-                    <span className="ml-2 rounded-full bg-yellow-100 px-2 py-0.5 text-[10px] font-medium text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300">
-                      Unverified
-                    </span>
-                  )}
-                </p>
-              </div>
-              <LoanRow loanId={loan.id} month={month} />
-            </div>
-          );
-        })}
+        {loans.map((loan) => (
+          <LoanRow key={loan.id} loan={loan} month={month} />
+        ))}
       </div>
     </div>
   );

--- a/apps/web/src/components/monthly-close/ManualAssetPanel.tsx
+++ b/apps/web/src/components/monthly-close/ManualAssetPanel.tsx
@@ -1,7 +1,100 @@
 'use client';
 
 import { useState } from 'react';
-import { useManualAssets, useUpsertManualAssetSnapshot } from '@/lib/hooks/useMonthlyClose';
+import {
+  useManualAssets,
+  useUpsertManualAssetSnapshot,
+  useCreateManualAsset,
+} from '@/lib/hooks/useMonthlyClose';
+import type { ManualAssetType } from '@moneypulse/shared';
+
+const ASSET_TYPES: { value: ManualAssetType; label: string }[] = [
+  { value: 'home', label: 'Home' },
+  { value: 'car', label: 'Car' },
+  { value: 'gold', label: 'Gold' },
+  { value: 'other', label: 'Other' },
+];
+
+/** Form to create a new manual asset (name + type) and, optionally, seed its
+ *  initial value for the current month. Shown both when the list is empty and as
+ *  a persistent "+ Add asset" action, since a household can have more than one
+ *  home/car. */
+function AddAssetForm({ month, onDone }: { month: string; onDone: () => void }) {
+  const [name, setName] = useState('');
+  const [assetType, setAssetType] = useState<ManualAssetType>('home');
+  const [value, setValue] = useState('');
+  const createAsset = useCreateManualAsset();
+  const upsertSnapshot = useUpsertManualAssetSnapshot();
+
+  const submit = async () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    const dollars = value.trim() === '' ? null : parseFloat(value);
+    if (dollars !== null && (!Number.isFinite(dollars) || dollars < 0)) return;
+
+    const created = await createAsset.mutateAsync({ name: trimmed, assetType });
+    if (dollars !== null) {
+      await upsertSnapshot.mutateAsync({
+        assetId: created.data.id,
+        month,
+        valueCents: Math.round(dollars * 100),
+        source: 'manual',
+      });
+    }
+    setName('');
+    setValue('');
+    setAssetType('home');
+    onDone();
+  };
+
+  const pending = createAsset.isPending || upsertSnapshot.isPending;
+
+  return (
+    <div className="mb-3 space-y-2 rounded-md border border-[var(--border)] p-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <input
+          type="text"
+          autoFocus
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Name (e.g. Home, Honda Civic)"
+          className="min-w-[10rem] flex-1 rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-sm"
+        />
+        <select
+          value={assetType}
+          onChange={(e) => setAssetType(e.target.value as ManualAssetType)}
+          className="rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-sm"
+        >
+          {ASSET_TYPES.map((t) => (
+            <option key={t.value} value={t.value}>
+              {t.label}
+            </option>
+          ))}
+        </select>
+        <input
+          type="number"
+          inputMode="decimal"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="Value (optional)"
+          className="w-32 rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-sm tabular-nums"
+        />
+      </div>
+      <div className="flex items-center gap-2">
+        <button
+          onClick={submit}
+          disabled={pending || !name.trim()}
+          className="rounded-md bg-[var(--primary)] px-2 py-1 text-xs font-semibold text-[var(--primary-foreground)] disabled:opacity-50"
+        >
+          Add asset
+        </button>
+        <button onClick={onDone} className="text-xs text-[var(--muted-foreground)]">
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}
 
 /** Inline month editor + staleness badge for one manual asset (home/car/gold/other).
  *  Carry-forward means a missing month isn't an error — it's just stale (epic #158
@@ -73,12 +166,24 @@ export function ManualAssetPanel({
 }) {
   const { data, isLoading } = useManualAssets();
   const assets = data?.data ?? [];
+  const [adding, setAdding] = useState(false);
 
   return (
     <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4" data-testid="manual-asset-panel">
-      <h3 className="mb-2 font-bold">Manual Assets</h3>
+      <div className="mb-2 flex items-center justify-between">
+        <h3 className="font-bold">Manual Assets</h3>
+        {!adding && (
+          <button
+            onClick={() => setAdding(true)}
+            className="rounded-md border border-[var(--border)] px-2 py-1 text-xs font-medium hover:bg-[var(--muted)]"
+          >
+            + Add asset
+          </button>
+        )}
+      </div>
+      {adding && <AddAssetForm month={month} onDone={() => setAdding(false)} />}
       {isLoading && <p className="text-sm text-[var(--muted-foreground)]">Loading…</p>}
-      {!isLoading && assets.length === 0 && (
+      {!isLoading && assets.length === 0 && !adding && (
         <p className="text-sm text-[var(--muted-foreground)]">
           No manual assets tracked yet (home, car, gold).
         </p>


### PR DESCRIPTION
Committed successfully.

## Summary

**Problem 1 — no UI to create a manual asset:** `ManualAssetPanel` only rendered editors for assets that already existed; there was no create affordance even though `POST /manual-assets` already existed on the backend. Added an `AddAssetForm` (name, asset type dropdown, optional initial value) reachable via a persistent "+ Add asset" button in the panel header, using the existing `useCreateManualAsset` + `useUpsertManualAssetSnapshot` hooks — no backend changes needed since the CRUD was already complete.

**Problem 2 — Loan Verification never showed the verified balance:** `LoanRow` unconditionally computed and displayed the client-side amortized estimate, and never read back `loan_balance_snapshots`. Each loan row now also calls `useLoanBalanceSnapshots(loan.id)` (an existing hook wired to the existing `GET /loans/:id/balance-snapshots` endpoint), finds the snapshot for the current month (falling back to the most recent one on file if the current month hasn't been verified yet), and displays that as the primary "Verified" figure with the amortized estimate shown only as a secondary comparison. The Verified/Unverified badge now reflects whether a current-month `manual_statement` snapshot exists, computed client-side from the fetched snapshot list rather than the stale server-provided `unverifiedLoans` name list (which was also dropped as an unused prop from the page).

Verified by building `@moneypulse/shared`, running `next build` (TypeScript + production build succeeds), `eslint` on the touched files, and the full `apps/web` vitest suite (87 passed, 3 skipped, no regressions).

---
### Test evidence
_No test files were added or modified in this change._

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
web:test:  [32m✓[39m src/__tests__/investment-holdings.spec.tsx [2m([22m[2m4 tests[22m[2m)[22m[33m 551[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/format.spec.ts [2m([22m[2m13 tests[22m[2m)[22m[32m 24[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/pwa.spec.tsx [2m([22m[2m5 tests[22m[2m)[22m[32m 17[2mms[22m[39m
@moneypulse/web:test: Not implemented: navigation to another Document
@moneypulse/web:test:  [32m✓[39m src/__tests__/api.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 8[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/split-transaction.spec.tsx [2m([22m[2m10 tests[22m[2m)[22m[33m 1218[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/accountGrouping.spec.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 4[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/add-transaction.spec.tsx [2m([22m[2m9 tests[22m[2m)[22m[33m 1233[2mms[22m[39m
@moneypulse/web:test: 
@moneypulse/web:test: [2m Test Files [22m [1m[32m11 passed[39m[22m[90m (11)[39m
@moneypulse/web:test: [2m      Tests [22m [1m[32m87 passed[39m[22m[2m | [22m[33m3 skipped[39m[90m (90)[39m
@moneypulse/web:test: [2m   Start at [22m 21:59:15
@moneypulse/web:test: [2m   Duration [22m 2.69s[2m (transform 468ms, setup 803ms, import 2.14s, tests 4.30s, environment 8.34s)[22m
@moneypulse/web:test: 

 Tasks:    2 successful, 2 total
Cached:    1 cached, 2 total
  Time:    3.157s
```
</details>

### Review
**Review verdict:** approve

Findings (advisory — did not block landing):
- [low/advisory] apps/web/src/components/monthly-close/LoanVerificationPanel.tsx:90 — Row can read 'Verified: $X' (from a prior-month snapshot) while simultaneously showing the 'Unverified' badge, which is contradictory UX; consider labeling the prior-month figure differently (e.g. 'Last statement').
- [low/advisory] apps/web/src/components/monthly-close/LoanVerificationPanel.tsx:19 — Each LoanRow issues its own useLoanBalanceSnapshots query (N+1 fetches for N loans); acceptable but a batched fetch in the panel would be cheaper. Also verify useUpsertLoanBalanceSnapshot invalidates the per-loan snapshot query so the Verified badge updates after saving.

---
Dispatched via coxd (`MyMoney-health-page-no-ui-to-create-1785203715`) · cost $1.313 · 🤖 coxd