### PR TITLE
13.7 AI monthly review + monthly-close MCP tools

### DIFF
--- a/apps/api/src/advisor/__tests__/mcp-client.service.spec.ts
+++ b/apps/api/src/advisor/__tests__/mcp-client.service.spec.ts
@@ -32,6 +32,8 @@ const ALL_TOOLS = [
   { name: 'get_earned_apy', description: 'w', inputSchema: { type: 'object' } }, // row-level, excluded
   { name: 'get_rate_watchlist', description: 'w', inputSchema: { type: 'object' } },
   { name: 'get_allocation', description: 'x', inputSchema: { type: 'object' } },
+  { name: 'get_monthly_close', description: 'y', inputSchema: { type: 'object' } },
+  { name: 'get_financial_health', description: 'z', inputSchema: { type: 'object' } },
   { name: 'get_transactions', description: 'ROW-LEVEL', inputSchema: { type: 'object' } },
   { name: 'search_transactions', description: 'ROW-LEVEL', inputSchema: { type: 'object' } },
   {

--- a/apps/api/src/advisor/advisor.module.ts
+++ b/apps/api/src/advisor/advisor.module.ts
@@ -24,6 +24,6 @@ import { AdvisorReviewService } from './review/advisor-review.service';
     AdvisorReviewService,
   ],
   controllers: [AdvisorController],
-  exports: [AdvisorService, AdvisorDigestService, AdvisorReviewService],
+  exports: [AdvisorService, AdvisorDigestService, AdvisorReviewService, AdvisorSettingsService, LlmProviderFactory],
 })
 export class AdvisorModule {}

--- a/apps/api/src/advisor/mcp-client.service.ts
+++ b/apps/api/src/advisor/mcp-client.service.ts
@@ -39,6 +39,8 @@ export const AGGREGATE_TOOL_ALLOWLIST = new Set([
   // get_earned_apy is intentionally excluded: its evidence cites individual interest
   // transactions (date/amount/description) — row-level data, same as get_transactions.
   'get_rate_watchlist', // user-entered advertised rates + auto-populated Treasury rows, no PII
+  'get_monthly_close', // frozen aggregate close totals/ratios/target-status/freshness, no row-level data
+  'get_financial_health', // ratio/target/trend rollup across recent closes, aggregate only
 ]);
 
 /** Anthropic tool definition shape (name + description + JSON schema). */

--- a/apps/api/src/analytics/__tests__/brief.service.spec.ts
+++ b/apps/api/src/analytics/__tests__/brief.service.spec.ts
@@ -130,16 +130,24 @@ describe('BriefService', () => {
     });
 
     it('includes budget pace section only when a budget is projected over 100%', async () => {
-      setYesterdayAndBudgetResponses(
-        { total: 0, count: 0, largest_amount: 0, largest_merchant: null },
-        [{ category_name: 'Dining', budget_cents: 10000, spent_cents: 9000 }],
-      );
-      const svc = makeService();
-      const result = await svc.buildBrief('user-1', 'America/New_York');
+      // Pin "today" to early in the month so the day-of-month/days-in-month
+      // pace projection is stable regardless of when this suite runs.
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-07-10T12:00:00Z'));
+      try {
+        setYesterdayAndBudgetResponses(
+          { total: 0, count: 0, largest_amount: 0, largest_merchant: null },
+          [{ category_name: 'Dining', budget_cents: 10000, spent_cents: 9000 }],
+        );
+        const svc = makeService();
+        const result = await svc.buildBrief('user-1', 'America/New_York');
 
-      const pace = result.sections.find((s) => s.label.includes('Budget pace'));
-      expect(pace).toBeDefined();
-      expect(pace!.value).toContain('Dining');
+        const pace = result.sections.find((s) => s.label.includes('Budget pace'));
+        expect(pace).toBeDefined();
+        expect(pace!.value).toContain('Dining');
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('omits budget pace section when no budget is over pace', async () => {

--- a/apps/api/src/monthly-close/__tests__/ai-monthly-review.service.spec.ts
+++ b/apps/api/src/monthly-close/__tests__/ai-monthly-review.service.spec.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ServiceUnavailableException } from '@nestjs/common';
+import {
+  AiMonthlyReviewService,
+  findForbiddenViolations,
+  parseBullets,
+  isCaveatBullet,
+  INCOMPLETE_CLOSE_CAVEAT_MARKER,
+} from '../ai-monthly-review.service';
+import type { LlmStreamChunk, LlmTurnResult } from '../../advisor/llm/types';
+
+function turn(text: string): AsyncIterable<LlmStreamChunk> {
+  const result: LlmTurnResult = {
+    text,
+    content: [{ type: 'text', text }],
+    toolCalls: [],
+    stopReason: 'end_turn',
+    usage: { inputTokens: 20, outputTokens: 10 },
+  };
+  return {
+    async *[Symbol.asyncIterator]() {
+      if (text) yield { type: 'text', text };
+      yield { type: 'final', result };
+    },
+  };
+}
+
+const completeSnapshot = {
+  id: 'snap-current',
+  snapshotMonth: '2026-06-01',
+  status: 'confirmed',
+  notes: null,
+  takeHomeIncomeCents: 500000,
+  expenseCents: 300000,
+  cashSavingsCents: 100000,
+  investmentContributionCents: 50000,
+  debtPrincipalPaidCents: 20000,
+  netWorthCents: 10000000,
+  savingsRateBps: 2000,
+  expenseRatioBps: 6000,
+  debtPaydownRateBps: 400,
+  targetStatus: { emergencyFund: 'on_track' },
+  freshness: { isComplete: true, missingManualAssets: [], staleAccounts: [], unverifiedLoans: [] },
+};
+
+const incompleteSnapshot = {
+  ...completeSnapshot,
+  freshness: {
+    isComplete: false,
+    missingManualAssets: ['Home'],
+    staleAccounts: [],
+    unverifiedLoans: [],
+  },
+};
+
+function build(opts: { narration: string; snapshot?: any; resolved?: any }) {
+  const snapshot = opts.snapshot ?? completeSnapshot;
+  const monthlyCloseService: any = {
+    findOne: vi.fn().mockResolvedValue(snapshot),
+    findAll: vi.fn().mockResolvedValue([snapshot]),
+    saveAiReview: vi.fn().mockResolvedValue(undefined),
+  };
+  const resolved =
+    'resolved' in opts ? opts.resolved : { provider: 'anthropic', model: 'claude-opus-4-8', apiKey: 'sk-test' };
+  const settings: any = { resolve: vi.fn().mockResolvedValue(resolved) };
+  const provider = { id: 'anthropic', streamTurn: vi.fn(() => turn(opts.narration)), testConnection: vi.fn() };
+  const factory: any = { create: vi.fn().mockReturnValue(provider) };
+  const aiLogs: any = { create: vi.fn().mockResolvedValue(undefined) };
+
+  const service = new AiMonthlyReviewService(monthlyCloseService, settings, factory, aiLogs);
+  return { service, monthlyCloseService, settings, factory, provider };
+}
+
+describe('AiMonthlyReviewService', () => {
+  it('returns 3-5 bullets from aggregate inputs when the close is complete', async () => {
+    const narration = [
+      '- Expenses were $3,000.00 against income of $5,000.00, in line with prior months.',
+      '- Net worth grew to $100,000.00 with $200.00 of debt principal paid down.',
+      '- With your emergency fund on track, direct the next dollar toward extra debt paydown.',
+    ].join('\n');
+    const { service, monthlyCloseService } = build({ narration });
+
+    const result = await service.review('user-1', '2026-06');
+
+    expect(result.bullets.length).toBeGreaterThanOrEqual(3);
+    expect(result.bullets.length).toBeLessThanOrEqual(5);
+    expect(result.isIncomplete).toBe(false);
+    expect(monthlyCloseService.saveAiReview).toHaveBeenCalledWith('user-1', '2026-06', expect.any(String));
+  });
+
+  it('refuses to deliver an uncaveated summary when the close is incomplete', async () => {
+    // Model ignores the incompleteness instruction and returns a "clean" summary.
+    const narration = [
+      '- Expenses were $3,000.00 against income of $5,000.00.',
+      '- Net worth grew to $100,000.00.',
+      '- Direct the next dollar toward extra debt paydown.',
+    ].join('\n');
+    const { service } = build({ narration, snapshot: incompleteSnapshot });
+
+    const result = await service.review('user-1', '2026-06');
+
+    expect(result.isIncomplete).toBe(true);
+    expect(result.bullets[0]).toContain(INCOMPLETE_CLOSE_CAVEAT_MARKER);
+    expect(isCaveatBullet(result.bullets[0])).toBe(true);
+  });
+
+  it('keeps the model-provided caveat when it already leads with one', async () => {
+    const narration = [
+      '- This close is incomplete: missing manual asset values (Home) — figures below are provisional.',
+      '- Expenses were $3,000.00 against income of $5,000.00.',
+      '- Direct the next dollar toward extra debt paydown.',
+    ].join('\n');
+    const { service } = build({ narration, snapshot: incompleteSnapshot });
+
+    const result = await service.review('user-1', '2026-06');
+    expect(isCaveatBullet(result.bullets[0])).toBe(true);
+    // Should not have double-prepended a second caveat bullet.
+    expect(result.bullets.filter((b) => isCaveatBullet(b)).length).toBe(1);
+  });
+
+  it('drops a bullet that narrates home-value appreciation as savings', async () => {
+    const narration = [
+      '- Your home value jumped this month, which saved you a lot on net worth.',
+      '- Expenses were $3,000.00 against income of $5,000.00.',
+      '- Net worth grew to $100,000.00.',
+      '- Direct the next dollar toward extra debt paydown.',
+    ].join('\n');
+    const { service } = build({ narration });
+
+    const result = await service.review('user-1', '2026-06');
+    expect(result.bullets.some((b) => /saved/i.test(b) && /home value/i.test(b))).toBe(false);
+  });
+
+  it('drops a bullet that recommends trading a specific security', async () => {
+    const narration = [
+      '- You should buy more shares of that stock next month.',
+      '- Expenses were $3,000.00 against income of $5,000.00.',
+      '- Net worth grew to $100,000.00.',
+      '- Direct the next dollar toward extra debt paydown.',
+    ].join('\n');
+    const { service } = build({ narration });
+
+    const result = await service.review('user-1', '2026-06');
+    expect(result.bullets.some((b) => /buy more shares/i.test(b))).toBe(false);
+  });
+
+  it('drops a bullet that double-counts a credit-card payment as an expense', async () => {
+    const narration = [
+      '- Your credit card payment of $500 was a big expense this month.',
+      '- Expenses were $3,000.00 against income of $5,000.00.',
+      '- Net worth grew to $100,000.00.',
+      '- Direct the next dollar toward extra debt paydown.',
+    ].join('\n');
+    const { service } = build({ narration });
+
+    const result = await service.review('user-1', '2026-06');
+    expect(result.bullets.some((b) => /credit card payment/i.test(b) && /expense/i.test(b))).toBe(false);
+  });
+
+  it('falls back to a deterministic minimal review when the model output is unusable', async () => {
+    const { service } = build({ narration: 'not a bullet list at all' });
+    const result = await service.review('user-1', '2026-06');
+    expect(result.bullets.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('throws when the advisor is not configured', async () => {
+    const { service } = build({ narration: '- anything', resolved: null });
+    await expect(service.review('user-1', '2026-06')).rejects.toThrow(ServiceUnavailableException);
+  });
+});
+
+describe('findForbiddenViolations', () => {
+  it('flags trade recommendations', () => {
+    expect(findForbiddenViolations('You should buy that stock now')).toContain('trade-recommendation');
+  });
+  it('flags market predictions', () => {
+    expect(findForbiddenViolations('The market will rally next quarter')).toContain('market-prediction');
+  });
+  it('flags home-value-as-savings narration in either order', () => {
+    expect(findForbiddenViolations('Your home value appreciation saved you money')).toContain(
+      'revaluation-as-savings',
+    );
+    expect(findForbiddenViolations('You saved money thanks to your home value appreciation')).toContain(
+      'revaluation-as-savings-reverse',
+    );
+  });
+  it('flags credit-card payments narrated as expenses', () => {
+    expect(findForbiddenViolations('Your credit card payment was an expense')).toContain(
+      'credit-card-payment-as-expense',
+    );
+  });
+  it('does not flag a clean bullet', () => {
+    expect(findForbiddenViolations('Expenses were $3,000.00 against income of $5,000.00.')).toEqual([]);
+  });
+});
+
+describe('parseBullets', () => {
+  it('extracts only lines starting with "- "', () => {
+    expect(parseBullets('preamble\n- one\n- two\ntrailing')).toEqual(['one', 'two']);
+  });
+  it('returns empty for unparsable text', () => {
+    expect(parseBullets('just a sentence')).toEqual([]);
+  });
+});

--- a/apps/api/src/monthly-close/ai-monthly-review.service.ts
+++ b/apps/api/src/monthly-close/ai-monthly-review.service.ts
@@ -1,0 +1,282 @@
+import { Injectable, Logger, NotFoundException, ServiceUnavailableException } from '@nestjs/common';
+import { MonthlyCloseService } from './monthly-close.service';
+import { AdvisorSettingsService } from '../advisor/advisor-settings.service';
+import { LlmProviderFactory } from '../advisor/llm/provider-factory';
+import { AiLogsService } from '../ai-logs/ai-logs.service';
+import { ADVISOR_DISCLAIMER } from '../advisor/advisor.service';
+import type { LlmStreamChunk, LlmTurnResult } from '../advisor/llm/types';
+
+const MAX_TOKENS = 2048;
+const MIN_BULLETS = 3;
+const MAX_BULLETS = 5;
+
+/** Prefix stamped on the deterministic caveat we prepend when the close is incomplete
+ *  and the model's own output doesn't already lead with a caveat (belt-and-suspenders —
+ *  epic #158/13.7 acceptance criterion #10: never emit an uncaveated summary). */
+export const INCOMPLETE_CLOSE_CAVEAT_MARKER = 'INCOMPLETE CLOSE';
+
+/** Keywords that indicate a bullet is already caveating an incomplete close. */
+const CAVEAT_KEYWORDS = ['incomplete', 'missing', 'stale', 'unverified', 'caveat'];
+
+/**
+ * Deterministic forbidden-pattern checks (13.7 spec): the model must never invent
+ * numbers (handled by prompt + tool-free, aggregate-only input), recommend trades,
+ * predict markets, treat home/car/gold revaluation as savings behavior, or double-count
+ * credit-card payments as expenses on top of the purchases that already flow through
+ * expenseCents. These are best-effort textual guards on top of the system prompt —
+ * any bullet that trips one is dropped rather than delivered.
+ */
+const FORBIDDEN_PATTERNS: Array<{ name: string; pattern: RegExp }> = [
+  {
+    name: 'trade-recommendation',
+    pattern: /\b(buy|sell|short|invest(?:ing)? in)\b[^.]{0,40}\b(stock|shares?|crypto|bitcoin|etf|bond|fund|ticker)\b/i,
+  },
+  {
+    name: 'market-prediction',
+    pattern: /\b(market|s&p|nasdaq|dow)\b[^.]{0,40}\b(will|is going to|expected to|predict(?:ed|ion)?)\b/i,
+  },
+  {
+    name: 'revaluation-as-savings',
+    pattern: /\b(home|house|car|vehicle|gold)\b[^.]{0,60}\b(value|appreciat\w*|worth)\b[^.]{0,60}\b(sav(?:ed|ings|e))\b/i,
+  },
+  {
+    name: 'revaluation-as-savings-reverse',
+    pattern: /\bsav(?:ed|ings|e)\b[^.]{0,60}\b(home|house|car|vehicle|gold)\b[^.]{0,60}\b(value|appreciat\w*|worth)\b/i,
+  },
+  {
+    name: 'credit-card-payment-as-expense',
+    pattern: /\bcredit[- ]card payment\b[^.]{0,60}\bexpense\b/i,
+  },
+  {
+    name: 'credit-card-payment-as-expense-reverse',
+    pattern: /\bexpense\b[^.]{0,60}\bcredit[- ]card payment\b/i,
+  },
+];
+
+/** Returns the names of forbidden patterns a bullet trips, if any. */
+export function findForbiddenViolations(bullet: string): string[] {
+  return FORBIDDEN_PATTERNS.filter((p) => p.pattern.test(bullet)).map((p) => p.name);
+}
+
+/** True if the bullet reads as caveating incomplete/stale data. */
+export function isCaveatBullet(bullet: string): boolean {
+  const lower = bullet.toLowerCase();
+  return CAVEAT_KEYWORDS.some((k) => lower.includes(k));
+}
+
+/** Split the model's raw answer into "- " bullet lines, trimmed. */
+export function parseBullets(raw: string): string[] {
+  return raw
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.startsWith('-'))
+    .map((l) => l.replace(/^-\s*/, '').trim())
+    .filter((l) => l.length > 0);
+}
+
+function pct(bps: number | null | undefined): string {
+  return bps === null || bps === undefined ? 'n/a' : `${(bps / 100).toFixed(1)}%`;
+}
+function dollars(cents: number | null | undefined): string {
+  return `$${(Number(cents ?? 0) / 100).toFixed(2)}`;
+}
+
+/** Render one snapshot row as a compact aggregate line for the prompt. */
+function summarizeSnapshot(row: any): string {
+  const month = String(row.snapshotMonth).slice(0, 7);
+  const freshness = row.freshness ?? {};
+  const caveat = freshness.isComplete ? '' : ' [INCOMPLETE]';
+  return (
+    `${month}${caveat}: income ${dollars(row.takeHomeIncomeCents)}, expenses ${dollars(row.expenseCents)}, ` +
+    `cash savings ${dollars(row.cashSavingsCents)}, investing ${dollars(row.investmentContributionCents)}, ` +
+    `debt principal paid ${dollars(row.debtPrincipalPaidCents)}, net worth ${dollars(row.netWorthCents)}, ` +
+    `savings rate ${pct(row.savingsRateBps)}, expense ratio ${pct(row.expenseRatioBps)}, ` +
+    `target status ${JSON.stringify(row.targetStatus ?? {})}`
+  );
+}
+
+export interface AiMonthlyReviewResult {
+  bullets: string[];
+  disclaimer: string;
+  isIncomplete: boolean;
+}
+
+const SYSTEM_PROMPT = `You are MoneyPulse's monthly-close reviewer. You receive ONLY pre-computed aggregate figures for one user's monthly close (income/expense/savings/investment/debt/net-worth totals, ratio percentages, target status, and freshness flags) plus prior-month trend summaries. You never see raw transactions, merchant names, account numbers, or addresses.
+
+Output contract:
+- Output ONLY a markdown bullet list, one line per item, each starting with "- ". No preamble or closing paragraph.
+- Produce 3 to 5 bullets total, covering:
+  1. One expense-accountability observation (spending vs. income or vs. prior months).
+  2. One net-worth or debt-paydown observation.
+  3. One "next dollar" (pay-yourself-first / FOO) recommendation — where the next marginal dollar should go given targets and current rates.
+  4. If the close is flagged incomplete (freshness.isComplete = false), a bullet that clearly states the close is incomplete/provisional and names what's missing — this bullet is MANDATORY and must be the FIRST bullet whenever the close is incomplete.
+
+Hard rules:
+- Every number you state MUST come from the aggregate data you were given. Never invent, estimate, or extrapolate a figure.
+- Never recommend buying, selling, or timing any specific stock, crypto, bond, or fund. Never predict market direction.
+- Home, car, or gold value changes are asset revaluation, NOT savings behavior — never describe them as "saved" or as part of the savings rate.
+- Credit-card PAYMENTS are debt settlement, not a new expense — the underlying purchases are already counted in expenses for the month they were made. Never describe a credit-card payment itself as an expense.
+- If the close is incomplete, you MUST NOT produce a clean, uncaveated summary — lead with the caveat bullet and hedge the other bullets accordingly (e.g. "based on partial data").`;
+
+/**
+ * 13.7 — AI monthly review. Reuses the Phase-12 advisor LLM provider infra but, unlike
+ * the interactive chat/proactive-review services, takes NO tools: the monthly-close
+ * aggregates are already fully assembled server-side (current month + prior trend),
+ * so there is nothing for the model to fetch and therefore nothing row-level it could
+ * ever request. This keeps the aggregates-only privacy posture structurally guaranteed
+ * rather than allowlist-enforced alone.
+ */
+@Injectable()
+export class AiMonthlyReviewService {
+  private readonly logger = new Logger(AiMonthlyReviewService.name);
+
+  constructor(
+    private readonly monthlyCloseService: MonthlyCloseService,
+    private readonly settings: AdvisorSettingsService,
+    private readonly factory: LlmProviderFactory,
+    private readonly aiLogs: AiLogsService,
+  ) {}
+
+  /** Build the user-turn prompt text from the current close + trailing trend rows. */
+  buildPrompt(current: any, trendRows: any[], userNotes?: string | null): string {
+    const trendLines = trendRows
+      .filter((r) => r.id !== current.id)
+      .slice(0, 12)
+      .map(summarizeSnapshot);
+
+    return [
+      'Current month close:',
+      summarizeSnapshot(current),
+      '',
+      trendLines.length > 0 ? 'Prior months (most recent first):' : 'No prior months on record.',
+      ...(trendLines.length > 0 ? [trendLines.join('\n')] : []),
+      ...(userNotes ? ['', `User notes for this month: ${userNotes}`] : []),
+    ].join('\n');
+  }
+
+  /** Deterministic fallback used when the model can't be reached or produces nothing
+   *  usable — still satisfies the "never emit a clean uncaveated summary" rule. */
+  private fallbackBullets(current: any, isIncomplete: boolean): string[] {
+    const bullets: string[] = [];
+    if (isIncomplete) {
+      const freshness = current.freshness ?? {};
+      const gaps = [
+        ...(freshness.missingManualAssets ?? []),
+        ...(freshness.staleAccounts ?? []),
+        ...(freshness.unverifiedLoans ?? []),
+      ];
+      bullets.push(
+        `[${INCOMPLETE_CLOSE_CAVEAT_MARKER}] This close is missing or has stale data (${gaps.length} item(s)) — the figures below are provisional until it's completed.`,
+      );
+    }
+    bullets.push(
+      `Expenses were ${dollars(current.expenseCents)} against take-home income of ${dollars(current.takeHomeIncomeCents)} (expense ratio ${pct(current.expenseRatioBps)}).`,
+    );
+    bullets.push(`Net worth stands at ${dollars(current.netWorthCents)}, with debt-paydown rate ${pct(current.debtPaydownRateBps)}.`);
+    bullets.push(
+      `Based on your current savings rate (${pct(current.savingsRateBps)}) and target status, review your Foundation Order of Operations to decide where the next dollar should go.`,
+    );
+    return bullets.slice(0, MAX_BULLETS);
+  }
+
+  /**
+   * Run the AI monthly review for `userId`/`month`. Persists the result text onto the
+   * snapshot's `aiReview` column and returns the structured bullets.
+   */
+  async review(userId: string, month: string): Promise<AiMonthlyReviewResult> {
+    const current = await this.monthlyCloseService.findOne(userId, month);
+    if (!current) throw new NotFoundException('Monthly close not found');
+
+    const freshness = current.freshness as { isComplete?: boolean } | null;
+    const isIncomplete = !(freshness?.isComplete ?? false);
+
+    const resolved = await this.settings.resolve();
+    if (!resolved) {
+      throw new ServiceUnavailableException('AI advisor is not configured');
+    }
+
+    const trendRows = await this.monthlyCloseService.findAll(userId, 13);
+    const prompt = this.buildPrompt(current, trendRows, current.notes);
+
+    const provider = this.factory.create(resolved.provider, resolved.apiKey);
+    const startMs = Date.now();
+    let answer = '';
+    let tokensIn = 0;
+    let tokensOut = 0;
+    try {
+      for await (const chunk of provider.streamTurn({
+        model: resolved.model,
+        maxTokens: MAX_TOKENS,
+        system: SYSTEM_PROMPT,
+        tools: [],
+        messages: [{ role: 'user', content: prompt }],
+      }) as AsyncIterable<LlmStreamChunk>) {
+        if (chunk.type === 'text') answer += chunk.text;
+        else {
+          const final: LlmTurnResult = chunk.result;
+          tokensIn += final.usage.inputTokens;
+          tokensOut += final.usage.outputTokens;
+        }
+      }
+    } catch (err: any) {
+      this.logger.error(`AI monthly review LLM call failed: ${err.message}`);
+      answer = '';
+    } finally {
+      this.aiLogs
+        .create({
+          userId,
+          promptType: 'advisor',
+          model: resolved.model,
+          inputText: `ai-monthly-review-${month}`,
+          outputText: answer || undefined,
+          tokenCountIn: tokensIn || undefined,
+          tokenCountOut: tokensOut || undefined,
+          latencyMs: Date.now() - startMs,
+          piiDetected: false,
+          piiTypesFound: [],
+        })
+        .catch((err) => this.logger.warn(`AI monthly review log failed: ${err.message}`));
+    }
+
+    let bullets = this.sanitizeBullets(parseBullets(answer), isIncomplete);
+    if (bullets.length < MIN_BULLETS) {
+      bullets = this.fallbackBullets(current, isIncomplete);
+    }
+
+    const text = bullets.map((b) => `- ${b}`).join('\n');
+    try {
+      await this.monthlyCloseService.saveAiReview(userId, month, text);
+    } catch (err: any) {
+      this.logger.warn(`Failed to persist AI monthly review: ${err.message}`);
+    }
+
+    return { bullets, disclaimer: ADVISOR_DISCLAIMER, isIncomplete };
+  }
+
+  /**
+   * Drop any bullet that trips a forbidden pattern, cap to MAX_BULLETS, and — for an
+   * incomplete close — force a caveat bullet to the front if the model didn't already
+   * lead with one (acceptance criterion #10: never a clean uncaveated summary).
+   */
+  private sanitizeBullets(rawBullets: string[], isIncomplete: boolean): string[] {
+    const clean: string[] = [];
+    for (const bullet of rawBullets) {
+      const violations = findForbiddenViolations(bullet);
+      if (violations.length > 0) {
+        this.logger.warn(`AI monthly review: dropped bullet for [${violations.join(', ')}]: "${bullet}"`);
+        continue;
+      }
+      clean.push(bullet);
+    }
+
+    if (isIncomplete) {
+      const hasCaveat = clean.some((b) => isCaveatBullet(b));
+      if (!hasCaveat || !isCaveatBullet(clean[0] ?? '')) {
+        const caveat = `[${INCOMPLETE_CLOSE_CAVEAT_MARKER}] This close is flagged incomplete — treat the figures below as provisional until missing/stale data is filled in.`;
+        clean.unshift(caveat);
+      }
+    }
+
+    return clean.slice(0, MAX_BULLETS);
+  }
+}

--- a/apps/api/src/monthly-close/monthly-close.controller.ts
+++ b/apps/api/src/monthly-close/monthly-close.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, Post, Patch, Param, Body, Query, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
 import { MonthlyCloseService } from './monthly-close.service';
+import { AiMonthlyReviewService } from './ai-monthly-review.service';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
 import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
@@ -11,7 +12,10 @@ import type { AuthTokenPayload, PatchMonthlyCloseInput } from '@moneypulse/share
 @Controller('monthly-close')
 @UseGuards(JwtAuthGuard)
 export class MonthlyCloseController {
-  constructor(private readonly monthlyCloseService: MonthlyCloseService) {}
+  constructor(
+    private readonly monthlyCloseService: MonthlyCloseService,
+    private readonly aiMonthlyReviewService: AiMonthlyReviewService,
+  ) {}
 
   @Get()
   @ApiOperation({ summary: 'List recent monthly closes (6–12 month grid)' })
@@ -58,5 +62,11 @@ export class MonthlyCloseController {
   @ApiOperation({ summary: 'Reopen a confirmed close back to draft' })
   async reopen(@Param('month') month: string, @CurrentUser() user: AuthTokenPayload) {
     return { data: await this.monthlyCloseService.reopen(user.sub, month) };
+  }
+
+  @Post(':month/ai-review')
+  @ApiOperation({ summary: 'Generate (or regenerate) the AI monthly review for this close' })
+  async aiReview(@Param('month') month: string, @CurrentUser() user: AuthTokenPayload) {
+    return { data: await this.aiMonthlyReviewService.review(user.sub, month) };
   }
 }

--- a/apps/api/src/monthly-close/monthly-close.module.ts
+++ b/apps/api/src/monthly-close/monthly-close.module.ts
@@ -1,15 +1,18 @@
 import { Module } from '@nestjs/common';
 import { MonthlyCloseService } from './monthly-close.service';
+import { AiMonthlyReviewService } from './ai-monthly-review.service';
 import { MonthlyCloseController } from './monthly-close.controller';
 import { ManualAssetsModule } from './manual-assets.module';
 import { InvestmentsModule } from '../investments/investments.module';
 import { LoansModule } from '../loans/loans.module';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { AdvisorModule } from '../advisor/advisor.module';
+import { AiLogsModule } from '../ai-logs/ai-logs.module';
 
 @Module({
-  imports: [ManualAssetsModule, InvestmentsModule, LoansModule, NotificationsModule],
-  providers: [MonthlyCloseService],
+  imports: [ManualAssetsModule, InvestmentsModule, LoansModule, NotificationsModule, AdvisorModule, AiLogsModule],
+  providers: [MonthlyCloseService, AiMonthlyReviewService],
   controllers: [MonthlyCloseController],
-  exports: [MonthlyCloseService],
+  exports: [MonthlyCloseService, AiMonthlyReviewService],
 })
 export class MonthlyCloseModule {}

--- a/apps/api/src/monthly-close/monthly-close.service.ts
+++ b/apps/api/src/monthly-close/monthly-close.service.ts
@@ -502,6 +502,20 @@ export class MonthlyCloseService {
     return rows[0];
   }
 
+  /** Persist the rendered AI monthly review text onto the snapshot (13.7). Does not
+   *  touch status/notes/edit-audit fields — this is a derived artifact, not a user edit. */
+  async saveAiReview(userId: string, month: string, aiReview: string) {
+    const snapshotMonth = toMonthStart(month);
+    const existing = await this.findRow(userId, snapshotMonth);
+    if (!existing) throw new NotFoundException('Monthly close not found');
+    const rows = await this.db
+      .update(schema.monthlyFinancialSnapshots)
+      .set({ aiReview, updatedAt: new Date() })
+      .where(eq(schema.monthlyFinancialSnapshots.id, existing.id))
+      .returning();
+    return rows[0];
+  }
+
   async reopen(userId: string, month: string) {
     const snapshotMonth = toMonthStart(month);
     const existing = await this.findRow(userId, snapshotMonth);

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -30,6 +30,8 @@ import { registerGetSubscriptionTotal } from './tools/get-subscription-total.js'
 import { registerGetYoyComparison } from './tools/get-yoy-comparison.js';
 import { registerGetPortfolioValue } from './tools/get-portfolio-value.js';
 import { registerGetAllocation } from './tools/get-allocation.js';
+import { registerGetMonthlyClose } from './tools/get-monthly-close.js';
+import { registerGetFinancialHealth } from './tools/get-financial-health.js';
 import { close } from './db.js';
 import http from 'node:http';
 
@@ -67,6 +69,8 @@ registerGetSubscriptionTotal(server);
 registerGetYoyComparison(server);
 registerGetPortfolioValue(server);
 registerGetAllocation(server);
+registerGetMonthlyClose(server);
+registerGetFinancialHealth(server);
 
 const mode = process.argv.includes('--sse') ? 'sse' : 'stdio';
 

--- a/apps/mcp-server/src/tools/get-financial-health.ts
+++ b/apps/mcp-server/src/tools/get-financial-health.ts
@@ -23,7 +23,7 @@ export function registerGetFinancialHealth(server: McpServer) {
       const userId = await getUserId();
       const rows = await query(
         `SELECT * FROM monthly_financial_snapshots
-         WHERE user_id = $1
+         WHERE monthly_financial_snapshots.user_id = $1
          ORDER BY snapshot_month DESC
          LIMIT $2`,
         [userId, params.months],

--- a/apps/mcp-server/src/tools/get-financial-health.ts
+++ b/apps/mcp-server/src/tools/get-financial-health.ts
@@ -1,0 +1,66 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { query, getUserId } from '../db.js';
+
+/**
+ * 13.7 — the ratio/target/trend rollup across recent monthly closes. Aggregate-only:
+ * ratio percentages, target statuses and net-worth/savings-rate trend lines, never
+ * row-level transactions or account identifiers.
+ */
+export function registerGetFinancialHealth(server: McpServer) {
+  server.tool(
+    'get_financial_health',
+    'Trend of savings/investing/debt-paydown/wealth-building rates, expense ratio, and target status across recent monthly closes. Answers "how is my financial health trending" and "am I hitting my targets".',
+    {
+      months: z
+        .number()
+        .min(1)
+        .max(24)
+        .default(6)
+        .describe('How many trailing closed months to include'),
+    },
+    async (params) => {
+      const userId = await getUserId();
+      const rows = await query(
+        `SELECT * FROM monthly_financial_snapshots
+         WHERE user_id = $1
+         ORDER BY snapshot_month DESC
+         LIMIT $2`,
+        [userId, params.months],
+      );
+
+      if (rows.length === 0) {
+        return { content: [{ type: 'text' as const, text: 'No monthly closes available yet.' }] };
+      }
+
+      const pct = (bps: number | null) => (bps === null || bps === undefined ? 'n/a' : `${(Number(bps) / 100).toFixed(1)}%`);
+      const dollars = (c: number) => `$${(Number(c) / 100).toFixed(2)}`;
+
+      const ordered = [...rows].reverse(); // oldest → newest
+      const lines = ordered.map((r: any) => {
+        const month = new Date(r.snapshot_month).toISOString().slice(0, 7);
+        const freshness = r.freshness ?? {};
+        const caveat = freshness.isComplete ? '' : ' [incomplete]';
+        return `${month}${caveat}: savings ${pct(r.savings_rate_bps)}, investing ${pct(r.investing_rate_bps)}, debt-paydown ${pct(r.debt_paydown_rate_bps)}, wealth-building ${pct(r.wealth_building_rate_bps)}, expense-ratio ${pct(r.expense_ratio_bps)}, net worth ${dollars(r.net_worth_cents)}`;
+      });
+
+      const latest = rows[0] as any;
+      const latestTargets = latest.target_status ?? {};
+      const incompleteCount = rows.filter((r: any) => !(r.freshness ?? {}).isComplete).length;
+
+      const text = [
+        `Financial health — trailing ${rows.length} month(s):`,
+        lines.join('\n'),
+        '',
+        `Latest (${new Date(latest.snapshot_month).toISOString().slice(0, 7)}) target status: ${JSON.stringify(latestTargets)}`,
+        incompleteCount > 0
+          ? `Note: ${incompleteCount} of ${rows.length} month(s) in this window are flagged incomplete (missing/stale data) — treat their ratios as provisional.`
+          : undefined,
+      ]
+        .filter(Boolean)
+        .join('\n');
+
+      return { content: [{ type: 'text' as const, text }] };
+    },
+  );
+}

--- a/apps/mcp-server/src/tools/get-monthly-close.ts
+++ b/apps/mcp-server/src/tools/get-monthly-close.ts
@@ -27,13 +27,13 @@ export function registerGetMonthlyClose(server: McpServer) {
       const rows = params.month
         ? await query(
             `SELECT * FROM monthly_financial_snapshots
-             WHERE user_id = $1 AND snapshot_month = date_trunc('month', $2::date)
+             WHERE monthly_financial_snapshots.user_id = $1 AND snapshot_month = date_trunc('month', $2::date)
              LIMIT 1`,
             [userId, params.month.length === 7 ? `${params.month}-01` : params.month],
           )
         : await query(
             `SELECT * FROM monthly_financial_snapshots
-             WHERE user_id = $1
+             WHERE monthly_financial_snapshots.user_id = $1
              ORDER BY snapshot_month DESC
              LIMIT 1`,
             [userId],

--- a/apps/mcp-server/src/tools/get-monthly-close.ts
+++ b/apps/mcp-server/src/tools/get-monthly-close.ts
@@ -1,0 +1,75 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { query, getUserId } from '../db.js';
+
+/**
+ * 13.7 — aggregate monthly-close summary. Reads only the frozen aggregate columns on
+ * `monthly_financial_snapshots` (income/expense/savings/net-worth totals + ratio bps +
+ * target status + freshness flags) — never raw transactions, merchant names, or
+ * account numbers. Safe for the aggregates-only cloud advisor allowlist.
+ */
+export function registerGetMonthlyClose(server: McpServer) {
+  server.tool(
+    'get_monthly_close',
+    'Aggregate monthly-close summary for a given month (or the most recent close if omitted): income, expenses, savings/investment/debt-paydown amounts, assets/liabilities/net worth, ratio percentages, target status, and freshness (whether the close is complete). Answers "what did my close for month X look like".',
+    {
+      month: z
+        .string()
+        .regex(/^\d{4}-\d{2}(-\d{2})?$/)
+        .optional()
+        .describe('Month as YYYY-MM (or YYYY-MM-DD). Defaults to the most recent close.'),
+    },
+    async (params) => {
+      const userId = await getUserId();
+      const dollars = (c: number) => `$${(Number(c) / 100).toFixed(2)}`;
+      const pct = (bps: number | null) => (bps === null || bps === undefined ? 'n/a' : `${(Number(bps) / 100).toFixed(1)}%`);
+
+      const rows = params.month
+        ? await query(
+            `SELECT * FROM monthly_financial_snapshots
+             WHERE user_id = $1 AND snapshot_month = date_trunc('month', $2::date)
+             LIMIT 1`,
+            [userId, params.month.length === 7 ? `${params.month}-01` : params.month],
+          )
+        : await query(
+            `SELECT * FROM monthly_financial_snapshots
+             WHERE user_id = $1
+             ORDER BY snapshot_month DESC
+             LIMIT 1`,
+            [userId],
+          );
+
+      if (rows.length === 0) {
+        return { content: [{ type: 'text' as const, text: 'No monthly close found for that month.' }] };
+      }
+
+      const r = rows[0] as any;
+      const month = new Date(r.snapshot_month).toISOString().slice(0, 7);
+      const freshness = r.freshness ?? {};
+      const targetStatus = r.target_status ?? {};
+
+      const text = [
+        `Monthly close — ${month} (${r.status}${r.is_edited ? ', edited' : ''}):`,
+        `  Take-home income: ${dollars(r.take_home_income_cents)}`,
+        `  Expenses: ${dollars(r.expense_cents)} (fixed ${dollars(r.fixed_expense_cents)}, variable ${dollars(r.variable_expense_cents)})`,
+        `  Cash savings: ${dollars(r.cash_savings_cents)}`,
+        `  Investment contribution: ${dollars(r.investment_contribution_cents)}`,
+        `  Debt principal paid: ${dollars(r.debt_principal_paid_cents)} (extra: ${dollars(r.extra_debt_principal_paid_cents)})`,
+        `  Total assets: ${dollars(r.total_asset_cents)} (liquid ${dollars(r.liquid_asset_cents)}, investment ${dollars(r.investment_asset_cents)}, manual ${dollars(r.manual_asset_cents)})`,
+        `  Total liabilities: ${dollars(r.total_liability_cents)} (credit card ${dollars(r.credit_card_liability_cents)}, loans ${dollars(r.loan_liability_cents)})`,
+        `  Net worth: ${dollars(r.net_worth_cents)}`,
+        `  Savings rate: ${pct(r.savings_rate_bps)}, Investing rate: ${pct(r.investing_rate_bps)}, Debt-paydown rate: ${pct(r.debt_paydown_rate_bps)}, Wealth-building rate: ${pct(r.wealth_building_rate_bps)}`,
+        `  Expense ratio: ${pct(r.expense_ratio_bps)}, Liquid/net-worth ratio: ${pct(r.liquid_net_worth_ratio_bps)}, Debt/asset ratio: ${pct(r.debt_asset_ratio_bps)}`,
+        `  Target status: ${JSON.stringify(targetStatus)}`,
+        `  Close complete: ${freshness.isComplete ? 'yes' : 'NO — missing/stale data present'}`,
+        freshness.isComplete
+          ? undefined
+          : `  Freshness gaps: missing manual assets [${(freshness.missingManualAssets ?? []).join(', ')}], stale accounts [${(freshness.staleAccounts ?? []).length}], unverified loans [${(freshness.unverifiedLoans ?? []).join(', ')}]`,
+      ]
+        .filter(Boolean)
+        .join('\n');
+
+      return { content: [{ type: 'text' as const, text }] };
+    },
+  );
+}

--- a/apps/web/src/app/(protected)/health/page.tsx
+++ b/apps/web/src/app/(protected)/health/page.tsx
@@ -14,6 +14,7 @@ import { MonthlyCloseMonthCard } from '@/components/monthly-close/MonthlyCloseMo
 import { ManualAssetPanel } from '@/components/monthly-close/ManualAssetPanel';
 import { LoanVerificationPanel } from '@/components/monthly-close/LoanVerificationPanel';
 import { CoachOverlayPanel } from '@/components/monthly-close/CoachOverlayPanel';
+import { AiMonthlyReview } from '@/components/monthly-close/AiMonthlyReview';
 
 function currentMonth(): string {
   const now = new Date();
@@ -114,6 +115,8 @@ export default function HealthPage() {
       </div>
 
       <CoachOverlayPanel snapshot={current} />
+
+      <AiMonthlyReview month={month} hasClose={!!current} />
 
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
         <ManualAssetPanel

--- a/apps/web/src/components/monthly-close/AiMonthlyReview.tsx
+++ b/apps/web/src/components/monthly-close/AiMonthlyReview.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { Sparkles } from 'lucide-react';
+import { useAiMonthlyReview } from '@/lib/hooks/useMonthlyClose';
+
+/**
+ * 13.7 — AI monthly review card: 3-5 bullets generated from this month's aggregate
+ * close data (+ prior-month trend), never raw transactions. Purely on-demand — the
+ * user triggers generation and the result is rendered as-is, including any caveat
+ * bullet the API forces to the front when the close is flagged incomplete.
+ */
+export function AiMonthlyReview({ month, hasClose }: { month: string; hasClose: boolean }) {
+  const { mutate, data, isPending, isError, error } = useAiMonthlyReview();
+
+  return (
+    <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4" data-testid="ai-monthly-review">
+      <div className="mb-2 flex items-center justify-between">
+        <h3 className="flex items-center gap-2 font-bold">
+          <Sparkles className="h-4 w-4 text-[var(--primary)]" />
+          AI Monthly Review
+        </h3>
+        <button
+          onClick={() => mutate(month)}
+          disabled={!hasClose || isPending}
+          className="rounded-md border border-[var(--border)] px-3 py-1.5 text-xs font-semibold hover:bg-[var(--muted)] disabled:opacity-50"
+        >
+          {isPending ? 'Generating…' : data ? 'Regenerate' : 'Generate review'}
+        </button>
+      </div>
+
+      {!hasClose && (
+        <p className="text-sm text-[var(--muted-foreground)]">Create a draft close first to generate a review.</p>
+      )}
+
+      {isError && (
+        <p className="text-sm text-[var(--destructive,#dc2626)]">
+          {(error as any)?.message ?? 'Could not generate the AI review — is the advisor configured?'}
+        </p>
+      )}
+
+      {data?.data && (
+        <div className="space-y-2">
+          <ul className="list-disc space-y-1 pl-5 text-sm">
+            {data.data.bullets.map((b, i) => (
+              <li key={i}>{b}</li>
+            ))}
+          </ul>
+          <p className="text-xs text-[var(--muted-foreground)]">{data.data.disclaimer}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/hooks/useMonthlyClose.ts
+++ b/apps/web/src/lib/hooks/useMonthlyClose.ts
@@ -76,6 +76,22 @@ export function useConfirmClose() {
   });
 }
 
+export interface AiMonthlyReviewResult {
+  bullets: string[];
+  disclaimer: string;
+  isIncomplete: boolean;
+}
+
+/** 13.7 — AI monthly review: 3-5 bullets from the close's aggregate figures only. */
+export function useAiMonthlyReview() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (month: string) =>
+      api.post<{ data: AiMonthlyReviewResult }>(`/monthly-close/${month}/ai-review`, {}),
+    onSuccess: () => invalidateAll(queryClient),
+  });
+}
+
 export function useReopenClose() {
   const queryClient = useQueryClient();
   return useMutation({


### PR DESCRIPTION
Fixed and committed. Root cause: the failing test wasn't related to the 13.7 feature — `BriefService`'s budget-pace projection formula (`spent/dayOfMonth × daysInMonth`) is date-sensitive, and running the suite late in the month made a previously-passing 90%-spent fixture no longer project over 100%, flipping the test to fail. Pinned the system clock to a fixed early-month date for that one test (via `vi.useFakeTimers`/`setSystemTime`, restored in a `finally`) so it's deterministic regardless of when the suite runs, with no change to production logic. Full API suite now passes (96 files / 819 tests), and the mcp-server suite fixed in the prior turn still passes (80 tests).

---
### Test evidence
**15 new test case(s) added** (heuristic count):
```
 .../advisor/__tests__/mcp-client.service.spec.ts   |   2 +
 .../src/analytics/__tests__/brief.service.spec.ts  |  28 +-
 .../__tests__/ai-monthly-review.service.spec.ts    | 204 +++++++++++++++
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
m[39m
@moneypulse/api:test:  [32m✓[39m src/categorization/__tests__/learning.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 5[2mms[22m[39m
@moneypulse/api:test: [90mstdout[2m | src/embeddings/__tests__/embedding-categorizer.service.spec.ts[2m > [22m[2mEmbeddingCategorizerService.voteFromNeighbors (pure NN vote logic)[2m > [22m[2mNN accuracy report: predicts the correct category for a held-out slice
@moneypulse/api:test: [22m[39m[11.10 NN categorization accuracy] held-out=4 predicted=3 correct=3 precision=100%
@moneypulse/api:test: 
@moneypulse/api:test:  [32m✓[39m src/embeddings/__tests__/embedding-categorizer.service.spec.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/expected-cycle-date.spec.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/next-loan-due-date.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m96 passed[39m[22m[90m (96)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m819 passed[39m[22m[90m (819)[39m
@moneypulse/api:test: [2m   Start at [22m 11:56:00
@moneypulse/api:test: [2m   Duration [22m 10.98s[2m (transform 3.68s, setup 0ms, import 57.39s, tests 2.12s, environment 6ms)[22m
@moneypulse/api:test: 

 Tasks:    4 successful, 4 total
Cached:    3 cached, 4 total
  Time:    11.439s
```
</details>

### Review
**Review verdict:** approve

Findings (advisory — did not block landing):
- [low/advisory] apps/api/src/monthly-close/ai-monthly-review.service.ts:50 — trade-recommendation forbidden-pattern regex matches 'invest in ... fund', which will false-positive on the system-prompt-mandated 'next dollar'/FOO recommendation bullet (e.g. 'invest in an index fund'), silently dropping a required bullet and possibly forcing the deterministic fallback.
- [low/advisory] apps/api/src/monthly-close/ai-monthly-review.service.ts:268 — When the model emits a caveat bullet that is not first, sanitizeBullets prepends a second caveat (hasCaveat true but clean[0] not a caveat), producing two caveat bullets; harmless belt-and-suspenders but redundant.
- [low/advisory] apps/mcp-server/src/tools/get-financial-health.ts:48 — Raw-SQL tools reference columns (investing_rate_bps, wealth_building_rate_bps, liquid_net_worth_ratio_bps, etc.) not visible in the diff and not used by the API's summarizeSnapshot; unverifiable here—confirm these columns exist on monthly_financial_snapshots or the tool throws at runtime.

---
Dispatched via coxd (`MyMoney-13-7-ai-monthly-review-month-1785239220`) · cost $3.779 · 🤖 coxd