### PR TITLE
Notification bell dropdown overflows off-screen on mobile

### DIFF
--- a/apps/web/src/components/NotificationBell.tsx
+++ b/apps/web/src/components/NotificationBell.tsx
@@ -128,7 +128,7 @@ export function NotificationBell() {
       </button>
 
       {open && (
-        <div className="absolute right-0 mt-2 w-80 bg-[var(--card)] text-[var(--card-foreground)] border border-[var(--border)] rounded-lg shadow-lg z-50 max-h-96 overflow-y-auto">
+        <div className="fixed top-[4.5rem] left-2 right-2 w-auto max-w-none sm:absolute sm:top-auto sm:left-auto sm:right-0 sm:mt-2 sm:w-80 sm:max-w-[calc(100vw-2rem)] bg-[var(--card)] text-[var(--card-foreground)] border border-[var(--border)] rounded-lg shadow-lg z-50 max-h-96 overflow-y-auto">
           <div className="p-3 border-b border-[var(--border)] flex items-center justify-between sticky top-0 bg-[var(--card)]">
             <h3 className="font-medium text-sm">Notifications</h3>
             {!!unread && unread > 0 && (


### PR DESCRIPTION
Committed. Root cause and fix as described above.

---
### Test evidence
_No test files were added or modified in this change._

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
eypulse/web:test:  [32m✓[39m src/__tests__/mobile-nav.spec.tsx [2m([22m[2m15 tests[22m[2m)[22m[33m 491[2mms[22m[39m
@moneypulse/web:test: Not implemented: navigation to another Document
@moneypulse/web:test:  [32m✓[39m src/__tests__/api.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 11[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/format.spec.ts [2m([22m[2m13 tests[22m[2m)[22m[32m 25[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/mobile-card.spec.tsx [2m([22m[2m8 tests[22m[2m)[22m[32m 185[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/split-transaction.spec.tsx [2m([22m[2m10 tests[22m[2m)[22m[33m 1151[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/add-transaction.spec.tsx [2m([22m[2m9 tests[22m[2m)[22m[33m 1175[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/pwa.spec.tsx [2m([22m[2m5 tests[22m[2m)[22m[32m 11[2mms[22m[39m
@moneypulse/web:test: 
@moneypulse/web:test: [2m Test Files [22m [1m[32m11 passed[39m[22m[90m (11)[39m
@moneypulse/web:test: [2m      Tests [22m [1m[32m87 passed[39m[22m[2m | [22m[33m3 skipped[39m[90m (90)[39m
@moneypulse/web:test: [2m   Start at [22m 19:45:45
@moneypulse/web:test: [2m   Duration [22m 2.80s[2m (transform 848ms, setup 661ms, import 2.71s, tests 4.02s, environment 8.69s)[22m
@moneypulse/web:test: 

 Tasks:    2 successful, 2 total
Cached:    1 cached, 2 total
  Time:    4.156s
```
</details>

### Review
**Review verdict:** approve

---
Dispatched via coxd (`MyMoney-notification-bell-dropdown-o-1785282290`) · cost $0.200 · 🤖 coxd