### PR TITLE
Monthly-close backfill uses today's portfolio value for historical mon

### DIFF
--- a/apps/api/src/investments/__tests__/investments.service.spec.ts
+++ b/apps/api/src/investments/__tests__/investments.service.spec.ts
@@ -268,6 +268,57 @@ describe('InvestmentsService', () => {
     });
   });
 
+  describe('getPortfolioValueAsOf (#189)', () => {
+    it('returns zero total with no holdings as of that date', async () => {
+      mockDb.execute.mockResolvedValue({ rows: [] });
+      const result = await service.getPortfolioValueAsOf(userId, '2025-06-30');
+      expect(result).toEqual({
+        totalCents: 0,
+        holdings: [],
+        staleFound: false,
+        missingPriceFound: false,
+        staleDays: 90,
+      });
+    });
+
+    it('values holdings using the as-of holding row and price on or before that date, not today\'s', async () => {
+      const asOfDate = '2025-06-30';
+      mockDb.execute
+        // getHoldingsAsOf query — shares as declared as of the historical month-end
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              investment_account_id: accountId,
+              ticker: 'AAA',
+              share_count: '10',
+              as_of: '2025-06-01',
+              notes: null,
+            },
+          ],
+        })
+        // security_prices query — historical close as of that date, not a later/current one
+        .mockResolvedValueOnce({
+          rows: [{ ticker: 'AAA', price_date: '2025-06-27', close_cents: 500, source: 'test' }],
+        });
+
+      const result = await service.getPortfolioValueAsOf(userId, asOfDate);
+
+      expect(result.totalCents).toBe(10 * 500);
+      expect(result.holdings[0].priceDate).toBe('2025-06-27');
+
+      // Both queries must be bounded by asOfDate rather than "latest overall".
+      const holdingsQuery = mockDb.execute.mock.calls[0][0];
+      const { sql: holdingsSql, params: holdingsParams } = new PgDialect().sqlToQuery(holdingsQuery);
+      expect(holdingsSql).toMatch(/as_of\s*<=/);
+      expect(holdingsParams).toContain(asOfDate);
+
+      const priceQuery = mockDb.execute.mock.calls[1][0];
+      const { sql: priceSql, params: priceParams } = new PgDialect().sqlToQuery(priceQuery);
+      expect(priceSql).toMatch(/price_date\s*<=/);
+      expect(priceParams).toContain(asOfDate);
+    });
+  });
+
   describe('getAllocation', () => {
     it('computes percent of total value per ticker, excluding unpriced holdings', async () => {
       const recentDate = new Date().toISOString().slice(0, 10);

--- a/apps/api/src/investments/investments.service.ts
+++ b/apps/api/src/investments/investments.service.ts
@@ -246,8 +246,9 @@ export class InvestmentsService {
    * Portfolio market value as of a historical date: shares held on that date x the
    * most recent EOD close on or before that date, per holding, summed to a total.
    * Used by monthly-close backfill (#189) so a historical month's close reflects
-   * that month's actual holdings/prices instead of today's — getPortfolioValue
-   * (current-value) delegates to this with today's date.
+   * that month's actual holdings/prices instead of today's. `getPortfolioValue`
+   * (current-value, used elsewhere) is a separate method, not a delegation to
+   * this one — left untouched to avoid behavior changes outside the backfill path.
    */
   async getPortfolioValueAsOf(
     userId: string,

--- a/apps/api/src/investments/investments.service.ts
+++ b/apps/api/src/investments/investments.service.ts
@@ -216,6 +216,100 @@ export class InvestmentsService {
   }
 
   /**
+   * All tickers with their latest declared share count/as-of date across a user's
+   * accounts, as they stood on a given historical date (one row per ticker per
+   * account) — the "as of" counterpart to getCurrentHoldings, using each holding
+   * row's own as_of instead of "latest overall" so a month's close reflects the
+   * shares actually held that month, not shares added/removed later.
+   */
+  async getHoldingsAsOf(userId: string, asOfDate: string) {
+    const rows = await this.db.execute(sql`
+      SELECT DISTINCT ON (h.investment_account_id, h.ticker)
+        h.id, h.investment_account_id, h.ticker, h.share_count, h.as_of, h.notes
+      FROM ${schema.investmentHoldings} h
+      JOIN ${schema.investmentAccounts} ia ON ia.id = h.investment_account_id
+      WHERE ia.user_id = ${userId} AND ia.deleted_at IS NULL
+        AND h.as_of <= ${asOfDate}
+      ORDER BY h.investment_account_id, h.ticker, h.as_of DESC, h.created_at DESC
+    `);
+    return (rows.rows ?? rows).map((r: any) => ({
+      id: r.id,
+      investmentAccountId: r.investment_account_id,
+      ticker: r.ticker,
+      shareCount: r.share_count,
+      asOf: String(r.as_of).slice(0, 10),
+      notes: r.notes ?? null,
+    }));
+  }
+
+  /**
+   * Portfolio market value as of a historical date: shares held on that date x the
+   * most recent EOD close on or before that date, per holding, summed to a total.
+   * Used by monthly-close backfill (#189) so a historical month's close reflects
+   * that month's actual holdings/prices instead of today's — getPortfolioValue
+   * (current-value) delegates to this with today's date.
+   */
+  async getPortfolioValueAsOf(
+    userId: string,
+    asOfDate: string,
+    staleDays = DEFAULT_HOLDINGS_STALE_DAYS,
+  ) {
+    const holdings = await this.getHoldingsAsOf(userId, asOfDate);
+    if (holdings.length === 0) {
+      return { totalCents: 0, holdings: [], staleFound: false, missingPriceFound: false, staleDays };
+    }
+
+    const tickers = Array.from(new Set(holdings.map((h: any) => h.ticker))) as string[];
+    const priceRows = await this.db.execute(sql`
+      SELECT DISTINCT ON (ticker) ticker, price_date::text AS price_date, close_cents, source
+      FROM ${schema.securityPrices}
+      WHERE ticker = ANY(${sqlArray(tickers, 'text')})
+        AND price_date <= ${asOfDate}
+      ORDER BY ticker, price_date DESC
+    `);
+    const prices = (priceRows.rows ?? priceRows) as any[];
+    const priceByTicker = new Map(prices.map((p) => [p.ticker, p]));
+
+    const asOfTime = new Date(asOfDate).getTime();
+    let totalCents = 0;
+    let staleFound = false;
+    let missingPriceFound = false;
+
+    const result = holdings.map((h: any) => {
+      const isStale = asOfTime - new Date(h.asOf).getTime() > staleDays * 24 * 3600_000;
+      if (isStale) staleFound = true;
+      const price = priceByTicker.get(h.ticker);
+      if (!price) {
+        missingPriceFound = true;
+        return {
+          investmentAccountId: h.investmentAccountId,
+          ticker: h.ticker,
+          shareCount: h.shareCount,
+          asOf: h.asOf,
+          isStale,
+          priceDate: null,
+          closeCents: null,
+          marketValueCents: null,
+        };
+      }
+      const marketValueCents = Math.round(Number(h.shareCount) * Number(price.close_cents));
+      totalCents += marketValueCents;
+      return {
+        investmentAccountId: h.investmentAccountId,
+        ticker: h.ticker,
+        shareCount: h.shareCount,
+        asOf: h.asOf,
+        isStale,
+        priceDate: String(price.price_date).slice(0, 10),
+        closeCents: Number(price.close_cents),
+        marketValueCents,
+      };
+    });
+
+    return { totalCents, holdings: result, staleFound, missingPriceFound, staleDays };
+  }
+
+  /**
    * Portfolio market value: shares x latest EOD close, per holding, summed to a
    * total. Mirrors the `get_portfolio_value` MCP tool's computation (same
    * "latest holding per ticker per account" + "latest price per ticker" joins),

--- a/apps/api/src/monthly-close/__tests__/monthly-close.service.spec.ts
+++ b/apps/api/src/monthly-close/__tests__/monthly-close.service.spec.ts
@@ -50,6 +50,7 @@ describe('MonthlyCloseService', () => {
           provide: InvestmentsService,
           useValue: {
             getPortfolioValue: vi.fn().mockResolvedValue({ totalCents: 0, holdings: [], staleFound: false, missingPriceFound: false }),
+            getPortfolioValueAsOf: vi.fn().mockResolvedValue({ totalCents: 0, holdings: [], staleFound: false, missingPriceFound: false }),
           },
         },
         { provide: LoansService, useValue: { getBalanceForMonth: vi.fn() } },

--- a/apps/api/src/monthly-close/monthly-close.service.ts
+++ b/apps/api/src/monthly-close/monthly-close.service.ts
@@ -299,8 +299,11 @@ export class MonthlyCloseService {
     }
 
     // ── Investments: holdings x latest EOD close when holdings exist, else the
-    // manual investment_snapshots value for the month — never both (decision #2). ──
-    const portfolio = await this.investmentsService.getPortfolioValue(userId);
+    // manual investment_snapshots value for the month — never both (decision #2).
+    // Uses holdings/prices as they stood at that month's end (#189) — not today's
+    // portfolio value — so backfilled historical months aren't skewed by today's
+    // holdings/market prices. ──
+    const portfolio = await this.investmentsService.getPortfolioValueAsOf(userId, lastDay);
     let investmentAssetCents = regularInvestmentAssetCents;
     if (portfolio.holdings.length > 0) {
       investmentAssetCents += portfolio.totalCents;


### PR DESCRIPTION
Committed successfully.

## Summary

Fixed issue #189: the monthly-close auto-draft cron's backfill path called `InvestmentsService.getPortfolioValue(userId)` — which prices *current* holdings at *today's* market close — and applied that single figure to every backfilled historical month, skewing wealth-building-rate and net-worth figures for past months.

**Root cause:** no historical portfolio-value lookup existed; the existing `investment_holdings` and `security_prices` tables already retain full history (holdings are append-only with an `as_of` date, and `security_prices` keeps EOD closes per date), so no new schema was needed — only a point-in-time query.

**Fix:**
- Added `InvestmentsService.getHoldingsAsOf(userId, asOfDate)` and `getPortfolioValueAsOf(userId, asOfDate, staleDays)`, which select the latest holding row per ticker/account with `as_of <= asOfDate` and price it against the latest `security_prices` row with `price_date <= asOfDate`, mirroring the existing "current" query but bounded to a historical date.
- `MonthlyCloseService.gatherInputs` now calls `getPortfolioValueAsOf(userId, lastDay)` (that month's last day) instead of the current-value lookup, so both live drafts and backfilled historical months price holdings as of their own month-end.
- Left the existing `getPortfolioValue` (current value, used elsewhere — allocation view, investment coach) untouched to avoid behavior changes outside the backfill path.

**Verification:** added unit tests for `getPortfolioValueAsOf` confirming both the holdings and price queries are bounded by the as-of date (not "latest overall") and that market value is computed from the historical share count × historical close; updated the monthly-close service test's mock to include the new method. Ran the full API test suite (823 tests) and `tsc --noEmit` — all green.

---
### Test evidence
**2 new test case(s) added** (heuristic count):
```
 .../__tests__/investments.service.spec.ts          | 51 ++++++++++++
 .../__tests__/monthly-close.service.spec.ts        |  1 +
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/sync-delivery.processor.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 4[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/transactions/__tests__/business-date.spec.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test: [32m[Nest] 78992  - [39m07/28/2026, 11:47:51 PM [32m    LOG[39m [38;5;3m[AlertCronProcessor] [39m[32mProcessing alert job: monthly-close-auto-draft[39m
@moneypulse/api:test: [32m[Nest] 78992  - [39m07/28/2026, 11:47:51 PM [32m    LOG[39m [38;5;3m[AlertCronProcessor] [39m[32mMonthly-close auto-draft: 3 user(s) processed, 2 close(s) created[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/monthly-close-cron.spec.ts [2m([22m[2m1 test[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/next-loan-due-date.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m96 passed[39m[22m[90m (96)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m823 passed[39m[22m[90m (823)[39m
@moneypulse/api:test: [2m   Start at [22m 23:47:40
@moneypulse/api:test: [2m   Duration [22m 11.19s[2m (transform 3.79s, setup 0ms, import 59.57s, tests 2.14s, environment 6ms)[22m
@moneypulse/api:test: 

 Tasks:    2 successful, 2 total
Cached:    1 cached, 2 total
  Time:    11.689s
```
</details>

### Review
**Review verdict:** approve

Findings (advisory — did not block landing):
- [low/advisory] apps/api/src/monthly-close/monthly-close.service.ts:306 — When as-of holdings exist but historical prices are missing, totalCents can be ~0 while the manual investment_snapshots fallback stays suppressed (holdings.length>0) and the returned missingPriceFound flag is ignored, so a backfilled month may persist a silently-low investment value.
- [low/advisory] apps/api/src/investments/investments.service.ts:245 — getPortfolioValueAsOf docstring says getPortfolioValue 'delegates to this with today's date,' but the diff does not change getPortfolioValue to delegate — stale/inaccurate comment.

---
Dispatched via coxd (`MyMoney-monthly-close-backfill-uses-1785282289`) · cost $1.014 · 🤖 coxd