### PR TITLE
getPortfolioValue() throws with the same broken ANY() pattern as #202 

### DIFF
--- a/apps/api/src/analytics/account-freshness.service.ts
+++ b/apps/api/src/analytics/account-freshness.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Inject } from '@nestjs/common';
 import { DATABASE_CONNECTION } from '../db/db.module';
 import * as schema from '../db/schema';
 import { sql, and, eq } from 'drizzle-orm';
+import { sqlArray } from '../db/sql-array';
 
 export type FreshnessStatus = 'fresh' | 'stale' | 'dormant';
 
@@ -189,8 +190,8 @@ export class AccountFreshnessService {
     const result = await this.db.execute(sql`
       SELECT DISTINCT account_id
       FROM ${schema.transactions}
-      WHERE ${schema.transactions.id} = ANY(${transactionIds})
-        AND ${schema.transactions.userId} = ANY(${userIds})
+      WHERE ${schema.transactions.id} = ANY(${sqlArray(transactionIds, 'uuid')})
+        AND ${schema.transactions.userId} = ANY(${sqlArray(userIds, 'uuid')})
         AND ${schema.transactions.deletedAt} IS NULL
     `);
 

--- a/apps/api/src/analytics/market-insight-detector.service.ts
+++ b/apps/api/src/analytics/market-insight-detector.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Inject, Logger } from '@nestjs/common';
 import { DATABASE_CONNECTION } from '../db/db.module';
 import * as schema from '../db/schema';
 import { and, eq, isNull, sql } from 'drizzle-orm';
+import { sqlArray } from '../db/sql-array';
 import { NotificationsService } from '../notifications/notifications.service';
 import { AccountFreshnessService } from './account-freshness.service';
 import { MarketDataService } from '../market-data/market-data.service';
@@ -175,7 +176,7 @@ export class MarketInsightDetectorService {
     const balanceRows = await this.db.execute(sql`
       SELECT DISTINCT ON (account_id) account_id, balance_cents
       FROM ${schema.accountBalanceSnapshots}
-      WHERE account_id = ANY(${relevantAccountIds})
+      WHERE account_id = ANY(${sqlArray(relevantAccountIds, 'uuid')})
       ORDER BY account_id, snapshot_date DESC
     `);
     const totalBalanceCents = (balanceRows.rows ?? balanceRows).reduce(

--- a/apps/api/src/db/sql-array.ts
+++ b/apps/api/src/db/sql-array.ts
@@ -1,0 +1,22 @@
+import { sql, type SQL } from 'drizzle-orm';
+
+/**
+ * Build a genuine Postgres array literal for use with `ANY(...)`/`ALL(...)`, e.g.
+ * `WHERE ticker = ANY(${sqlArray(tickers, 'text')})`.
+ *
+ * Never interpolate a raw JS array directly into a `sql` template tag for use with
+ * `ANY(...)` (e.g. `ANY(${myJsArray})`) — drizzle's `sql` tag renders a bare array
+ * as a parenthesized list `($1, $2, ...)`, not a real Postgres array. Postgres
+ * accepts that as `ANY(...)` only in the degenerate single-element case and
+ * rejects it with "op ANY/ALL (array) requires array on right side" once there
+ * are 2+ elements (see #202, #206).
+ */
+export function sqlArray(values: readonly (string | number)[], pgType: 'uuid' | 'text'): SQL {
+  if (values.length === 0) {
+    return sql`ARRAY[]::${sql.raw(pgType)}[]`;
+  }
+  return sql`ARRAY[${sql.join(
+    values.map((v) => sql`${v}::${sql.raw(pgType)}`),
+    sql`, `,
+  )}]`;
+}

--- a/apps/api/src/embeddings/embedding.service.ts
+++ b/apps/api/src/embeddings/embedding.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Inject, Logger } from '@nestjs/common';
 import { sql } from 'drizzle-orm';
 import { DATABASE_CONNECTION } from '../db/db.module';
+import { sqlArray } from '../db/sql-array';
 import { OllamaEmbeddingService, EMBEDDING_MODEL } from './ollama-embedding.service';
 
 export interface SimilarTransactionRow {
@@ -67,7 +68,7 @@ export class EmbeddingService {
              c.name AS "categoryName"
       FROM transactions t
       LEFT JOIN categories c ON t.category_id = c.id
-      WHERE t.id = ANY(${transactionIds})
+      WHERE t.id = ANY(${sqlArray(transactionIds, 'uuid')})
         AND t.deleted_at IS NULL
     `);
 

--- a/apps/api/src/investments/__tests__/investments.service.spec.ts
+++ b/apps/api/src/investments/__tests__/investments.service.spec.ts
@@ -1,4 +1,5 @@
 import { NotFoundException, ForbiddenException } from '@nestjs/common';
+import { PgDialect } from 'drizzle-orm/pg-core';
 import { InvestmentsService } from '../investments.service';
 
 describe('InvestmentsService', () => {
@@ -222,6 +223,48 @@ describe('InvestmentsService', () => {
       const bbb = result.holdings.find((h: any) => h.ticker === 'BBB');
       expect(bbb.marketValueCents).toBeNull();
       expect(bbb.isStale).toBe(true);
+    });
+
+    it('builds the price-lookup ticker filter as a real Postgres array, not a parenthesized list (#206)', async () => {
+      // Regression for #206 (same root cause as #202): `= ANY(($2, $3, ...))` is a row/list
+      // expression, not an array literal, and Postgres rejects it with "op ANY/ALL (array)
+      // requires array on right side" once there's more than one element. A 1-2 ticker
+      // fixture wouldn't catch this (ANY((x)) degenerates and "accidentally" works), so use
+      // the realistic 14-ticker production portfolio that originally triggered this bug.
+      const recentDate = new Date().toISOString().slice(0, 10);
+      const tickers = [
+        'CSGP', 'AMZN', 'COST', 'CRWD', 'CVS', 'DIS', 'DOCN',
+        'DOCU', 'MSFT', 'TTD', 'WIX', 'WMT', 'VMFXX', 'VUSXX',
+      ];
+      mockDb.execute
+        // getCurrentHoldings query
+        .mockResolvedValueOnce({
+          rows: tickers.map((ticker) => ({
+            investment_account_id: accountId,
+            ticker,
+            share_count: '1',
+            as_of: recentDate,
+            notes: null,
+          })),
+        })
+        // security_prices query
+        .mockResolvedValueOnce({ rows: [] });
+
+      await service.getPortfolioValue(userId);
+
+      const priceQuery = mockDb.execute.mock.calls[1][0];
+      const { sql: sqlText, params } = new PgDialect().sqlToQuery(priceQuery);
+
+      // Must be a genuine array literal (each element cast to ::text, wrapped in a real
+      // ARRAY[...] constructor), never a bare parenthesized list like ANY(($1, ...)).
+      expect(sqlText).toMatch(/=\s*ANY\(ARRAY\[(\$\d+::text,?\s*)+\]\)/);
+      expect(sqlText).not.toMatch(/=\s*ANY\(\(\$/);
+
+      // Every ticker must actually be bound as a param.
+      expect(params).toHaveLength(tickers.length);
+      for (const ticker of tickers) {
+        expect(params).toContain(ticker);
+      }
     });
   });
 

--- a/apps/api/src/investments/investments.service.ts
+++ b/apps/api/src/investments/investments.service.ts
@@ -7,6 +7,7 @@ import {
 import { DATABASE_CONNECTION } from '../db/db.module';
 import * as schema from '../db/schema';
 import { eq, and, isNull, desc, sql } from 'drizzle-orm';
+import { sqlArray } from '../db/sql-array';
 import type {
   CreateInvestmentAccountInput,
   UpdateInvestmentAccountInput,
@@ -228,11 +229,11 @@ export class InvestmentsService {
       return { totalCents: 0, holdings: [], staleFound: false, missingPriceFound: false, staleDays };
     }
 
-    const tickers = Array.from(new Set(holdings.map((h: any) => h.ticker)));
+    const tickers = Array.from(new Set(holdings.map((h: any) => h.ticker))) as string[];
     const priceRows = await this.db.execute(sql`
       SELECT DISTINCT ON (ticker) ticker, price_date::text AS price_date, close_cents, source
       FROM ${schema.securityPrices}
-      WHERE ticker = ANY(${tickers})
+      WHERE ticker = ANY(${sqlArray(tickers, 'text')})
       ORDER BY ticker, price_date DESC
     `);
     const prices = (priceRows.rows ?? priceRows) as any[];

--- a/apps/api/src/notifications/alert-engine.service.ts
+++ b/apps/api/src/notifications/alert-engine.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Inject } from '@nestjs/common';
 import { DATABASE_CONNECTION } from '../db/db.module';
 import * as schema from '../db/schema';
 import { sql } from 'drizzle-orm';
+import { sqlArray } from '../db/sql-array';
 import { NotificationsService } from './notifications.service';
 
 interface BudgetAlert {
@@ -66,7 +67,7 @@ export class AlertEngineService {
           )
       ) spent ON true
       WHERE b.deleted_at IS NULL
-        ${userIds?.length ? sql`AND b.user_id = ANY(${userIds})` : sql``}
+        ${userIds?.length ? sql`AND b.user_id = ANY(${sqlArray(userIds, 'uuid')})` : sql``}
     `);
 
     const alerts: BudgetAlert[] = [];

--- a/apps/api/src/recommendations/cash-manager.service.ts
+++ b/apps/api/src/recommendations/cash-manager.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Inject, Logger } from '@nestjs/common';
 import { and, desc, eq, isNull, sql } from 'drizzle-orm';
 import { DATABASE_CONNECTION } from '../db/db.module';
 import * as schema from '../db/schema';
+import { sqlArray } from '../db/sql-array';
 import { NotificationsService } from '../notifications/notifications.service';
 import { RecommendationSuppressionService } from './recommendation-suppression.service';
 import {
@@ -174,7 +175,7 @@ export class CashManagerService {
     const interestRows = await this.db.execute(sql`
       SELECT COALESCE(SUM(amount_cents), 0)::bigint AS total_cents
       FROM ${schema.transactions} t
-      WHERE t.account_id = ANY(${accountIds})
+      WHERE t.account_id = ANY(${sqlArray(accountIds, 'uuid')})
         AND t.user_id = ${userId}
         AND t.deleted_at IS NULL
         AND t.is_split_parent = false
@@ -187,7 +188,7 @@ export class CashManagerService {
     const snapshotRows = await this.db.execute(sql`
       SELECT AVG(balance_cents)::numeric AS avg_cents
       FROM ${schema.accountBalanceSnapshots}
-      WHERE account_id = ANY(${accountIds}) AND snapshot_date >= NOW() - INTERVAL '12 months'
+      WHERE account_id = ANY(${sqlArray(accountIds, 'uuid')}) AND snapshot_date >= NOW() - INTERVAL '12 months'
     `);
     const avgBalanceCents = Number((snapshotRows.rows ?? snapshotRows)[0]?.avg_cents ?? 0);
 
@@ -258,7 +259,7 @@ export class CashManagerService {
         ? await this.db.execute(sql`
       SELECT DISTINCT ON (account_id) account_id, balance_cents
       FROM ${schema.accountBalanceSnapshots}
-      WHERE account_id = ANY(${accountIds})
+      WHERE account_id = ANY(${sqlArray(accountIds, 'uuid')})
       ORDER BY account_id, snapshot_date DESC
     `)
         : { rows: [] };

--- a/apps/api/src/recommendations/investment-coach.service.ts
+++ b/apps/api/src/recommendations/investment-coach.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Inject, Logger } from '@nestjs/common';
 import { and, eq, isNull, sql } from 'drizzle-orm';
 import { DATABASE_CONNECTION } from '../db/db.module';
 import * as schema from '../db/schema';
+import { sqlArray } from '../db/sql-array';
 import { NotificationsService } from '../notifications/notifications.service';
 import { RecommendationSuppressionService } from './recommendation-suppression.service';
 import { AnalyticsService } from '../analytics/analytics.service';
@@ -89,7 +90,7 @@ export class InvestmentCoachService {
     const balanceRows = await this.db.execute(sql`
       SELECT DISTINCT ON (account_id) account_id, balance_cents
       FROM ${schema.accountBalanceSnapshots}
-      WHERE account_id = ANY(${accountIds})
+      WHERE account_id = ANY(${sqlArray(accountIds, 'uuid')})
       ORDER BY account_id, snapshot_date DESC
     `);
     return (balanceRows.rows ?? balanceRows).reduce((sum: number, r: any) => sum + Number(r.balance_cents), 0);


### PR DESCRIPTION
Committed successfully.

## Summary

**Root cause:** `InvestmentsService.getPortfolioValue` interpolated a raw JS array directly into `ANY(${tickers})`. Drizzle's `sql` tagged template renders a bare-array interpolation as a parenthesized list `($1, $2, ...)`, not a real Postgres array — Postgres accepts that shape for `ANY()` only in the degenerate single-element case and throws `op ANY/ALL (array) requires array on right side` once there are 2+ elements. This is the identical bug already fixed once in `AnalyticsService.subscriptionTotal` (#202), and it broke "Create Draft" on `/health` for any user with 2+ held tickers, since `MonthlyCloseService.gatherInputs` → `MonthlyCloseController.draft` calls `getPortfolioValue`.

**Investigation:** Grepped for the same `ANY(${...})` anti-pattern across the codebase and found it was not isolated to one extra call site — six other services had the identical bug (would break with 2+ elements): `embedding.service.ts`, `alert-engine.service.ts`, `account-freshness.service.ts` (two occurrences), `market-insight-detector.service.ts`, `cash-manager.service.ts` (three occurrences), and `investment-coach.service.ts`. All of these silently degenerate to a false "works" in tests/manual checks with 0–1 elements but throw with real multi-row data.

**Fix:** Added a small shared helper, `sqlArray(values, pgType)` (`apps/api/src/db/sql-array.ts`), that builds a genuine `ARRAY[$1::type, $2::type, ...]` literal (mirroring the pattern already used correctly elsewhere in the codebase, e.g. `transactions.service.ts`/`forecast.service.ts`), and replaced every broken `ANY(${arr})` call site with `ANY(${sqlArray(arr, 'uuid'|'text')})`.

**Verification:** Added a regression test for `getPortfolioValue` using the reported 14-ticker production portfolio shape, asserting via `PgDialect().sqlToQuery()` that the rendered SQL contains a real `ARRAY[...]` construct and not a parenthesized-list `ANY((...))` — mirroring the existing #202 regression test pat

_(summary truncated)_

---
### Test evidence
**1 new test case(s) added** (heuristic count):
```
 .../__tests__/investments.service.spec.ts          | 43 ++++++++++++++++++++++
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
eue for transaction id-1: DB connection lost[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/ingestion.processor.sync.spec.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 5[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/categorization/__tests__/learning.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/next-loan-due-date.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test: [32m[Nest] 61159  - [39m07/28/2026, 2:18:29 AM [32m    LOG[39m [38;5;3m[AlertCronProcessor] [39m[32mProcessing alert job: monthly-close-auto-draft[39m
@moneypulse/api:test: [32m[Nest] 61159  - [39m07/28/2026, 2:18:29 AM [32m    LOG[39m [38;5;3m[AlertCronProcessor] [39m[32mMonthly-close auto-draft: 3 user(s) processed, 2 close(s) created[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/monthly-close-cron.spec.ts [2m([22m[2m1 test[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m95 passed[39m[22m[90m (95)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m804 passed[39m[22m[90m (804)[39m
@moneypulse/api:test: [2m   Start at [22m 02:18:19
@moneypulse/api:test: [2m   Duration [22m 9.99s[2m (transform 3.06s, setup 0ms, import 52.47s, tests 1.89s, environment 6ms)[22m
@moneypulse/api:test: 

 Tasks:    2 successful, 2 total
Cached:    1 cached, 2 total
  Time:    10.491s
```
</details>

### Review
**Review verdict:** approve

---
Dispatched via coxd (`MyMoney-getportfoliovalue-throws-wit-1785204805`) · cost $1.520 · 🤖 coxd