### PR TITLE
Wire benchmark rate-move detection to an actual market_event notificat

### DIFF
--- a/apps/api/src/jobs/alert-cron.processor.ts
+++ b/apps/api/src/jobs/alert-cron.processor.ts
@@ -165,13 +165,15 @@ export class AlertCronProcessor extends WorkerHost {
         this.logger.log(`Treasury watchlist auto-sync: ${syncResult.usersSynced} user(s) synced`);
 
         // Cash Manager event trigger leg 1 (manifest: "benchmark-rate-move(>=25bps)").
-        const benchmarkMoved = await this.cashManagerService.checkBenchmarkRateMove(
+        const benchmarkMove = await this.cashManagerService.checkBenchmarkRateMove(
           result.refreshed,
         );
-        if (benchmarkMoved) {
+        if (benchmarkMove.moved) {
           await this.alertsQueue.add('cash-manager-check', {}, { removeOnComplete: true });
+          await this.cashManagerService.notifyBenchmarkRateMove(benchmarkMove);
           this.logger.log(
-            'Benchmark rate move >=25bps detected — queued ad hoc cash-manager-check',
+            `Benchmark rate move >=25bps detected (${benchmarkMove.deltaBps}bps) — queued ` +
+              'ad hoc cash-manager-check and dispatched market_event notification',
           );
         }
         break;

--- a/apps/api/src/recommendations/__tests__/cash-manager.service.spec.ts
+++ b/apps/api/src/recommendations/__tests__/cash-manager.service.spec.ts
@@ -120,9 +120,9 @@ describe('CashManagerService — benchmark-rate-move event trigger', () => {
     const db: any = { execute: vi.fn() };
     const svc = new CashManagerService(db, notifications as any, suppression as any);
 
-    const moved = await svc.checkBenchmarkRateMove(['gas_retail_regular']);
+    const result = await svc.checkBenchmarkRateMove(['gas_retail_regular']);
 
-    expect(moved).toBe(false);
+    expect(result.moved).toBe(false);
     expect(db.execute).not.toHaveBeenCalled();
   });
 
@@ -138,12 +138,12 @@ describe('CashManagerService — benchmark-rate-move event trigger', () => {
     };
     const svc = new CashManagerService(db, notifications as any, suppression as any);
 
-    const moved = await svc.checkBenchmarkRateMove(['treasury_bill_13w']);
+    const result = await svc.checkBenchmarkRateMove(['treasury_bill_13w']);
 
-    expect(moved).toBe(false);
+    expect(result.moved).toBe(false);
   });
 
-  it('returns true when the latest-vs-previous delta is >= 25bps', async () => {
+  it('returns moved=true with the delta/old/new values when the latest-vs-previous delta is >= 25bps', async () => {
     const db: any = {
       select: () => ({
         from: () => ({
@@ -161,9 +161,16 @@ describe('CashManagerService — benchmark-rate-move event trigger', () => {
     };
     const svc = new CashManagerService(db, notifications as any, suppression as any);
 
-    const moved = await svc.checkBenchmarkRateMove(['treasury_bill_13w']);
+    const result = await svc.checkBenchmarkRateMove(['treasury_bill_13w']);
 
-    expect(moved).toBe(true);
+    expect(result).toEqual({
+      moved: true,
+      metricKey: 'treasury_bill_13w',
+      deltaBps: 25,
+      previousValue: 4.5,
+      latestValue: 4.75,
+      latestPeriodDate: '2026-07-24',
+    });
   });
 
   it('returns false when the delta is below the 25bps threshold', async () => {
@@ -184,9 +191,77 @@ describe('CashManagerService — benchmark-rate-move event trigger', () => {
     };
     const svc = new CashManagerService(db, notifications as any, suppression as any);
 
-    const moved = await svc.checkBenchmarkRateMove(['treasury_bill_13w']);
+    const result = await svc.checkBenchmarkRateMove(['treasury_bill_13w']);
 
-    expect(moved).toBe(false);
+    expect(result.moved).toBe(false);
+  });
+});
+
+describe('CashManagerService — notifyBenchmarkRateMove (market_event)', () => {
+  const qualifyingMove = {
+    moved: true,
+    metricKey: 'treasury_bill_13w',
+    deltaBps: 32,
+    previousValue: 4.5,
+    latestValue: 4.82,
+    latestPeriodDate: '2026-07-24',
+  };
+  const subThresholdMove = {
+    moved: false,
+    metricKey: 'treasury_bill_13w',
+    deltaBps: 5,
+    previousValue: 4.5,
+    latestValue: 4.55,
+    latestPeriodDate: '2026-07-24',
+  };
+
+  function buildActiveUsersDb(userIds: string[]) {
+    return {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => Promise.resolve(userIds.map((id) => ({ id })))),
+        })),
+      })),
+    };
+  }
+
+  it('calls notify with type market_event and the delta/old/new values when a qualifying move is detected', async () => {
+    const db: any = buildActiveUsersDb(['user-1']);
+    const notifications = {
+      findByMetadata: vi.fn().mockResolvedValue(false),
+      createAndDispatch: vi.fn().mockResolvedValue(undefined),
+    };
+    const suppression = { checkAndSuppress: vi.fn() };
+    const svc = new CashManagerService(db, notifications as any, suppression as any);
+
+    await svc.notifyBenchmarkRateMove(qualifyingMove as any);
+
+    expect(notifications.createAndDispatch).toHaveBeenCalledTimes(1);
+    const payload = notifications.createAndDispatch.mock.calls[0][0];
+    expect(payload.userId).toBe('user-1');
+    expect(payload.notificationType).toBe('market_event');
+    expect(payload.message).toContain('32bps');
+    expect(payload.message).toContain('4.50%');
+    expect(payload.message).toContain('4.82%');
+    expect(payload.data).toMatchObject({
+      deltaBps: 32,
+      previousValue: 4.5,
+      latestValue: 4.82,
+    });
+  });
+
+  it('does not call notify when the move is below the 25bps threshold', async () => {
+    const db: any = buildActiveUsersDb(['user-1']);
+    const notifications = {
+      findByMetadata: vi.fn().mockResolvedValue(false),
+      createAndDispatch: vi.fn().mockResolvedValue(undefined),
+    };
+    const suppression = { checkAndSuppress: vi.fn() };
+    const svc = new CashManagerService(db, notifications as any, suppression as any);
+
+    await svc.notifyBenchmarkRateMove(subThresholdMove as any);
+
+    expect(notifications.createAndDispatch).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/recommendations/cash-manager.service.ts
+++ b/apps/api/src/recommendations/cash-manager.service.ts
@@ -29,6 +29,28 @@ const BENCHMARK_RATE_METRIC_KEY = 'treasury_bill_13w';
 const BENCHMARK_RATE_MOVE_THRESHOLD_BPS = 25;
 /** Manifest schedule: "liquid-balance-move(>=20%)". */
 const LIQUID_BALANCE_MOVE_THRESHOLD_PCT = 0.2;
+/** Human-readable label for `BENCHMARK_RATE_METRIC_KEY`, used in the `market_event`
+ * notification copy — the metric key itself is an internal identifier. */
+const BENCHMARK_RATE_METRIC_LABEL = '3-month Treasury bill yield';
+
+export interface BenchmarkRateMoveResult {
+  /** Whether the move cleared `BENCHMARK_RATE_MOVE_THRESHOLD_BPS`. */
+  moved: boolean;
+  metricKey: string;
+  deltaBps: number;
+  previousValue: number;
+  latestValue: number;
+  latestPeriodDate: string | null;
+}
+
+const NO_BENCHMARK_RATE_MOVE: BenchmarkRateMoveResult = {
+  moved: false,
+  metricKey: BENCHMARK_RATE_METRIC_KEY,
+  deltaBps: 0,
+  previousValue: 0,
+  latestValue: 0,
+  latestPeriodDate: null,
+};
 
 /**
  * 12.5 — Cash Manager agent. Gathers sanitized (no lastFour/account-number) inputs,
@@ -77,8 +99,8 @@ export class CashManagerService {
    * Compares the two most recent stored values for the benchmark series; a straightforward
    * latest-vs-previous comparison, no new detector framework.
    */
-  async checkBenchmarkRateMove(refreshedMetricKeys: string[]): Promise<boolean> {
-    if (!refreshedMetricKeys.includes(BENCHMARK_RATE_METRIC_KEY)) return false;
+  async checkBenchmarkRateMove(refreshedMetricKeys: string[]): Promise<BenchmarkRateMoveResult> {
+    if (!refreshedMetricKeys.includes(BENCHMARK_RATE_METRIC_KEY)) return NO_BENCHMARK_RATE_MOVE;
 
     const rows = await this.db
       .select({ value: schema.marketMetrics.value, periodDate: schema.marketMetrics.periodDate })
@@ -86,11 +108,67 @@ export class CashManagerService {
       .where(eq(schema.marketMetrics.metricKey, BENCHMARK_RATE_METRIC_KEY))
       .orderBy(desc(schema.marketMetrics.periodDate))
       .limit(2);
-    if (rows.length < 2) return false;
+    if (rows.length < 2) return NO_BENCHMARK_RATE_MOVE;
 
     const [latest, previous] = rows;
-    const deltaBps = Math.round(Math.abs(Number(latest.value) - Number(previous.value)) * 100);
-    return deltaBps >= BENCHMARK_RATE_MOVE_THRESHOLD_BPS;
+    const latestValue = Number(latest.value);
+    const previousValue = Number(previous.value);
+    const deltaBps = Math.round(Math.abs(latestValue - previousValue) * 100);
+    return {
+      moved: deltaBps >= BENCHMARK_RATE_MOVE_THRESHOLD_BPS,
+      metricKey: BENCHMARK_RATE_METRIC_KEY,
+      deltaBps,
+      previousValue,
+      latestValue,
+      latestPeriodDate: String(latest.periodDate),
+    };
+  }
+
+  /**
+   * Fires the `market_event` notification for a qualifying benchmark-rate move
+   * (manifest: "benchmark-rate-move(>=25bps)"), to every active user — this app is
+   * single-household, so no per-user targeting beyond the existing ad-hoc
+   * cash-manager-check job is needed. Additive to (never a replacement for) that
+   * ad-hoc job, which continues to drive the full cash-placement re-evaluation.
+   */
+  async notifyBenchmarkRateMove(move: BenchmarkRateMoveResult): Promise<void> {
+    if (!move.moved) return;
+
+    const direction = move.latestValue >= move.previousValue ? 'up' : 'down';
+    const message =
+      `${BENCHMARK_RATE_METRIC_LABEL} moved ${move.deltaBps}bps ${direction}: ` +
+      `${move.previousValue.toFixed(2)}% → ${move.latestValue.toFixed(2)}%`;
+    const dedupeKey = `market_event_benchmark_${move.metricKey}_${move.latestPeriodDate}`;
+
+    const users = await this.activeUsers();
+    for (const user of users) {
+      try {
+        if (await this.notificationsService.findByMetadata(user.id, dedupeKey)) continue;
+        await this.notificationsService.createAndDispatch({
+          userId: user.id,
+          type: 'benchmark_rate_move',
+          notificationType: 'market_event',
+          source: 'market',
+          severity: 'insight',
+          title: `${BENCHMARK_RATE_METRIC_LABEL} moved ${move.deltaBps}bps`,
+          message,
+          dedupeKey,
+          metadata: { dedupeKey },
+          data: {
+            metricKey: move.metricKey,
+            deltaBps: move.deltaBps,
+            previousValue: move.previousValue,
+            latestValue: move.latestValue,
+            latestPeriodDate: move.latestPeriodDate,
+          },
+        });
+      } catch (err: any) {
+        this.logger.error(
+          `Benchmark rate move notification failed for user ${user.id}: ${err.message}`,
+          err.stack,
+        );
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Committed. 

## Summary of this fix

The `apps/api` test gate was failing on `brief.service.spec.ts`'s "budget pace" test — unrelated to the `market_event` wiring change itself, but blocking the same `pnpm run test` run.

**Root cause:** the test's budget-pace fixture (`spent_cents: 9000` against `budget_cents: 10000`) computes a projected month-end pace as `(spent / dayOfMonth) * daysInMonth`, and the section only renders when that projected percentage is strictly `> 100`. On days where `dayOfMonth` is close to `daysInMonth` (e.g. day 28 of a 31-day month), that projection rounds to exactly 100, not above it — so the test's pass/fail depended on the real wall-clock date the suite happened to run on, since `getLocalToday()` isn't mocked.

**Fix:** changed the fixture so `spent_cents` already exceeds `budget_cents` outright (105%). Since the projected pace formula only ever scales spent-to-date *up* (never down) as the month progresses, this guarantees the projected pace stays above 100% on every possible day of the month, making the test deterministic.

Verified with `pnpm run test` in `apps/api`: 95/95 test files and 806/806 tests now pass.

---
### Test evidence
**3 new test case(s) added** (heuristic count):
```
 .../src/analytics/__tests__/brief.service.spec.ts  |  6 +-
 .../__tests__/cash-manager.service.spec.ts         | 93 +++++++++++++++++++---
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
[22m[2m8 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/categorization/__tests__/learning.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test: [32m[Nest] 1732  - [39m07/28/2026, 12:15:47 PM [32m    LOG[39m [38;5;3m[AlertCronProcessor] [39m[32mProcessing alert job: monthly-close-auto-draft[39m
@moneypulse/api:test: [32m[Nest] 1732  - [39m07/28/2026, 12:15:47 PM [32m    LOG[39m [38;5;3m[AlertCronProcessor] [39m[32mMonthly-close auto-draft: 3 user(s) processed, 2 close(s) created[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/monthly-close-cron.spec.ts [2m([22m[2m1 test[22m[2m)[22m[32m 4[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/expected-cycle-date.spec.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/next-loan-due-date.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m95 passed[39m[22m[90m (95)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m806 passed[39m[22m[90m (806)[39m
@moneypulse/api:test: [2m   Start at [22m 12:15:37
@moneypulse/api:test: [2m   Duration [22m 9.77s[2m (transform 2.97s, setup 0ms, import 50.75s, tests 1.92s, environment 5ms)[22m
@moneypulse/api:test: 

 Tasks:    4 successful, 4 total
Cached:    3 cached, 4 total
  Time:    10.228s
```
</details>

### Review
**Review verdict:** approve

Findings (advisory — did not block landing):
- [low/advisory] apps/api/src/recommendations/cash-manager.service.ts:133 — notifyBenchmarkRateMove relies only on findByMetadata dedupe and does not use the injected suppression.checkAndSuppress; confirm the market_event path is intentionally exempt from suppression.

---
Dispatched via coxd (`MyMoney-wire-benchmark-rate-move-det-1785240638`) · cost $1.378 · 🤖 coxd