### PR TITLE
Premium credit card 'worth it' calculator: annual statement credits vs

### DIFF
--- a/apps/api/src/accounts/accounts.service.ts
+++ b/apps/api/src/accounts/accounts.service.ts
@@ -54,6 +54,7 @@ export class AccountsService {
         startingBalanceCents: input.startingBalanceCents,
         creditLimitCents: input.creditLimitCents ?? null,
         interestRateBps: input.interestRateBps ?? null,
+        annualFeeCents: input.annualFeeCents ?? null,
       })
       .returning();
 

--- a/apps/api/src/analytics/__tests__/analytics.service.spec.ts
+++ b/apps/api/src/analytics/__tests__/analytics.service.spec.ts
@@ -266,6 +266,65 @@ describe('AnalyticsService', () => {
     });
   });
 
+  describe('cardWorthIt', () => {
+    it('flags a card as worth it when statement credits exceed the annual fee', async () => {
+      const mockRows = [
+        {
+          account_id: 'acc-amex-gold',
+          nickname: 'Amex Gold',
+          annual_fee_cents: '25000',
+          statement_credits_cents: '30000',
+        },
+      ];
+      mockDb.execute.mockResolvedValue({ rows: mockRows });
+
+      const result = await service.cardWorthIt(TEST_USER_ID, { household: false });
+
+      expect(result).toEqual([
+        {
+          accountId: 'acc-amex-gold',
+          nickname: 'Amex Gold',
+          annualFeeCents: 25000,
+          statementCreditsCents: 30000,
+          netCents: 5000,
+          worthIt: true,
+        },
+      ]);
+    });
+
+    it('flags a card as not worth it when statement credits fall short of the annual fee', async () => {
+      const mockRows = [
+        {
+          account_id: 'acc-amex-plat',
+          nickname: 'Amex Platinum',
+          annual_fee_cents: '69500',
+          statement_credits_cents: '40000',
+        },
+      ];
+      mockDb.execute.mockResolvedValue({ rows: mockRows });
+
+      const result = await service.cardWorthIt(TEST_USER_ID, { household: false });
+
+      expect(result).toEqual([
+        {
+          accountId: 'acc-amex-plat',
+          nickname: 'Amex Platinum',
+          annualFeeCents: 69500,
+          statementCreditsCents: 40000,
+          netCents: -29500,
+          worthIt: false,
+        },
+      ]);
+    });
+
+    it('should return empty when no cards have an annual fee recorded', async () => {
+      mockDb.execute.mockResolvedValue({ rows: [] });
+
+      const result = await service.cardWorthIt(TEST_USER_ID, { household: false });
+      expect(result).toEqual([]);
+    });
+  });
+
   describe('netWorth', () => {
     /** netWorth() is built entirely from netWorthBreakdown()'s line items (see #192), which
      *  issues 4 sequential db.execute calls in this order:

--- a/apps/api/src/analytics/__tests__/analytics.service.spec.ts
+++ b/apps/api/src/analytics/__tests__/analytics.service.spec.ts
@@ -323,6 +323,19 @@ describe('AnalyticsService', () => {
       const result = await service.cardWorthIt(TEST_USER_ID, { household: false });
       expect(result).toEqual([]);
     });
+
+    it('excludes transfer-category rows (e.g. AUTOPAY bill payments) from statement credits', async () => {
+      // A card's own autopay payment is is_credit=true on the card account just
+      // like a real statement credit, but it's tagged with a transfer category
+      // (is_transfer=true) — without excluding those, a $5,000 bill payment would
+      // be counted as a "statement credit" and dwarf the real ones.
+      mockDb.execute.mockResolvedValue({ rows: [] });
+      await service.cardWorthIt(TEST_USER_ID, { household: false });
+
+      const query = mockDb.execute.mock.calls[0][0];
+      const { sql: sqlText } = new PgDialect().sqlToQuery(query);
+      expect(sqlText).toMatch(/is_transfer/);
+    });
   });
 
   describe('netWorth', () => {

--- a/apps/api/src/analytics/analytics.controller.ts
+++ b/apps/api/src/analytics/analytics.controller.ts
@@ -155,6 +155,31 @@ export class AnalyticsController {
   }
 
   /**
+   * GET /analytics/card-worth-it — "Is this card worth it?" calculator (#142):
+   * for each credit card with an annual fee recorded, compares trailing-12-month
+   * statement credits received against the card's annual fee.
+   * Scoped to the authenticated user or their household.
+   *
+   * @param query - Validated household filter parameter.
+   * @param user - JWT token payload containing user identity.
+   * @returns `{ data: Array<{ accountId, nickname, annualFeeCents, statementCreditsCents, netCents, worthIt }> }`
+   * @throws {UnauthorizedException} If the request is not authenticated.
+   */
+  @Get('card-worth-it')
+  @ApiOperation({ summary: 'Premium credit card annual-fee worth-it calculator' })
+  async cardWorthIt(
+    @Query(new ZodValidationPipe(analyticsQuerySchema)) query: AnalyticsQuery,
+    @CurrentUser() user: AuthTokenPayload,
+  ) {
+    const data = await this.analyticsService.cardWorthIt(
+      user.sub,
+      { household: query.household },
+      user.householdId,
+    );
+    return { data };
+  }
+
+  /**
    * GET /analytics/net-worth — Net worth snapshot: assets + investments - liabilities.
    * Scoped to the authenticated user or their household.
    *

--- a/apps/api/src/analytics/analytics.service.ts
+++ b/apps/api/src/analytics/analytics.service.ts
@@ -330,6 +330,73 @@ export class AnalyticsService {
   }
 
   /**
+   * "Is this card worth it?" calculator (#142, follow-up to #115/#141): for each
+   * premium credit card that has an `annualFeeCents` recorded, compares the
+   * trailing-12-months statement credits received on that card against the
+   * card's annual fee.
+   *
+   * Statement credits are identified the same way analytics.service.ts's
+   * income_cents aggregates and the income drill-down (#141) do: is_credit = true
+   * rows on an account_type = 'credit_card' account are a refund of prior spend,
+   * not income — here we sum exactly those rows over the trailing 12 months.
+   * Scoped to the authenticated user or their household members.
+   *
+   * @param {string} userId - The authenticated user's ID.
+   * @param {Pick<AnalyticsQuery, 'household'>} query - Household flag for scoping.
+   * @param {string | null} [householdId] - Optional household ID for multi-user scoping.
+   * @returns {Promise<Array<{ accountId; nickname; annualFeeCents; statementCreditsCents; netCents; worthIt }>>}
+   *   One entry per credit-card account that has an annual fee recorded.
+   * @throws {Error} If the database query fails.
+   */
+  async cardWorthIt(
+    userId: string,
+    query: Pick<AnalyticsQuery, 'household'>,
+    householdId?: string | null,
+  ) {
+    const userScope = householdId && query.household
+      ? sql`a.user_id IN (SELECT id FROM ${schema.users} WHERE household_id = ${householdId})`
+      : sql`a.user_id = ${userId}`;
+
+    const result = await this.db.execute(sql`
+      SELECT
+        a.id AS account_id,
+        a.nickname,
+        a.annual_fee_cents,
+        COALESCE(SUM(
+          CASE
+            WHEN t.is_credit = true
+              AND t.deleted_at IS NULL
+              AND t.is_split_parent = false
+              AND t.date >= NOW() - INTERVAL '12 months'
+            THEN t.amount_cents
+            ELSE 0
+          END
+        ), 0) AS statement_credits_cents
+      FROM ${schema.accounts} a
+      LEFT JOIN ${schema.transactions} t ON a.id = t.account_id
+      WHERE a.account_type = 'credit_card'
+        AND a.deleted_at IS NULL
+        AND a.annual_fee_cents IS NOT NULL
+        AND ${userScope}
+      GROUP BY a.id, a.nickname, a.annual_fee_cents
+    `);
+
+    return this.extractRows(result).map((r: any) => {
+      const annualFeeCents = Number(r.annual_fee_cents);
+      const statementCreditsCents = Number(r.statement_credits_cents);
+      const netCents = statementCreditsCents - annualFeeCents;
+      return {
+        accountId: r.account_id,
+        nickname: r.nickname,
+        annualFeeCents,
+        statementCreditsCents,
+        netCents,
+        worthIt: netCents >= 0,
+      };
+    });
+  }
+
+  /**
    * Returns a full net worth snapshot across every asset/liability source the app
    * tracks (see Phase 13 epic #158 decisions):
    *  - Liquid = checking + savings + cash_sweep regular accounts (starting balance

--- a/apps/api/src/analytics/analytics.service.ts
+++ b/apps/api/src/analytics/analytics.service.ts
@@ -339,6 +339,10 @@ export class AnalyticsService {
    * income_cents aggregates and the income drill-down (#141) do: is_credit = true
    * rows on an account_type = 'credit_card' account are a refund of prior spend,
    * not income — here we sum exactly those rows over the trailing 12 months.
+   * Excludes transfer-category rows (e.g. "AUTOPAY PAYMENT" bill payments), which
+   * are also is_credit = true on the card account but are debt payoff, not a
+   * merchant refund — without this a card's own autopay would be counted as a
+   * statement credit and dwarf the real ones, making every card "worth it".
    * Scoped to the authenticated user or their household members.
    *
    * @param {string} userId - The authenticated user's ID.
@@ -368,12 +372,14 @@ export class AnalyticsService {
               AND t.deleted_at IS NULL
               AND t.is_split_parent = false
               AND t.date >= NOW() - INTERVAL '12 months'
+              AND (cat.is_transfer IS NULL OR cat.is_transfer = false)
             THEN t.amount_cents
             ELSE 0
           END
         ), 0) AS statement_credits_cents
       FROM ${schema.accounts} a
       LEFT JOIN ${schema.transactions} t ON a.id = t.account_id
+      LEFT JOIN ${schema.categories} cat ON cat.id = t.category_id
       WHERE a.account_type = 'credit_card'
         AND a.deleted_at IS NULL
         AND a.annual_fee_cents IS NOT NULL

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -238,6 +238,8 @@ export const accounts = pgTable('accounts', {
   creditLimitCents: integer('credit_limit_cents'),
   /** Basis points (e.g. 450 = 4.50% APY). Only meaningful for interest-bearing types (savings, cash_sweep, brokerage). */
   interestRateBps: integer('interest_rate_bps'),
+  /** Annual fee charged by this card, in cents. Only meaningful for account_type = 'credit_card'; drives the "is this card worth it" calculator (#142). */
+  annualFeeCents: integer('annual_fee_cents'),
   csvFormatConfig: jsonb('csv_format_config'),
   expectedImportCadenceDays: integer('expected_import_cadence_days'),
   isDormant: boolean('is_dormant').notNull().default(false),

--- a/apps/web/src/app/(protected)/accounts/page.tsx
+++ b/apps/web/src/app/(protected)/accounts/page.tsx
@@ -9,6 +9,7 @@ import {
   useReconcileAccount,
   useUpdateAccount,
 } from '@/lib/hooks/useAccounts';
+import { useCardWorthIt } from '@/lib/hooks/useAnalytics';
 import { formatCents } from '@/lib/format';
 import { cn } from '@/lib/utils';
 import { BankLogo } from '@/components/BankLogo';
@@ -20,6 +21,10 @@ const INTEREST_BEARING_TYPES: AccountType[] = ['savings', 'cash_sweep', 'brokera
 /** Accounts page — view, create, and manage bank accounts. */
 export default function AccountsPage() {
   const { data: accountsData, isLoading } = useAccounts();
+  const { data: cardWorthItData } = useCardWorthIt();
+  const cardWorthItByAccount = new Map(
+    (cardWorthItData?.data ?? []).map((row) => [row.accountId, row]),
+  );
   const createAccount = useCreateAccount();
   const deleteAccount = useDeleteAccount();
   const reconcileAccount = useReconcileAccount();
@@ -33,6 +38,7 @@ export default function AccountsPage() {
     nickname: '',
     accountType: 'checking' as AccountType,
     interestRatePercent: '',
+    annualFeeCents: null as number | null,
   });
   const [form, setForm] = useState({
     institution: 'boa' as Institution,
@@ -42,6 +48,7 @@ export default function AccountsPage() {
     startingBalanceCents: 0,
     creditLimitCents: null as number | null,
     interestRatePercent: '',
+    annualFeeCents: null as number | null,
   });
 
   const accounts = accountsData?.data ?? [];
@@ -70,6 +77,10 @@ export default function AccountsPage() {
         isInterestBearing && form.interestRatePercent.trim() !== ''
           ? Math.round(parseFloat(form.interestRatePercent) * 100)
           : null,
+      annualFeeCents:
+        form.accountType === 'credit_card' && form.annualFeeCents !== null
+          ? Math.round(form.annualFeeCents * 100)
+          : null,
     });
     setShowForm(false);
     setForm({
@@ -80,6 +91,7 @@ export default function AccountsPage() {
       startingBalanceCents: 0,
       creditLimitCents: null,
       interestRatePercent: '',
+      annualFeeCents: null,
     });
   }
 
@@ -91,10 +103,12 @@ export default function AccountsPage() {
       accountType: account.accountType,
       interestRatePercent:
         account.interestRateBps != null ? (account.interestRateBps / 100).toString() : '',
+      annualFeeCents:
+        account.annualFeeCents != null ? account.annualFeeCents / 100 : null,
     });
   }
 
-  /** Handle form submission to update an existing account's nickname/type/interest rate. */
+  /** Handle form submission to update an existing account's nickname/type/interest rate/annual fee. */
   async function handleEditSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!editTarget) return;
@@ -103,11 +117,16 @@ export default function AccountsPage() {
       isInterestBearing && editForm.interestRatePercent.trim() !== ''
         ? Math.round(parseFloat(editForm.interestRatePercent) * 100)
         : null;
+    const annualFeeCents =
+      editForm.accountType === 'credit_card' && editForm.annualFeeCents !== null
+        ? Math.round(editForm.annualFeeCents * 100)
+        : null;
     await updateAccount.mutateAsync({
       id: editTarget.id,
       nickname: editForm.nickname,
       accountType: editForm.accountType,
       interestRateBps,
+      annualFeeCents,
     });
     setEditTarget(null);
   }
@@ -211,6 +230,22 @@ export default function AccountsPage() {
                   onChange={(e) =>
                     setForm({ ...form, creditLimitCents: e.target.value ? Number(e.target.value) : null })
                   }
+                  className="w-full rounded-xl border border-[var(--border)] bg-[var(--surface-container-low)] px-3 py-2.5 text-sm focus:border-[var(--primary)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)]/30 transition-all"
+                />
+              </div>
+            )}
+            {form.accountType === 'credit_card' && (
+              <div>
+                <label className="mb-1.5 block text-sm font-semibold">Annual Fee ($)</label>
+                <input
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  value={form.annualFeeCents ?? ''}
+                  onChange={(e) =>
+                    setForm({ ...form, annualFeeCents: e.target.value ? Number(e.target.value) : null })
+                  }
+                  placeholder="e.g. 695 for Amex Platinum"
                   className="w-full rounded-xl border border-[var(--border)] bg-[var(--surface-container-low)] px-3 py-2.5 text-sm focus:border-[var(--primary)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)]/30 transition-all"
                 />
               </div>
@@ -339,6 +374,32 @@ export default function AccountsPage() {
                     APY: {(account.interestRateBps / 100).toFixed(2)}%
                   </p>
                 )}
+                {account.annualFeeCents != null && (
+                  <p className="mt-1 text-xs text-[var(--muted-foreground)]">
+                    Annual fee: {formatCents(account.annualFeeCents)}
+                  </p>
+                )}
+                {(() => {
+                  const worthIt = cardWorthItByAccount.get(account.id);
+                  if (!worthIt) return null;
+                  return (
+                    <div
+                      className={cn(
+                        'mt-3 rounded-xl px-3 py-2 text-xs font-semibold',
+                        worthIt.worthIt
+                          ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
+                          : 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400',
+                      )}
+                    >
+                      {worthIt.worthIt ? 'Worth it: ' : 'Not worth it: '}
+                      {formatCents(worthIt.statementCreditsCents)} in statement credits (trailing 12mo)
+                      {' vs. '}
+                      {formatCents(worthIt.annualFeeCents)} annual fee (
+                      {worthIt.netCents >= 0 ? '+' : '-'}
+                      {formatCents(Math.abs(worthIt.netCents))})
+                    </div>
+                  );
+                })()}
                 {/* Bottom accent bar */}
                 <div className="absolute bottom-0 left-0 h-1 w-full bg-gradient-to-r from-[var(--primary)]/50 to-transparent" />
               </div>
@@ -466,6 +527,25 @@ export default function AccountsPage() {
                       setEditForm({ ...editForm, interestRatePercent: e.target.value })
                     }
                     placeholder="e.g. 4.50"
+                    className="w-full rounded-xl border border-[var(--border)] bg-[var(--surface-container-low)] px-3 py-2.5 text-sm focus:border-[var(--primary)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)]/30 transition-all"
+                  />
+                </div>
+              )}
+              {editForm.accountType === 'credit_card' && (
+                <div>
+                  <label className="mb-1.5 block text-sm font-semibold">Annual Fee ($)</label>
+                  <input
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    value={editForm.annualFeeCents ?? ''}
+                    onChange={(e) =>
+                      setEditForm({
+                        ...editForm,
+                        annualFeeCents: e.target.value ? Number(e.target.value) : null,
+                      })
+                    }
+                    placeholder="e.g. 695 for Amex Platinum"
                     className="w-full rounded-xl border border-[var(--border)] bg-[var(--surface-container-low)] px-3 py-2.5 text-sm focus:border-[var(--primary)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)]/30 transition-all"
                   />
                 </div>

--- a/apps/web/src/lib/hooks/useAnalytics.ts
+++ b/apps/web/src/lib/hooks/useAnalytics.ts
@@ -55,6 +55,16 @@ export interface CreditUtilizationItem {
   utilizationPercent: number;
 }
 
+/** "Is this card worth it?" row — trailing-12mo statement credits vs. annual fee. */
+export interface CardWorthItItem {
+  accountId: string;
+  nickname: string;
+  annualFeeCents: number;
+  statementCreditsCents: number;
+  netCents: number;
+  worthIt: boolean;
+}
+
 /** A single contributing row behind a net-worth total (one account/asset/loan). */
 export interface NetWorthLineItem {
   id: string;
@@ -168,6 +178,15 @@ export function useCreditUtilization(params: AnalyticsParams = {}) {
     queryKey: ['analytics', 'credit-utilization', params],
     queryFn: () =>
       api.get<{ data: CreditUtilizationItem[] }>('/analytics/credit-utilization', { params }),
+  });
+}
+
+/** Fetch "is this card worth it" data: statement credits vs. annual fee, per card. */
+export function useCardWorthIt(params: AnalyticsParams = {}) {
+  return useQuery({
+    queryKey: ['analytics', 'card-worth-it', params],
+    queryFn: () =>
+      api.get<{ data: CardWorthItItem[] }>('/analytics/card-worth-it', { params }),
   });
 }
 

--- a/db/migrations/0032_account_annual_fee.sql
+++ b/db/migrations/0032_account_annual_fee.sql
@@ -1,0 +1,6 @@
+-- Add nullable annual_fee_cents to accounts so premium credit cards (Amex
+-- Gold/Platinum style) can record their annual fee for the "is this card
+-- worth it" calculator (statement credits received vs. fee paid, #142).
+-- Additive-only: nullable column, no backfill, existing rows get NULL.
+
+ALTER TABLE "accounts" ADD COLUMN IF NOT EXISTS "annual_fee_cents" integer;

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1784560900000,
       "tag": "0031_monthly_close",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1784561000000,
+      "tag": "0032_account_annual_fee",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -80,6 +80,8 @@ export interface Account {
   creditLimitCents: number | null;
   /** Basis points (e.g. 450 = 4.50% APY). Only meaningful for interest-bearing types. */
   interestRateBps: number | null;
+  /** Annual fee in cents. Only meaningful for accountType = 'credit_card'. */
+  annualFeeCents: number | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/packages/shared/src/validation/index.ts
+++ b/packages/shared/src/validation/index.ts
@@ -56,6 +56,8 @@ export const createAccountSchema = z.object({
   creditLimitCents: z.int().nullable().optional(),
   /** Basis points (e.g. 450 = 4.50% APY). Only meaningful for interest-bearing types. */
   interestRateBps: z.int().min(0).max(100000).nullable().optional(),
+  /** Annual fee in cents. Only meaningful for accountType = 'credit_card'. */
+  annualFeeCents: z.int().min(0).nullable().optional(),
 });
 
 export const updateAccountSchema = createAccountSchema.partial();


### PR DESCRIPTION
Push is handled by the control plane, not by me directly — attempting `git push` here is blocked by a `coxswain no-push boundary`. The commit itself is already in place on the branch (`coxd/MyMoney-premium-credit-card-worth-it-1785284164`, commit `52f8187`), so there's nothing further for me to do locally; the retry of the push/PR-open step needs to happen at the control-plane level, not from within this worktree.

## Summary

Commit `52f8187` implements the "is this card worth it" calculator from #142:

- **Schema/migration**: added nullable `annual_fee_cents` on `accounts` (additive-only `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`, migration `0032`), scoped conceptually to `credit_card` accounts.
- **Shared types/validation**: `annualFeeCents` added to `Account`, `createAccountSchema`/`updateAccountSchema`.
- **API**: new `AnalyticsService.cardWorthIt()` + `GET /analytics/card-worth-it`, following the existing `creditUtilization` pattern (household-scoped raw SQL). It sums trailing-12-month statement credits per card — identified the same way #115/#141 already exclude them from income (`is_credit = true` rows on `account_type = 'credit_card'`) — and diffs against `annual_fee_cents` to produce a `worthIt` boolean and net cents. Added unit tests covering worth-it, not-worth-it, and empty cases.
- **Web**: extended the existing Accounts page (#114) rather than adding a new screen — annual fee input on create/edit forms for credit-card accounts, and a summary badge per card showing statement credits vs. fee and the net.

Verified: `pnpm build` passes for `shared`, `api`, and `web`; full API test suite (826 tests) passes including the new `cardWorthIt` cases. Nothing else was changed in this session — the work is already committed and ready for the control plane to push and open the PR.

---
### Test evidence
**3 new test case(s) added** (heuristic count):
```
 .../analytics/__tests__/analytics.service.spec.ts  | 59 ++++++++++++++++
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/categorization/__tests__/learning.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/expected-cycle-date.spec.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/next-loan-due-date.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test: [32m[Nest] 98494  - [39m07/29/2026, 12:22:05 AM [32m    LOG[39m [38;5;3m[AlertCronProcessor] [39m[32mProcessing alert job: monthly-close-auto-draft[39m
@moneypulse/api:test: [32m[Nest] 98494  - [39m07/29/2026, 12:22:05 AM [32m    LOG[39m [38;5;3m[AlertCronProcessor] [39m[32mMonthly-close auto-draft: 3 user(s) processed, 2 close(s) created[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/monthly-close-cron.spec.ts [2m([22m[2m1 test[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m96 passed[39m[22m[90m (96)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m826 passed[39m[22m[90m (826)[39m
@moneypulse/api:test: [2m   Start at [22m 00:21:52
@moneypulse/api:test: [2m   Duration [22m 12.54s[2m (transform 3.56s, setup 0ms, import 66.94s, tests 3.51s, environment 5ms)[22m
@moneypulse/api:test: 

 Tasks:    3 successful, 3 total
Cached:    3 cached, 3 total
  Time:    96ms >>> FULL TURBO
```
</details>

### Review
**Review verdict:** approve

---
Dispatched via coxd (`MyMoney-premium-credit-card-worth-it-1785284164`) · cost $2.305 · 🤖 coxd