### PR TITLE
40.1 Extend safe-to-spend to 30/60/90d horizons + goal-contribution su

### DIFF
--- a/apps/api/src/analytics/__tests__/brief.service.spec.ts
+++ b/apps/api/src/analytics/__tests__/brief.service.spec.ts
@@ -38,7 +38,34 @@ describe('computeSafeToSpend', () => {
 
   it('returns zero for an empty series', () => {
     const result = computeSafeToSpend({ netWorthSeries: [] }, 14);
-    expect(result).toEqual({ safeToSpendCents: 0, minProjectedCents: 0, minDate: null });
+    expect(result).toEqual({
+      safeToSpendCents: 0,
+      minProjectedCents: 0,
+      minDate: null,
+      goalContributionsCents: 0,
+    });
+  });
+
+  it('subtracts goal contributions from the minimum projected balance', () => {
+    const forecast = {
+      netWorthSeries: [
+        { date: '2026-07-20', projectedCents: 500_00 },
+        { date: '2026-07-21', projectedCents: 300_00 },
+      ],
+    };
+    const result = computeSafeToSpend(forecast, 30, 100_00);
+    expect(result.minProjectedCents).toBe(300_00);
+    expect(result.goalContributionsCents).toBe(100_00);
+    expect(result.safeToSpendCents).toBe(200_00);
+  });
+
+  it('clamps to zero when goal contributions exceed the minimum projected balance', () => {
+    const forecast = {
+      netWorthSeries: [{ date: '2026-07-20', projectedCents: 300_00 }],
+    };
+    const result = computeSafeToSpend(forecast, 30, 500_00);
+    expect(result.safeToSpendCents).toBe(0);
+    expect(result.minProjectedCents).toBe(300_00);
   });
 });
 

--- a/apps/api/src/analytics/brief.service.ts
+++ b/apps/api/src/analytics/brief.service.ts
@@ -16,13 +16,17 @@ export interface SafeToSpendResult {
   safeToSpendCents: number;
   minProjectedCents: number;
   minDate: string | null;
+  goalContributionsCents: number;
 }
 
 /**
  * Derives "safe to spend today" from a cash-flow forecast: the lowest projected
  * combined balance within the horizon, which is already net of every known
- * recurring bill (see `ForecastService.forecast`'s `netWorthSeries`). Clamped at
- * zero — a negative floor isn't "safe to spend", it's a shortfall.
+ * recurring bill (see `ForecastService.forecast`'s `netWorthSeries`). Optionally
+ * subtracts money already earmarked toward active goals (`goalContributionsCents`)
+ * per #40's formula: `balance + scheduled inflows − (remaining bills + goal
+ * contributions)`. Clamped at zero — a negative floor isn't "safe to spend", it's
+ * a shortfall.
  *
  * Kept as ONE standalone exported function so #40's goal planner can reuse the
  * exact same math without depending on BriefService's delivery/formatting concerns.
@@ -30,10 +34,11 @@ export interface SafeToSpendResult {
 export function computeSafeToSpend(
   forecast: Pick<ForecastResult, 'netWorthSeries'>,
   horizonDays = 14,
+  goalContributionsCents = 0,
 ): SafeToSpendResult {
   const window = forecast.netWorthSeries.slice(0, horizonDays);
   if (window.length === 0) {
-    return { safeToSpendCents: 0, minProjectedCents: 0, minDate: null };
+    return { safeToSpendCents: 0, minProjectedCents: 0, minDate: null, goalContributionsCents };
   }
 
   let min = window[0];
@@ -42,9 +47,10 @@ export function computeSafeToSpend(
   }
 
   return {
-    safeToSpendCents: Math.max(0, min.projectedCents),
+    safeToSpendCents: Math.max(0, min.projectedCents - goalContributionsCents),
     minProjectedCents: min.projectedCents,
     minDate: min.date,
+    goalContributionsCents,
   };
 }
 

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -32,6 +32,7 @@ import { registerGetPortfolioValue } from './tools/get-portfolio-value.js';
 import { registerGetAllocation } from './tools/get-allocation.js';
 import { registerGetMonthlyClose } from './tools/get-monthly-close.js';
 import { registerGetFinancialHealth } from './tools/get-financial-health.js';
+import { registerGetSafeToSpend } from './tools/get-safe-to-spend.js';
 import { close } from './db.js';
 import http from 'node:http';
 
@@ -71,6 +72,7 @@ registerGetPortfolioValue(server);
 registerGetAllocation(server);
 registerGetMonthlyClose(server);
 registerGetFinancialHealth(server);
+registerGetSafeToSpend(server);
 
 const mode = process.argv.includes('--sse') ? 'sse' : 'stdio';
 

--- a/apps/mcp-server/src/tools/__tests__/get-safe-to-spend.spec.ts
+++ b/apps/mcp-server/src/tools/__tests__/get-safe-to-spend.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const queryMock = vi.fn();
+const getUserIdMock = vi.fn().mockResolvedValue('user-1');
+
+vi.mock('../../db.js', () => ({
+  query: (...args: any[]) => queryMock(...args),
+  getUserId: () => getUserIdMock(),
+}));
+
+const { registerGetSafeToSpend } = await import('../get-safe-to-spend.js');
+
+function makeServer() {
+  let handler: (params: any) => Promise<any>;
+  const server = {
+    tool: (_name: string, _desc: string, _schema: any, fn: any) => {
+      handler = fn;
+    },
+  } as any;
+  registerGetSafeToSpend(server);
+  return (params: any = {}) => handler(params);
+}
+
+describe('get_safe_to_spend', () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+  });
+
+  it('subtracts a recurring bill and goal reservation from a synthetic flat-balance projection', async () => {
+    // Synthetic: $1,000 starting liquid balance, zero average daily net (flat trend),
+    // one $200 monthly bill due in 10 days -> floor should be $800, then minus a
+    // $100 goal reservation -> safe-to-spend $700.
+    const today = new Date();
+    const billDate = new Date(today);
+    billDate.setDate(billDate.getDate() + 10);
+    const billDateStr = billDate.toISOString().slice(0, 10);
+
+    queryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM accounts a')) {
+        return [{ liquid_cents: '100000' }];
+      }
+      if (sql.includes('FROM recurring_bills')) {
+        return [
+          {
+            expected_amount_cents: '20000',
+            frequency: 'monthly',
+            next_expected_date: billDateStr,
+          },
+        ];
+      }
+      if (sql.includes('net_90d')) {
+        return [{ net_90d: '0' }];
+      }
+      return [];
+    });
+
+    const call = makeServer();
+    const result = await call({ horizonDays: 30, goalContributionsCents: 10000 });
+    const text = result.content[0].text;
+
+    expect(text).toContain('Current liquid balance (checking/savings): $1000.00');
+    expect(text).toContain('Minimum projected balance over 30d: $800.00');
+    expect(text).toContain('Reserved for savings goals: $100.00');
+    expect(text).toContain('Safe to spend (30d horizon): $700.00');
+  });
+
+  it('clamps safe-to-spend at zero when the projected floor is negative', async () => {
+    queryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM accounts a')) return [{ liquid_cents: '5000' }];
+      if (sql.includes('FROM recurring_bills')) return [];
+      if (sql.includes('net_90d')) return [{ net_90d: '-18000' }]; // -$2/day avg trend over 90d
+      return [];
+    });
+
+    const call = makeServer();
+    const result = await call({ horizonDays: 30, goalContributionsCents: 0 });
+    const text = result.content[0].text;
+
+    expect(text).toContain('Safe to spend (30d horizon): $0.00');
+    expect(text).toContain('shortfall, not a safe-to-spend amount');
+  });
+
+  it('computes over a 30-day horizon with zero goal contributions', async () => {
+    // Note: the test harness invokes the tool's handler directly, bypassing the
+    // real MCP SDK's zod default-application, so horizonDays/goalContributionsCents
+    // are passed explicitly here rather than relying on the schema defaults.
+    queryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM accounts a')) return [{ liquid_cents: '10000' }];
+      if (sql.includes('FROM recurring_bills')) return [];
+      if (sql.includes('net_90d')) return [{ net_90d: '0' }];
+      return [];
+    });
+
+    const call = makeServer();
+    const result = await call({ horizonDays: 30, goalContributionsCents: 0 });
+    const text = result.content[0].text;
+
+    expect(text).toContain('over 30d');
+    expect(text).toContain('Reserved for savings goals: $0.00');
+  });
+});

--- a/apps/mcp-server/src/tools/__tests__/get-safe-to-spend.spec.ts
+++ b/apps/mcp-server/src/tools/__tests__/get-safe-to-spend.spec.ts
@@ -80,6 +80,34 @@ describe('get_safe_to_spend', () => {
     expect(text).toContain('shortfall, not a safe-to-spend amount');
   });
 
+  it('deducts a bill due exactly today from the projected floor, not just the informational total', async () => {
+    // A bill due *today* must hit the floor immediately — the day-by-day loop only
+    // walks tomorrow through the horizon, so without an explicit same-day deduction
+    // it would show up in "Bills due" but never actually lower "Minimum projected
+    // balance", overstating safe-to-spend on the one day it matters most.
+    const today = new Date();
+    const todayStr = today.toISOString().slice(0, 10);
+
+    queryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM accounts a')) return [{ liquid_cents: '100000' }];
+      if (sql.includes('FROM recurring_bills')) {
+        return [
+          { expected_amount_cents: '30000', frequency: 'monthly', next_expected_date: todayStr },
+        ];
+      }
+      if (sql.includes('net_90d')) return [{ net_90d: '0' }];
+      return [];
+    });
+
+    const call = makeServer();
+    const result = await call({ horizonDays: 30, goalContributionsCents: 0 });
+    const text = result.content[0].text;
+
+    expect(text).toContain('Bills due in next 30d: $300.00');
+    expect(text).toContain('Minimum projected balance over 30d: $700.00');
+    expect(text).toContain('Safe to spend (30d horizon): $700.00');
+  });
+
   it('computes over a 30-day horizon with zero goal contributions', async () => {
     // Note: the test harness invokes the tool's handler directly, bypassing the
     // real MCP SDK's zod default-application, so horizonDays/goalContributionsCents

--- a/apps/mcp-server/src/tools/get-safe-to-spend.ts
+++ b/apps/mcp-server/src/tools/get-safe-to-spend.ts
@@ -1,0 +1,194 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { query, getUserId } from '../db.js';
+
+type BillFrequency = 'weekly' | 'biweekly' | 'monthly' | 'quarterly' | 'semi_annual' | 'annual';
+
+/** Advance a date by one billing cycle, month-end aware. Mirrors ForecastService's addFrequency. */
+function addFrequency(date: Date, frequency: BillFrequency): Date {
+  const d = new Date(date);
+  switch (frequency) {
+    case 'weekly':
+      d.setDate(d.getDate() + 7);
+      break;
+    case 'biweekly':
+      d.setDate(d.getDate() + 14);
+      break;
+    case 'monthly': {
+      const originalDay = d.getDate();
+      d.setDate(1);
+      d.setMonth(d.getMonth() + 1);
+      const maxDay = new Date(d.getFullYear(), d.getMonth() + 1, 0).getDate();
+      d.setDate(Math.min(originalDay, maxDay));
+      break;
+    }
+    case 'quarterly': {
+      const originalDay = d.getDate();
+      d.setDate(1);
+      d.setMonth(d.getMonth() + 3);
+      const maxDay = new Date(d.getFullYear(), d.getMonth() + 1, 0).getDate();
+      d.setDate(Math.min(originalDay, maxDay));
+      break;
+    }
+    case 'semi_annual': {
+      const originalDay = d.getDate();
+      d.setDate(1);
+      d.setMonth(d.getMonth() + 6);
+      const maxDay = new Date(d.getFullYear(), d.getMonth() + 1, 0).getDate();
+      d.setDate(Math.min(originalDay, maxDay));
+      break;
+    }
+    case 'annual':
+      d.setFullYear(d.getFullYear() + 1);
+      break;
+  }
+  return d;
+}
+
+function toDateStr(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${dd}`;
+}
+
+/** Parse a date-only `YYYY-MM-DD` (or ISO timestamp) string as a *local* calendar date. */
+function parseDateOnly(s: string): Date {
+  const [y, m, d] = s.slice(0, 10).split('-').map(Number);
+  return new Date(y, m - 1, d);
+}
+
+/**
+ * #40.1 — safe-to-spend across 30/60/90d horizons: the lowest projected combined
+ * liquid balance within the window (already net of every recurring bill
+ * occurrence, fast-forwarded across the horizon), minus any amount the user
+ * wants reserved for savings goals. Aggregates-only: no row-level transactions
+ * or account identifiers are exposed, matching epic #36's provenance rules.
+ *
+ * There is no dedicated `goals` table yet, so goal reservations are taken as a
+ * caller-supplied total (`goalContributionsCents`) rather than looked up —
+ * per #40's "minimal goal-amount input" fallback until a goals feature exists.
+ */
+export function registerGetSafeToSpend(server: McpServer) {
+  server.tool(
+    'get_safe_to_spend',
+    'Safe-to-spend = minimum projected combined checking/savings balance over a 30/60/90-day horizon (already net of every recurring bill due in that window), minus any amount reserved for savings goals. Answers "how much can I safely spend" / "what\'s my safe-to-spend for the next 60 days".',
+    {
+      horizonDays: z
+        .union([z.literal(30), z.literal(60), z.literal(90)])
+        .default(30)
+        .describe('Forecast horizon in days: 30, 60, or 90'),
+      goalContributionsCents: z
+        .number()
+        .min(0)
+        .default(0)
+        .describe(
+          'Total amount (in cents) already earmarked toward savings goals over the horizon; subtracted from the safe-to-spend figure',
+        ),
+    },
+    async (params) => {
+      const userId = await getUserId();
+      const { horizonDays, goalContributionsCents } = params;
+      const dollars = (c: number) => `$${(c / 100).toFixed(2)}`;
+
+      // 1) Current combined liquid balance (checking + savings).
+      const balRows = await query(
+        `SELECT COALESCE(SUM(a.starting_balance_cents + COALESCE(tx.net, 0)), 0) AS liquid_cents
+         FROM accounts a
+         LEFT JOIN (
+           SELECT account_id,
+                  SUM(CASE WHEN is_credit THEN amount_cents ELSE -amount_cents END) AS net
+           FROM transactions
+           WHERE deleted_at IS NULL AND is_split_parent = false
+           GROUP BY account_id
+         ) tx ON tx.account_id = a.id
+         WHERE a.user_id = $1 AND a.deleted_at IS NULL
+           AND a.account_type IN ('checking', 'savings')`,
+        [userId],
+      );
+      const startCents = Number(balRows[0]?.liquid_cents ?? 0);
+
+      // 2) Active + confirmed recurring bills, fast-forwarded across the horizon
+      //    (a bill can occur more than once within a 90-day window).
+      const billRows = await query(
+        `SELECT expected_amount_cents, frequency, next_expected_date
+         FROM recurring_bills
+         WHERE user_id = $1 AND is_active = true AND is_confirmed = true
+           AND next_expected_date IS NOT NULL`,
+        [userId],
+      );
+
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      const horizon = new Date(today);
+      horizon.setDate(horizon.getDate() + horizonDays);
+
+      const billDeductions = new Map<string, number>();
+      let billTotalCents = 0;
+      for (const bill of billRows as Array<{
+        expected_amount_cents: string;
+        frequency: BillFrequency;
+        next_expected_date: string;
+      }>) {
+        const amount = Number(bill.expected_amount_cents);
+        let next = parseDateOnly(bill.next_expected_date);
+        next.setHours(0, 0, 0, 0);
+        while (next < today) {
+          next = addFrequency(next, bill.frequency);
+        }
+        while (next <= horizon) {
+          const key = toDateStr(next);
+          billDeductions.set(key, (billDeductions.get(key) ?? 0) + amount);
+          billTotalCents += amount;
+          next = addFrequency(next, bill.frequency);
+        }
+      }
+
+      // 3) Average daily net cash flow over the trailing 90 days (excl. transfers)
+      //    as a proxy for scheduled inflows/ordinary spending.
+      const netRows = await query(
+        `SELECT COALESCE(SUM(CASE WHEN t.is_credit THEN t.amount_cents ELSE -t.amount_cents END), 0) AS net_90d
+         FROM transactions t
+         LEFT JOIN categories c ON t.category_id = c.id
+         WHERE t.user_id = $1 AND t.deleted_at IS NULL AND t.is_split_parent = false
+           AND COALESCE(c.is_transfer, false) = false
+           AND t.date >= CURRENT_DATE - interval '90 days'`,
+        [userId],
+      );
+      const avgDailyNet = Number(netRows[0]?.net_90d ?? 0) / 90;
+
+      // 4) Day-by-day projection; track the minimum (the "floor" over the horizon).
+      let balance = startCents;
+      let minCents = startCents;
+      let minDate = toDateStr(today);
+      for (let d = 1; d <= horizonDays; d++) {
+        const date = new Date(today);
+        date.setDate(date.getDate() + d);
+        const dateStr = toDateStr(date);
+        const billHit = billDeductions.get(dateStr) ?? 0;
+        balance = Math.round(balance + avgDailyNet - billHit);
+        if (balance < minCents) {
+          minCents = balance;
+          minDate = dateStr;
+        }
+      }
+
+      const safeToSpendCents = Math.max(0, minCents - goalContributionsCents);
+
+      const lines = [
+        `Current liquid balance (checking/savings): ${dollars(startCents)}`,
+        `Bills due in next ${horizonDays}d: ${dollars(billTotalCents)}`,
+        `Minimum projected balance over ${horizonDays}d: ${dollars(minCents)} (around ${minDate})`,
+        `Reserved for savings goals: ${dollars(goalContributionsCents)}`,
+        `Safe to spend (${horizonDays}d horizon): ${dollars(safeToSpendCents)}`,
+      ];
+      if (minCents < 0) {
+        lines.push(
+          `⚠ Projected balance dips below $0 around ${minDate} even before goal reservations — this is a shortfall, not a safe-to-spend amount.`,
+        );
+      }
+
+      return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
+    },
+  );
+}

--- a/apps/mcp-server/src/tools/get-safe-to-spend.ts
+++ b/apps/mcp-server/src/tools/get-safe-to-spend.ts
@@ -158,8 +158,12 @@ export function registerGetSafeToSpend(server: McpServer) {
       const avgDailyNet = Number(netRows[0]?.net_90d ?? 0) / 90;
 
       // 4) Day-by-day projection; track the minimum (the "floor" over the horizon).
-      let balance = startCents;
-      let minCents = startCents;
+      // A bill due exactly today must hit the floor immediately — the loop below
+      // only walks d=1..horizonDays, so without this a same-day bill would be
+      // counted in billTotalCents but never actually subtracted from the floor.
+      let balance = startCents - (billDeductions.get(toDateStr(today)) ?? 0);
+      balance = Math.round(balance);
+      let minCents = balance;
       let minDate = toDateStr(today);
       for (let d = 1; d <= horizonDays; d++) {
         const date = new Date(today);


### PR DESCRIPTION
Committed successfully.

## Summary

Closes 40.1: extended safe-to-spend to explicit 30/60/90-day horizons and made it subtract money earmarked for goals.

**Root cause / gap:** `computeSafeToSpend()` already accepted a `horizonDays` parameter and `ForecastService.forecast()` already accepted an arbitrary `days` window, so the horizon plumbing existed — what was missing was (a) subtraction of goal contributions from the floor, and (b) an MCP tool exposing this at the 30/60/90d granularity the advisor chat needs. There's no `goals` table yet, so per the issue's fallback guidance this takes a caller-supplied reservation amount rather than building a full goals feature.

**Changes:**
- `computeSafeToSpend()` (`apps/api/src/analytics/brief.service.ts`) gains an optional `goalContributionsCents` param, subtracted from the minimum projected balance before clamping at zero; result now also reports the reservation amount used.
- New `get_safe_to_spend` MCP tool (`apps/mcp-server/src/tools/get-safe-to-spend.ts`): takes `horizonDays` (30/60/90) and `goalContributionsCents`, simulates the day-by-day combined checking/savings balance over the window (fast-forwarding recurring bill occurrences the same way `ForecastService` does internally), and returns the minimum projected floor net of bills and goal reservations. Output is aggregate-only (no row-level transactions/account identifiers), consistent with the other MCP tools' provenance rules.
- Registered the tool in `apps/mcp-server/src/index.ts`.
- Updated/added tests in both apps; verified with synthetic fixtures (flat/declining balance trends, a single monthly bill, goal reservations) rather than real account data.

**Verification:** `pnpm --filter api exec vitest run src/analytics` (151 passed), `pnpm --filter mcp-server exec vitest run` (85 passed, including the new tool's 3 tests and the existing user-scoping guardrail), `tsc --noEmit` clean for both packages (pre-existing unrelated `@moneypulse/shared` build-artifact iss

_(summary truncated)_

---
### Test evidence
**5 new test case(s) added** (heuristic count):
```
 .../src/analytics/__tests__/brief.service.spec.ts  |  29 ++-
 .../src/tools/__tests__/get-safe-to-spend.spec.ts  | 101 +++++++++++
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
[2m2 tests[22m[2m)[22m[32m 8[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/sync-delivery.processor.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 4[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/next-loan-due-date.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/categorization/__tests__/learning.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test: [32m[Nest] 28043  - [39m07/29/2026, 1:13:19 AM [32m    LOG[39m [38;5;3m[AlertCronProcessor] [39m[32mProcessing alert job: monthly-close-auto-draft[39m
@moneypulse/api:test: [32m[Nest] 28043  - [39m07/29/2026, 1:13:19 AM [32m    LOG[39m [38;5;3m[AlertCronProcessor] [39m[32mMonthly-close auto-draft: 3 user(s) processed, 2 close(s) created[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/monthly-close-cron.spec.ts [2m([22m[2m1 test[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m96 passed[39m[22m[90m (96)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m829 passed[39m[22m[90m (829)[39m
@moneypulse/api:test: [2m   Start at [22m 01:13:08
@moneypulse/api:test: [2m   Duration [22m 10.69s[2m (transform 3.27s, setup 0ms, import 55.40s, tests 2.03s, environment 5ms)[22m
@moneypulse/api:test: 

 Tasks:    3 successful, 3 total
Cached:    1 cached, 3 total
  Time:    11.284s
```
</details>

### Review
**Review verdict:** approve

Findings (advisory — did not block landing):
- [low/advisory] apps/mcp-server/src/tools/get-safe-to-spend.ts:141 — avgDailyNet (from trailing-90d history, which includes past bill payments) plus a separate future-bill deduction can double-count recurring bills; this only biases the floor downward (more conservative), so it never over-reports safe-to-spend.
- [low/advisory] apps/mcp-server/src/tools/get-safe-to-spend.ts:130 — A bill dated exactly today is included in billTotalCents but not applied to the projected balance since the projection loop starts at d=1; minor edge-case inconsistency.

---
Dispatched via coxd (`MyMoney-40-1-extend-safe-to-spend-to-1785287342`) · cost $1.545 · 🤖 coxd