### PR TITLE
40.2 Car affordability engine (20/4/10 rule + user-entered TCO + buy-v

### DIFF
--- a/apps/api/src/advisor/__tests__/mcp-client.service.spec.ts
+++ b/apps/api/src/advisor/__tests__/mcp-client.service.spec.ts
@@ -34,6 +34,7 @@ const ALL_TOOLS = [
   { name: 'get_allocation', description: 'x', inputSchema: { type: 'object' } },
   { name: 'get_monthly_close', description: 'y', inputSchema: { type: 'object' } },
   { name: 'get_financial_health', description: 'z', inputSchema: { type: 'object' } },
+  { name: 'get_car_affordability', description: 'aa', inputSchema: { type: 'object' } },
   { name: 'get_transactions', description: 'ROW-LEVEL', inputSchema: { type: 'object' } },
   { name: 'search_transactions', description: 'ROW-LEVEL', inputSchema: { type: 'object' } },
   {

--- a/apps/api/src/advisor/mcp-client.service.ts
+++ b/apps/api/src/advisor/mcp-client.service.ts
@@ -41,6 +41,7 @@ export const AGGREGATE_TOOL_ALLOWLIST = new Set([
   'get_rate_watchlist', // user-entered advertised rates + auto-populated Treasury rows, no PII
   'get_monthly_close', // frozen aggregate close totals/ratios/target-status/freshness, no row-level data
   'get_financial_health', // ratio/target/trend rollup across recent closes, aggregate only
+  'get_car_affordability', // user-entered TCO inputs + gross income figure + public gas price, no row-level data
 ]);
 
 /** Anthropic tool definition shape (name + description + JSON schema). */

--- a/apps/api/src/car-affordability/__tests__/car-affordability.service.spec.ts
+++ b/apps/api/src/car-affordability/__tests__/car-affordability.service.spec.ts
@@ -4,6 +4,7 @@ import {
   calculateTco,
   compareBuyVsLease,
   evaluateRule204010,
+  remainingLoanBalanceCents,
   toMonthlyCents,
   totalLoanInterestCents,
   CarAffordabilityInput,
@@ -221,10 +222,27 @@ describe('compareBuyVsLease', () => {
       termMonths: 24, // half of the 48-month ownership window
     });
     // Depreciation over 4yr = $30,000 - $12,000 = $18,000; half that at 24mo = $9,000
-    // → resale credit at 24mo = $30,000 - $9,000 = $21,000.
+    // → resale value at 24mo = $30,000 - $9,000 = $21,000. But the loan isn't paid
+    // off at 24 of 48 months — buy's actual equity is resale MINUS the remaining
+    // loan balance at that point, not the full resale value.
+    const monthlyPayment = amortizedMonthlyPaymentCents(2_400_000, 600, 48);
+    const remainingBalance = remainingLoanBalanceCents(2_400_000, 600, 48, 24);
+    const equity = Math.max(0, 2_100_000 - remainingBalance);
+    expect(result.buyTotalCostCents).toBe(600_000 + monthlyPayment * 24 - equity);
+  });
+
+  it('credits full resale value as equity once the loan is fully paid off by the comparison end', () => {
+    // Comparison term (48mo) equals the loan term, so remaining balance is zero
+    // and buy's equity should equal the full resale value — matches the old
+    // (pre-fix) behavior exactly in the fully-paid-off case.
+    const result = compareBuyVsLease(tcoTerms, {
+      monthlyPaymentCents: 0,
+      dueAtSigningCents: 0,
+      termMonths: 48,
+    });
     const monthlyPayment = amortizedMonthlyPaymentCents(2_400_000, 600, 48);
     expect(result.buyTotalCostCents).toBe(
-      600_000 + monthlyPayment * 24 - 2_100_000,
+      600_000 + monthlyPayment * 48 - 1_200_000,
     );
   });
 });

--- a/apps/api/src/car-affordability/__tests__/car-affordability.service.spec.ts
+++ b/apps/api/src/car-affordability/__tests__/car-affordability.service.spec.ts
@@ -1,0 +1,267 @@
+import {
+  amortizedMonthlyPaymentCents,
+  calculateCarAffordability,
+  calculateTco,
+  compareBuyVsLease,
+  evaluateRule204010,
+  toMonthlyCents,
+  totalLoanInterestCents,
+  CarAffordabilityInput,
+} from '../car-affordability.service';
+
+function baseInput(
+  overrides: Partial<CarAffordabilityInput> = {},
+): CarAffordabilityInput {
+  return {
+    priceCents: 3_000_000, // $30,000
+    downPaymentCents: 600_000, // $6,000 = 20%
+    loanTermMonths: 48,
+    loanAprBps: 600, // 6% APR
+    grossMonthlyIncomeCents: 800_000, // $8,000/mo gross
+    insurance: { amountCents: 120_000, frequency: 'annual' }, // $1,200/yr
+    maintenance: { amountCents: 60_000, frequency: 'annual' }, // $600/yr
+    annualMileage: 12_000,
+    mpg: 30,
+    gasPriceCentsPerGallon: 350, // $3.50/gal
+    ownershipYears: 4,
+    estimatedResaleValueCents: 1_200_000, // $12,000 after 4 years
+    ...overrides,
+  };
+}
+
+describe('toMonthlyCents', () => {
+  it('divides an annual figure by 12', () => {
+    expect(toMonthlyCents({ amountCents: 120_000, frequency: 'annual' })).toBe(10_000);
+  });
+
+  it('passes a monthly figure through unchanged', () => {
+    expect(toMonthlyCents({ amountCents: 10_000, frequency: 'monthly' })).toBe(10_000);
+  });
+});
+
+describe('amortizedMonthlyPaymentCents', () => {
+  it('matches the hand-worked standard amortization formula (5-year, $20k, 5% APR)', () => {
+    // M = P*r(1+r)^n / ((1+r)^n - 1); r = 0.05/12, n = 60, P = $20,000
+    const payment = amortizedMonthlyPaymentCents(2_000_000, 500, 60);
+    expect(payment).toBe(37_742); // $377.42/mo, verified against a standard loan calculator
+  });
+
+  it('degrades to a straight-line split at 0% APR', () => {
+    expect(amortizedMonthlyPaymentCents(1_200_000, 0, 12)).toBe(100_000);
+  });
+
+  it('returns 0 for a non-positive principal or term', () => {
+    expect(amortizedMonthlyPaymentCents(0, 500, 60)).toBe(0);
+    expect(amortizedMonthlyPaymentCents(2_000_000, 500, 0)).toBe(0);
+  });
+});
+
+describe('totalLoanInterestCents', () => {
+  it('is 0 when there is no principal financed', () => {
+    expect(totalLoanInterestCents(0, 500, 48)).toBe(0);
+  });
+
+  it('is positive whenever principal and APR are positive', () => {
+    expect(totalLoanInterestCents(2_000_000, 500, 60)).toBeGreaterThan(0);
+  });
+});
+
+describe('evaluateRule204010', () => {
+  it('passes all three legs for a well-within-budget scenario', () => {
+    const result = evaluateRule204010({
+      priceCents: 3_000_000,
+      downPaymentCents: 600_000, // exactly 20%
+      loanTermMonths: 48,
+      totalMonthlyVehicleCostCents: 700_000, // way under 10% of $8,000/mo... (see below)
+      grossMonthlyIncomeCents: 8_000_000, // $80,000/mo gross, so 10% = $8,000
+    });
+    expect(result.downPaymentPassed).toBe(true);
+    expect(result.downPaymentPercent).toBeCloseTo(0.2);
+    expect(result.loanTermPassed).toBe(true);
+    expect(result.monthlyCostPassed).toBe(true);
+    expect(result.passed).toBe(true);
+  });
+
+  it('fails the down-payment leg below 20%', () => {
+    const result = evaluateRule204010({
+      priceCents: 3_000_000,
+      downPaymentCents: 300_000, // 10%
+      loanTermMonths: 48,
+      totalMonthlyVehicleCostCents: 10_000,
+      grossMonthlyIncomeCents: 8_000_000,
+    });
+    expect(result.downPaymentPassed).toBe(false);
+    expect(result.downPaymentRequiredCents).toBe(600_000);
+    expect(result.passed).toBe(false);
+  });
+
+  it('fails the loan-term leg above 48 months', () => {
+    const result = evaluateRule204010({
+      priceCents: 3_000_000,
+      downPaymentCents: 600_000,
+      loanTermMonths: 60,
+      totalMonthlyVehicleCostCents: 10_000,
+      grossMonthlyIncomeCents: 8_000_000,
+    });
+    expect(result.loanTermPassed).toBe(false);
+    expect(result.passed).toBe(false);
+  });
+
+  it('fails the 10%-of-income leg when vehicle costs are too high', () => {
+    const result = evaluateRule204010({
+      priceCents: 3_000_000,
+      downPaymentCents: 600_000,
+      loanTermMonths: 48,
+      totalMonthlyVehicleCostCents: 90_000, // $900/mo
+      grossMonthlyIncomeCents: 800_000, // $8,000/mo → cap is $800/mo
+    });
+    expect(result.monthlyCostPassed).toBe(false);
+    expect(result.maxMonthlyCostCents).toBe(80_000);
+    expect(result.monthlyCostPercent).toBeCloseTo(0.1125);
+    expect(result.passed).toBe(false);
+  });
+
+  it('fails closed (never claims a pass) when gross income is unknown', () => {
+    const result = evaluateRule204010({
+      priceCents: 3_000_000,
+      downPaymentCents: 600_000,
+      loanTermMonths: 48,
+      totalMonthlyVehicleCostCents: 10_000,
+      grossMonthlyIncomeCents: 0,
+    });
+    expect(result.monthlyCostPassed).toBe(false);
+    expect(result.monthlyCostPercent).toBeNull();
+    expect(result.maxMonthlyCostCents).toBeNull();
+    expect(result.passed).toBe(false);
+  });
+});
+
+describe('calculateTco', () => {
+  it('produces a hand-worked breakdown for the base fixture', () => {
+    const tco = calculateTco(baseInput());
+    // Principal = $30,000 - $6,000 = $24,000 financed over 48mo @ 6% APR.
+    expect(tco.loanPrincipalCents).toBe(2_400_000);
+    expect(tco.monthlyLoanPaymentCents).toBeGreaterThan(0);
+    // Fuel: 12,000mi / 30mpg = 400gal/yr * $3.50 = $1,400/yr → $116.67/mo → rounds to 11,667c
+    expect(tco.monthlyFuelCents).toBe(11_667);
+    expect(tco.monthlyInsuranceCents).toBe(10_000); // $1,200/yr / 12
+    expect(tco.monthlyMaintenanceCents).toBe(5_000); // $600/yr / 12
+    expect(tco.ownershipMonths).toBe(48);
+    // Financing cash out over 4yr ownership = down payment + all 48 loan payments
+    // (loan term == ownership window here).
+    expect(tco.totalFinancingCashOutCents).toBe(
+      600_000 + tco.monthlyLoanPaymentCents * 48,
+    );
+    expect(tco.totalCostOfOwnershipCents).toBe(
+      tco.totalFinancingCashOutCents +
+        tco.totalInsuranceCents +
+        tco.totalMaintenanceCents +
+        tco.totalFuelCents -
+        tco.estimatedResaleValueCents,
+    );
+  });
+
+  it('only counts loan interest for the financed portion when ownership is shorter than the loan', () => {
+    const tco = calculateTco(baseInput({ loanTermMonths: 60, ownershipYears: 3 }));
+    expect(tco.ownershipMonths).toBe(36);
+    // Only 36 of the 60 scheduled payments happen inside the 3-year ownership window.
+    expect(tco.totalFinancingCashOutCents).toBe(
+      600_000 + tco.monthlyLoanPaymentCents * 36,
+    );
+  });
+
+  it('treats a 0-mile/0-mpg edge case as 0 fuel cost, not NaN or a divide-by-zero', () => {
+    const tco = calculateTco(baseInput({ annualMileage: 0, mpg: 0 }));
+    expect(tco.monthlyFuelCents).toBe(0);
+    expect(Number.isFinite(tco.totalCostOfOwnershipCents)).toBe(true);
+  });
+
+  it('handles an all-cash purchase (no loan) with 0 financing interest', () => {
+    const tco = calculateTco(baseInput({ downPaymentCents: 3_000_000, loanTermMonths: 48 }));
+    expect(tco.loanPrincipalCents).toBe(0);
+    expect(tco.monthlyLoanPaymentCents).toBe(0);
+    expect(tco.ownershipLoanInterestCents).toBe(0);
+  });
+});
+
+describe('compareBuyVsLease', () => {
+  const tcoTerms = {
+    priceCents: 3_000_000,
+    downPaymentCents: 600_000,
+    loanTermMonths: 48,
+    loanAprBps: 600,
+    estimatedResaleValueCents: 1_200_000,
+    ownershipYears: 4,
+  };
+
+  it('favors leasing when the lease is clearly cheaper', () => {
+    const result = compareBuyVsLease(tcoTerms, {
+      monthlyPaymentCents: 20_000, // $200/mo, well under the loan payment
+      dueAtSigningCents: 200_000,
+      termMonths: 36,
+    });
+    expect(result.cheaperOption).toBe('lease');
+    expect(result.costDifferenceCents).toBeLessThan(0);
+  });
+
+  it('favors buying when the lease due-at-signing and payments are steep', () => {
+    const result = compareBuyVsLease(tcoTerms, {
+      monthlyPaymentCents: 90_000, // $900/mo, far above the loan payment
+      dueAtSigningCents: 500_000,
+      termMonths: 36,
+    });
+    expect(result.cheaperOption).toBe('buy');
+    expect(result.costDifferenceCents).toBeGreaterThan(0);
+  });
+
+  it('prorates resale value linearly at the comparison horizon', () => {
+    const result = compareBuyVsLease(tcoTerms, {
+      monthlyPaymentCents: 0,
+      dueAtSigningCents: 0,
+      termMonths: 24, // half of the 48-month ownership window
+    });
+    // Depreciation over 4yr = $30,000 - $12,000 = $18,000; half that at 24mo = $9,000
+    // → resale credit at 24mo = $30,000 - $9,000 = $21,000.
+    const monthlyPayment = amortizedMonthlyPaymentCents(2_400_000, 600, 48);
+    expect(result.buyTotalCostCents).toBe(
+      600_000 + monthlyPayment * 24 - 2_100_000,
+    );
+  });
+});
+
+describe('calculateCarAffordability', () => {
+  it('assembles rule204010 + tco + buyVsLease from a single input', () => {
+    const result = calculateCarAffordability(
+      baseInput({
+        lease: { monthlyPaymentCents: 40_000, dueAtSigningCents: 300_000, termMonths: 36 },
+      }),
+    );
+    expect(result.rule204010).toBeDefined();
+    expect(result.tco).toBeDefined();
+    expect(result.buyVsLease).not.toBeNull();
+  });
+
+  it('omits buyVsLease when no lease terms are supplied', () => {
+    const result = calculateCarAffordability(baseInput());
+    expect(result.buyVsLease).toBeNull();
+  });
+
+  it('feeds the TCO monthly total (loan + insurance + maintenance + fuel) into the 20/4/10 income test', () => {
+    const input = baseInput();
+    const result = calculateCarAffordability(input);
+    const tco = calculateTco(input);
+    const expectedMonthlyTotal =
+      tco.monthlyLoanPaymentCents +
+      tco.monthlyInsuranceCents +
+      tco.monthlyMaintenanceCents +
+      tco.monthlyFuelCents;
+    const expected = evaluateRule204010({
+      priceCents: input.priceCents,
+      downPaymentCents: input.downPaymentCents,
+      loanTermMonths: input.loanTermMonths,
+      totalMonthlyVehicleCostCents: expectedMonthlyTotal,
+      grossMonthlyIncomeCents: input.grossMonthlyIncomeCents,
+    });
+    expect(result.rule204010).toEqual(expected);
+  });
+});

--- a/apps/api/src/car-affordability/car-affordability.service.ts
+++ b/apps/api/src/car-affordability/car-affordability.service.ts
@@ -1,0 +1,363 @@
+/**
+ * 40.2 — Car affordability engine. Pure, DB-free, LLM-free: given user-entered
+ * purchase/loan/insurance/maintenance/mileage figures plus the household's gross
+ * monthly income (resolved upstream the same way `BudgetPlanService` resolves it —
+ * most recent paycheck profile, smoothed to a monthly figure) and a current gas
+ * price (resolved upstream from `EiaClient`, the only externally-sourced input),
+ * computes:
+ *
+ *   1. The 20/4/10 rule pass/fail (down payment ≥20%, loan term ≤4yr, total
+ *      monthly vehicle cost ≤10% of gross monthly income).
+ *   2. A total-cost-of-ownership breakdown (financing + insurance + maintenance +
+ *      fuel − resale) over a user-chosen holding period.
+ *   3. A buy-vs-lease comparison over the lease term, when lease terms are given.
+ *
+ * All money fields are integer cents. Nothing here talks to the DB, an LLM, or an
+ * external API — every dollar figure is user-entered or passed in by the caller.
+ */
+
+export const CAR_AFFORDABILITY_CALCULATION_VERSION = 1;
+
+// ── Shared ─────────────────────────────────────────────────────────────
+
+export type CostFrequency = 'annual' | 'monthly';
+
+export interface RecurringCost {
+  amountCents: number; // non-negative
+  frequency: CostFrequency;
+}
+
+/** Normalize a user-entered annual-or-monthly cost to a monthly cents figure. */
+export function toMonthlyCents(cost: RecurringCost): number {
+  return cost.frequency === 'annual' ? Math.round(cost.amountCents / 12) : cost.amountCents;
+}
+
+/** Standard amortized loan payment (principal + interest), in cents. */
+export function amortizedMonthlyPaymentCents(
+  principalCents: number,
+  aprBps: number,
+  termMonths: number,
+): number {
+  if (principalCents <= 0 || termMonths <= 0) return 0;
+  const monthlyRate = aprBps / 10000 / 12;
+  if (monthlyRate === 0) return Math.round(principalCents / termMonths);
+  const factor = Math.pow(1 + monthlyRate, termMonths);
+  const payment = (principalCents * monthlyRate * factor) / (factor - 1);
+  return Math.round(payment);
+}
+
+/** Total interest paid over the full amortization schedule, in cents. */
+export function totalLoanInterestCents(
+  principalCents: number,
+  aprBps: number,
+  termMonths: number,
+): number {
+  const monthly = amortizedMonthlyPaymentCents(principalCents, aprBps, termMonths);
+  return Math.max(0, monthly * termMonths - principalCents);
+}
+
+// ── 1. The 20/4/10 rule ───────────────────────────────────────────────
+
+export interface Rule204010Input {
+  priceCents: number;
+  downPaymentCents: number;
+  loanTermMonths: number;
+  /** Total of the recurring monthly vehicle costs: loan payment + insurance +
+   *  maintenance + fuel (the same monthly figures used in the TCO breakdown). */
+  totalMonthlyVehicleCostCents: number;
+  grossMonthlyIncomeCents: number;
+}
+
+export interface Rule204010Result {
+  downPaymentPassed: boolean;
+  downPaymentPercent: number; // 0..1 (or >1 if overpaying down)
+  downPaymentRequiredCents: number;
+  loanTermPassed: boolean;
+  loanTermMonths: number;
+  maxLoanTermMonths: number;
+  monthlyCostPassed: boolean;
+  monthlyCostPercent: number | null; // null when income is unknown (<=0)
+  maxMonthlyCostCents: number | null;
+  passed: boolean;
+}
+
+const RULE_204010_DOWN_PAYMENT_MIN = 0.2;
+const RULE_204010_MAX_LOAN_TERM_MONTHS = 48;
+const RULE_204010_MAX_MONTHLY_COST_SHARE = 0.1;
+
+export function evaluateRule204010(input: Rule204010Input): Rule204010Result {
+  const downPaymentPercent =
+    input.priceCents > 0 ? input.downPaymentCents / input.priceCents : 0;
+  const downPaymentPassed = downPaymentPercent >= RULE_204010_DOWN_PAYMENT_MIN;
+  const downPaymentRequiredCents = Math.round(input.priceCents * RULE_204010_DOWN_PAYMENT_MIN);
+
+  const loanTermPassed = input.loanTermMonths <= RULE_204010_MAX_LOAN_TERM_MONTHS;
+
+  const hasIncome = input.grossMonthlyIncomeCents > 0;
+  const maxMonthlyCostCents = hasIncome
+    ? Math.round(input.grossMonthlyIncomeCents * RULE_204010_MAX_MONTHLY_COST_SHARE)
+    : null;
+  const monthlyCostPercent = hasIncome
+    ? input.totalMonthlyVehicleCostCents / input.grossMonthlyIncomeCents
+    : null;
+  // Without a known income we cannot claim the rule passed — fail closed.
+  const monthlyCostPassed =
+    hasIncome && input.totalMonthlyVehicleCostCents <= (maxMonthlyCostCents as number);
+
+  return {
+    downPaymentPassed,
+    downPaymentPercent,
+    downPaymentRequiredCents,
+    loanTermPassed,
+    loanTermMonths: input.loanTermMonths,
+    maxLoanTermMonths: RULE_204010_MAX_LOAN_TERM_MONTHS,
+    monthlyCostPassed,
+    monthlyCostPercent,
+    maxMonthlyCostCents,
+    passed: downPaymentPassed && loanTermPassed && monthlyCostPassed,
+  };
+}
+
+// ── 2. Total cost of ownership ────────────────────────────────────────
+
+export interface TcoInput {
+  priceCents: number;
+  downPaymentCents: number;
+  loanTermMonths: number;
+  loanAprBps: number;
+  insurance: RecurringCost;
+  maintenance: RecurringCost;
+  /** Expected miles driven per year. */
+  annualMileage: number;
+  /** Expected miles per gallon. */
+  mpg: number;
+  /** Current gas price, dollars per gallon, in cents (e.g. $3.50/gal → 350). */
+  gasPriceCentsPerGallon: number;
+  /** Holding period this TCO figure covers, in whole years. */
+  ownershipYears: number;
+  /** Estimated resale/trade-in value at the end of the ownership period. */
+  estimatedResaleValueCents: number;
+}
+
+export interface TcoBreakdown {
+  loanPrincipalCents: number;
+  monthlyLoanPaymentCents: number;
+  /** Loan interest actually incurred during the ownership window (not necessarily
+   *  the full loan term, if the holding period is shorter than the loan). */
+  ownershipLoanInterestCents: number;
+  monthlyInsuranceCents: number;
+  monthlyMaintenanceCents: number;
+  monthlyFuelCents: number;
+  totalInsuranceCents: number;
+  totalMaintenanceCents: number;
+  totalFuelCents: number;
+  /** downPayment + all loan payments made during the ownership window. */
+  totalFinancingCashOutCents: number;
+  estimatedResaleValueCents: number;
+  /** downPayment + financing + insurance + maintenance + fuel − resale, over the
+   *  ownership window. */
+  totalCostOfOwnershipCents: number;
+  ownershipMonths: number;
+}
+
+export function calculateTco(input: TcoInput): TcoBreakdown {
+  const principalCents = Math.max(0, input.priceCents - input.downPaymentCents);
+  const monthlyLoanPaymentCents = amortizedMonthlyPaymentCents(
+    principalCents,
+    input.loanAprBps,
+    input.loanTermMonths,
+  );
+  const ownershipMonths = Math.max(0, Math.round(input.ownershipYears * 12));
+  const monthsFinanced = Math.min(ownershipMonths, input.loanTermMonths);
+
+  // Interest actually paid during the financed portion of the ownership window,
+  // computed from the amortization schedule (not a flat-rate approximation).
+  let balance = principalCents;
+  let ownershipLoanInterestCents = 0;
+  const monthlyRate = input.loanAprBps / 10000 / 12;
+  for (let m = 0; m < monthsFinanced && balance > 0; m++) {
+    const interest = Math.round(balance * monthlyRate);
+    let principal = monthlyLoanPaymentCents - interest;
+    if (principal <= 0) principal = 0;
+    principal = Math.min(principal, balance);
+    balance -= principal;
+    ownershipLoanInterestCents += interest;
+  }
+
+  const monthlyInsuranceCents = toMonthlyCents(input.insurance);
+  const monthlyMaintenanceCents = toMonthlyCents(input.maintenance);
+  const gallonsPerYear = input.mpg > 0 ? input.annualMileage / input.mpg : 0;
+  const annualFuelCents = Math.round(gallonsPerYear * input.gasPriceCentsPerGallon);
+  const monthlyFuelCents = Math.round(annualFuelCents / 12);
+
+  const totalInsuranceCents = monthlyInsuranceCents * ownershipMonths;
+  const totalMaintenanceCents = monthlyMaintenanceCents * ownershipMonths;
+  const totalFuelCents = monthlyFuelCents * ownershipMonths;
+  const totalFinancingCashOutCents =
+    input.downPaymentCents + monthlyLoanPaymentCents * monthsFinanced;
+
+  const totalCostOfOwnershipCents =
+    totalFinancingCashOutCents +
+    totalInsuranceCents +
+    totalMaintenanceCents +
+    totalFuelCents -
+    input.estimatedResaleValueCents;
+
+  return {
+    loanPrincipalCents: principalCents,
+    monthlyLoanPaymentCents,
+    ownershipLoanInterestCents,
+    monthlyInsuranceCents,
+    monthlyMaintenanceCents,
+    monthlyFuelCents,
+    totalInsuranceCents,
+    totalMaintenanceCents,
+    totalFuelCents,
+    totalFinancingCashOutCents,
+    estimatedResaleValueCents: input.estimatedResaleValueCents,
+    totalCostOfOwnershipCents,
+    ownershipMonths,
+  };
+}
+
+// ── 3. Buy vs lease ────────────────────────────────────────────────────
+
+export interface LeaseInput {
+  monthlyPaymentCents: number;
+  /** Due-at-signing cash: first month, acquisition fee, cap-cost reduction, etc. */
+  dueAtSigningCents: number;
+  termMonths: number;
+}
+
+export interface BuyVsLeaseResult {
+  comparisonMonths: number;
+  buyTotalCostCents: number;
+  leaseTotalCostCents: number;
+  /** Positive when buying is cheaper, negative when leasing is cheaper. */
+  costDifferenceCents: number;
+  cheaperOption: 'buy' | 'lease' | 'tie';
+}
+
+/** Linearly prorate resale value at `atMonth` between full price (month 0) and the
+ *  estimated resale value at the end of `ownershipMonths`. */
+function proratedResaleValueCents(
+  priceCents: number,
+  estimatedResaleValueCents: number,
+  ownershipMonths: number,
+  atMonth: number,
+): number {
+  if (ownershipMonths <= 0) return priceCents;
+  const depreciation = priceCents - estimatedResaleValueCents;
+  const fraction = Math.min(1, Math.max(0, atMonth / ownershipMonths));
+  return Math.round(priceCents - depreciation * fraction);
+}
+
+/**
+ * Compares buying (via `tco`'s financing terms) against leasing over the lease
+ * term. Insurance/maintenance/fuel are assumed equal for both options (the same
+ * vehicle, the same driving) and are intentionally excluded from the comparison so
+ * it isolates the financing + resale difference between the two paths.
+ */
+export function compareBuyVsLease(
+  tcoInput: Pick<
+    TcoInput,
+    'priceCents' | 'downPaymentCents' | 'loanTermMonths' | 'loanAprBps' | 'estimatedResaleValueCents' | 'ownershipYears'
+  >,
+  lease: LeaseInput,
+): BuyVsLeaseResult {
+  const comparisonMonths = Math.max(0, lease.termMonths);
+  const principalCents = Math.max(0, tcoInput.priceCents - tcoInput.downPaymentCents);
+  const monthlyLoanPaymentCents = amortizedMonthlyPaymentCents(
+    principalCents,
+    tcoInput.loanAprBps,
+    tcoInput.loanTermMonths,
+  );
+  const monthsFinanced = Math.min(comparisonMonths, tcoInput.loanTermMonths);
+  const ownershipMonths = Math.max(0, Math.round(tcoInput.ownershipYears * 12));
+  const resaleAtComparisonEnd = proratedResaleValueCents(
+    tcoInput.priceCents,
+    tcoInput.estimatedResaleValueCents,
+    ownershipMonths,
+    comparisonMonths,
+  );
+
+  const buyTotalCostCents =
+    tcoInput.downPaymentCents +
+    monthlyLoanPaymentCents * monthsFinanced -
+    resaleAtComparisonEnd;
+
+  const leaseTotalCostCents =
+    lease.dueAtSigningCents + lease.monthlyPaymentCents * comparisonMonths;
+
+  const costDifferenceCents = leaseTotalCostCents - buyTotalCostCents;
+  const cheaperOption: BuyVsLeaseResult['cheaperOption'] =
+    costDifferenceCents > 0 ? 'buy' : costDifferenceCents < 0 ? 'lease' : 'tie';
+
+  return {
+    comparisonMonths,
+    buyTotalCostCents,
+    leaseTotalCostCents,
+    costDifferenceCents,
+    cheaperOption,
+  };
+}
+
+// ── Aggregate ──────────────────────────────────────────────────────────
+
+export interface CarAffordabilityInput {
+  priceCents: number;
+  downPaymentCents: number;
+  loanTermMonths: number;
+  loanAprBps: number;
+  grossMonthlyIncomeCents: number;
+  insurance: RecurringCost;
+  maintenance: RecurringCost;
+  annualMileage: number;
+  mpg: number;
+  gasPriceCentsPerGallon: number;
+  ownershipYears: number;
+  estimatedResaleValueCents: number;
+  lease?: LeaseInput;
+}
+
+export interface CarAffordabilityResult {
+  version: number;
+  rule204010: Rule204010Result;
+  tco: TcoBreakdown;
+  buyVsLease: BuyVsLeaseResult | null;
+}
+
+export function calculateCarAffordability(
+  input: CarAffordabilityInput,
+): CarAffordabilityResult {
+  const tco = calculateTco(input);
+  const totalMonthlyVehicleCostCents =
+    tco.monthlyLoanPaymentCents +
+    tco.monthlyInsuranceCents +
+    tco.monthlyMaintenanceCents +
+    tco.monthlyFuelCents;
+
+  const rule204010 = evaluateRule204010({
+    priceCents: input.priceCents,
+    downPaymentCents: input.downPaymentCents,
+    loanTermMonths: input.loanTermMonths,
+    totalMonthlyVehicleCostCents,
+    grossMonthlyIncomeCents: input.grossMonthlyIncomeCents,
+  });
+
+  const buyVsLease = input.lease
+    ? compareBuyVsLease(
+        {
+          priceCents: input.priceCents,
+          downPaymentCents: input.downPaymentCents,
+          loanTermMonths: input.loanTermMonths,
+          loanAprBps: input.loanAprBps,
+          estimatedResaleValueCents: input.estimatedResaleValueCents,
+          ownershipYears: input.ownershipYears,
+        },
+        input.lease,
+      )
+    : null;
+
+  return { version: CAR_AFFORDABILITY_CALCULATION_VERSION, rule204010, tco, buyVsLease };
+}

--- a/apps/api/src/car-affordability/car-affordability.service.ts
+++ b/apps/api/src/car-affordability/car-affordability.service.ts
@@ -56,6 +56,28 @@ export function totalLoanInterestCents(
   return Math.max(0, monthly * termMonths - principalCents);
 }
 
+/**
+ * Remaining principal balance after `monthsElapsed` payments on a standard
+ * amortizing loan, in cents. Zero once the loan term has fully elapsed.
+ */
+export function remainingLoanBalanceCents(
+  principalCents: number,
+  aprBps: number,
+  termMonths: number,
+  monthsElapsed: number,
+): number {
+  if (principalCents <= 0 || termMonths <= 0) return 0;
+  const n = Math.max(0, Math.min(monthsElapsed, termMonths));
+  if (n === 0) return principalCents;
+  if (n >= termMonths) return 0;
+  const monthlyRate = aprBps / 10000 / 12;
+  const payment = amortizedMonthlyPaymentCents(principalCents, aprBps, termMonths);
+  if (monthlyRate === 0) return Math.max(0, principalCents - payment * n);
+  const balance = principalCents * Math.pow(1 + monthlyRate, n) -
+    (payment * (Math.pow(1 + monthlyRate, n) - 1)) / monthlyRate;
+  return Math.max(0, Math.round(balance));
+}
+
 // ── 1. The 20/4/10 rule ───────────────────────────────────────────────
 
 export interface Rule204010Input {
@@ -280,11 +302,26 @@ export function compareBuyVsLease(
     ownershipMonths,
     comparisonMonths,
   );
+  // If the comparison term ends before the loan is paid off, the buyer's actual
+  // equity is resale value MINUS what's still owed — crediting the full resale
+  // value here would understate buy's true cost whenever a shorter lease term is
+  // compared against a longer loan (a common real scenario, e.g. a 3yr lease vs.
+  // a 5yr loan).
+  const remainingBalanceAtComparisonEnd = remainingLoanBalanceCents(
+    principalCents,
+    tcoInput.loanAprBps,
+    tcoInput.loanTermMonths,
+    comparisonMonths,
+  );
+  const buyEquityAtComparisonEnd = Math.max(
+    0,
+    resaleAtComparisonEnd - remainingBalanceAtComparisonEnd,
+  );
 
   const buyTotalCostCents =
     tcoInput.downPaymentCents +
     monthlyLoanPaymentCents * monthsFinanced -
-    resaleAtComparisonEnd;
+    buyEquityAtComparisonEnd;
 
   const leaseTotalCostCents =
     lease.dueAtSigningCents + lease.monthlyPaymentCents * comparisonMonths;

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -34,6 +34,7 @@ import { registerGetMonthlyClose } from './tools/get-monthly-close.js';
 import { registerGetFinancialHealth } from './tools/get-financial-health.js';
 import { registerGetSafeToSpend } from './tools/get-safe-to-spend.js';
 import { registerGetCollegePlan } from './tools/get-college-plan.js';
+import { registerGetCarAffordability } from './tools/get-car-affordability.js';
 import { close } from './db.js';
 import http from 'node:http';
 
@@ -75,6 +76,7 @@ registerGetMonthlyClose(server);
 registerGetFinancialHealth(server);
 registerGetSafeToSpend(server);
 registerGetCollegePlan(server);
+registerGetCarAffordability(server);
 
 const mode = process.argv.includes('--sse') ? 'sse' : 'stdio';
 

--- a/apps/mcp-server/src/lib/car-affordability.ts
+++ b/apps/mcp-server/src/lib/car-affordability.ts
@@ -61,6 +61,28 @@ export function totalLoanInterestCents(
   return Math.max(0, monthly * termMonths - principalCents);
 }
 
+/**
+ * Remaining principal balance after `monthsElapsed` payments on a standard
+ * amortizing loan, in cents. Zero once the loan term has fully elapsed.
+ */
+export function remainingLoanBalanceCents(
+  principalCents: number,
+  aprBps: number,
+  termMonths: number,
+  monthsElapsed: number,
+): number {
+  if (principalCents <= 0 || termMonths <= 0) return 0;
+  const n = Math.max(0, Math.min(monthsElapsed, termMonths));
+  if (n === 0) return principalCents;
+  if (n >= termMonths) return 0;
+  const monthlyRate = aprBps / 10000 / 12;
+  const payment = amortizedMonthlyPaymentCents(principalCents, aprBps, termMonths);
+  if (monthlyRate === 0) return Math.max(0, principalCents - payment * n);
+  const balance = principalCents * Math.pow(1 + monthlyRate, n) -
+    (payment * (Math.pow(1 + monthlyRate, n) - 1)) / monthlyRate;
+  return Math.max(0, Math.round(balance));
+}
+
 // ── 1. The 20/4/10 rule ───────────────────────────────────────────────
 
 export interface Rule204010Input {
@@ -285,11 +307,26 @@ export function compareBuyVsLease(
     ownershipMonths,
     comparisonMonths,
   );
+  // If the comparison term ends before the loan is paid off, the buyer's actual
+  // equity is resale value MINUS what's still owed — crediting the full resale
+  // value here would understate buy's true cost whenever a shorter lease term is
+  // compared against a longer loan (a common real scenario, e.g. a 3yr lease vs.
+  // a 5yr loan).
+  const remainingBalanceAtComparisonEnd = remainingLoanBalanceCents(
+    principalCents,
+    tcoInput.loanAprBps,
+    tcoInput.loanTermMonths,
+    comparisonMonths,
+  );
+  const buyEquityAtComparisonEnd = Math.max(
+    0,
+    resaleAtComparisonEnd - remainingBalanceAtComparisonEnd,
+  );
 
   const buyTotalCostCents =
     tcoInput.downPaymentCents +
     monthlyLoanPaymentCents * monthsFinanced -
-    resaleAtComparisonEnd;
+    buyEquityAtComparisonEnd;
 
   const leaseTotalCostCents =
     lease.dueAtSigningCents + lease.monthlyPaymentCents * comparisonMonths;

--- a/apps/mcp-server/src/lib/car-affordability.ts
+++ b/apps/mcp-server/src/lib/car-affordability.ts
@@ -1,0 +1,368 @@
+/**
+ * 40.2 — Car affordability engine. Mirrored verbatim from
+ * `apps/api/src/car-affordability/car-affordability.service.ts` (the mcp-server
+ * package has no dependency on the api app, same as `amortization.ts`'s relationship
+ * to the loans module) — keep the two in sync if the math changes.
+ *
+ * Pure, DB-free, LLM-free: given user-entered
+ * purchase/loan/insurance/maintenance/mileage figures plus the household's gross
+ * monthly income (resolved upstream the same way `BudgetPlanService` resolves it —
+ * most recent paycheck profile, smoothed to a monthly figure) and a current gas
+ * price (resolved upstream from `EiaClient`, the only externally-sourced input),
+ * computes:
+ *
+ *   1. The 20/4/10 rule pass/fail (down payment ≥20%, loan term ≤4yr, total
+ *      monthly vehicle cost ≤10% of gross monthly income).
+ *   2. A total-cost-of-ownership breakdown (financing + insurance + maintenance +
+ *      fuel − resale) over a user-chosen holding period.
+ *   3. A buy-vs-lease comparison over the lease term, when lease terms are given.
+ *
+ * All money fields are integer cents. Nothing here talks to the DB, an LLM, or an
+ * external API — every dollar figure is user-entered or passed in by the caller.
+ */
+
+export const CAR_AFFORDABILITY_CALCULATION_VERSION = 1;
+
+// ── Shared ─────────────────────────────────────────────────────────────
+
+export type CostFrequency = 'annual' | 'monthly';
+
+export interface RecurringCost {
+  amountCents: number; // non-negative
+  frequency: CostFrequency;
+}
+
+/** Normalize a user-entered annual-or-monthly cost to a monthly cents figure. */
+export function toMonthlyCents(cost: RecurringCost): number {
+  return cost.frequency === 'annual' ? Math.round(cost.amountCents / 12) : cost.amountCents;
+}
+
+/** Standard amortized loan payment (principal + interest), in cents. */
+export function amortizedMonthlyPaymentCents(
+  principalCents: number,
+  aprBps: number,
+  termMonths: number,
+): number {
+  if (principalCents <= 0 || termMonths <= 0) return 0;
+  const monthlyRate = aprBps / 10000 / 12;
+  if (monthlyRate === 0) return Math.round(principalCents / termMonths);
+  const factor = Math.pow(1 + monthlyRate, termMonths);
+  const payment = (principalCents * monthlyRate * factor) / (factor - 1);
+  return Math.round(payment);
+}
+
+/** Total interest paid over the full amortization schedule, in cents. */
+export function totalLoanInterestCents(
+  principalCents: number,
+  aprBps: number,
+  termMonths: number,
+): number {
+  const monthly = amortizedMonthlyPaymentCents(principalCents, aprBps, termMonths);
+  return Math.max(0, monthly * termMonths - principalCents);
+}
+
+// ── 1. The 20/4/10 rule ───────────────────────────────────────────────
+
+export interface Rule204010Input {
+  priceCents: number;
+  downPaymentCents: number;
+  loanTermMonths: number;
+  /** Total of the recurring monthly vehicle costs: loan payment + insurance +
+   *  maintenance + fuel (the same monthly figures used in the TCO breakdown). */
+  totalMonthlyVehicleCostCents: number;
+  grossMonthlyIncomeCents: number;
+}
+
+export interface Rule204010Result {
+  downPaymentPassed: boolean;
+  downPaymentPercent: number; // 0..1 (or >1 if overpaying down)
+  downPaymentRequiredCents: number;
+  loanTermPassed: boolean;
+  loanTermMonths: number;
+  maxLoanTermMonths: number;
+  monthlyCostPassed: boolean;
+  monthlyCostPercent: number | null; // null when income is unknown (<=0)
+  maxMonthlyCostCents: number | null;
+  passed: boolean;
+}
+
+const RULE_204010_DOWN_PAYMENT_MIN = 0.2;
+const RULE_204010_MAX_LOAN_TERM_MONTHS = 48;
+const RULE_204010_MAX_MONTHLY_COST_SHARE = 0.1;
+
+export function evaluateRule204010(input: Rule204010Input): Rule204010Result {
+  const downPaymentPercent =
+    input.priceCents > 0 ? input.downPaymentCents / input.priceCents : 0;
+  const downPaymentPassed = downPaymentPercent >= RULE_204010_DOWN_PAYMENT_MIN;
+  const downPaymentRequiredCents = Math.round(input.priceCents * RULE_204010_DOWN_PAYMENT_MIN);
+
+  const loanTermPassed = input.loanTermMonths <= RULE_204010_MAX_LOAN_TERM_MONTHS;
+
+  const hasIncome = input.grossMonthlyIncomeCents > 0;
+  const maxMonthlyCostCents = hasIncome
+    ? Math.round(input.grossMonthlyIncomeCents * RULE_204010_MAX_MONTHLY_COST_SHARE)
+    : null;
+  const monthlyCostPercent = hasIncome
+    ? input.totalMonthlyVehicleCostCents / input.grossMonthlyIncomeCents
+    : null;
+  // Without a known income we cannot claim the rule passed — fail closed.
+  const monthlyCostPassed =
+    hasIncome && input.totalMonthlyVehicleCostCents <= (maxMonthlyCostCents as number);
+
+  return {
+    downPaymentPassed,
+    downPaymentPercent,
+    downPaymentRequiredCents,
+    loanTermPassed,
+    loanTermMonths: input.loanTermMonths,
+    maxLoanTermMonths: RULE_204010_MAX_LOAN_TERM_MONTHS,
+    monthlyCostPassed,
+    monthlyCostPercent,
+    maxMonthlyCostCents,
+    passed: downPaymentPassed && loanTermPassed && monthlyCostPassed,
+  };
+}
+
+// ── 2. Total cost of ownership ────────────────────────────────────────
+
+export interface TcoInput {
+  priceCents: number;
+  downPaymentCents: number;
+  loanTermMonths: number;
+  loanAprBps: number;
+  insurance: RecurringCost;
+  maintenance: RecurringCost;
+  /** Expected miles driven per year. */
+  annualMileage: number;
+  /** Expected miles per gallon. */
+  mpg: number;
+  /** Current gas price, dollars per gallon, in cents (e.g. $3.50/gal → 350). */
+  gasPriceCentsPerGallon: number;
+  /** Holding period this TCO figure covers, in whole years. */
+  ownershipYears: number;
+  /** Estimated resale/trade-in value at the end of the ownership period. */
+  estimatedResaleValueCents: number;
+}
+
+export interface TcoBreakdown {
+  loanPrincipalCents: number;
+  monthlyLoanPaymentCents: number;
+  /** Loan interest actually incurred during the ownership window (not necessarily
+   *  the full loan term, if the holding period is shorter than the loan). */
+  ownershipLoanInterestCents: number;
+  monthlyInsuranceCents: number;
+  monthlyMaintenanceCents: number;
+  monthlyFuelCents: number;
+  totalInsuranceCents: number;
+  totalMaintenanceCents: number;
+  totalFuelCents: number;
+  /** downPayment + all loan payments made during the ownership window. */
+  totalFinancingCashOutCents: number;
+  estimatedResaleValueCents: number;
+  /** downPayment + financing + insurance + maintenance + fuel − resale, over the
+   *  ownership window. */
+  totalCostOfOwnershipCents: number;
+  ownershipMonths: number;
+}
+
+export function calculateTco(input: TcoInput): TcoBreakdown {
+  const principalCents = Math.max(0, input.priceCents - input.downPaymentCents);
+  const monthlyLoanPaymentCents = amortizedMonthlyPaymentCents(
+    principalCents,
+    input.loanAprBps,
+    input.loanTermMonths,
+  );
+  const ownershipMonths = Math.max(0, Math.round(input.ownershipYears * 12));
+  const monthsFinanced = Math.min(ownershipMonths, input.loanTermMonths);
+
+  // Interest actually paid during the financed portion of the ownership window,
+  // computed from the amortization schedule (not a flat-rate approximation).
+  let balance = principalCents;
+  let ownershipLoanInterestCents = 0;
+  const monthlyRate = input.loanAprBps / 10000 / 12;
+  for (let m = 0; m < monthsFinanced && balance > 0; m++) {
+    const interest = Math.round(balance * monthlyRate);
+    let principal = monthlyLoanPaymentCents - interest;
+    if (principal <= 0) principal = 0;
+    principal = Math.min(principal, balance);
+    balance -= principal;
+    ownershipLoanInterestCents += interest;
+  }
+
+  const monthlyInsuranceCents = toMonthlyCents(input.insurance);
+  const monthlyMaintenanceCents = toMonthlyCents(input.maintenance);
+  const gallonsPerYear = input.mpg > 0 ? input.annualMileage / input.mpg : 0;
+  const annualFuelCents = Math.round(gallonsPerYear * input.gasPriceCentsPerGallon);
+  const monthlyFuelCents = Math.round(annualFuelCents / 12);
+
+  const totalInsuranceCents = monthlyInsuranceCents * ownershipMonths;
+  const totalMaintenanceCents = monthlyMaintenanceCents * ownershipMonths;
+  const totalFuelCents = monthlyFuelCents * ownershipMonths;
+  const totalFinancingCashOutCents =
+    input.downPaymentCents + monthlyLoanPaymentCents * monthsFinanced;
+
+  const totalCostOfOwnershipCents =
+    totalFinancingCashOutCents +
+    totalInsuranceCents +
+    totalMaintenanceCents +
+    totalFuelCents -
+    input.estimatedResaleValueCents;
+
+  return {
+    loanPrincipalCents: principalCents,
+    monthlyLoanPaymentCents,
+    ownershipLoanInterestCents,
+    monthlyInsuranceCents,
+    monthlyMaintenanceCents,
+    monthlyFuelCents,
+    totalInsuranceCents,
+    totalMaintenanceCents,
+    totalFuelCents,
+    totalFinancingCashOutCents,
+    estimatedResaleValueCents: input.estimatedResaleValueCents,
+    totalCostOfOwnershipCents,
+    ownershipMonths,
+  };
+}
+
+// ── 3. Buy vs lease ────────────────────────────────────────────────────
+
+export interface LeaseInput {
+  monthlyPaymentCents: number;
+  /** Due-at-signing cash: first month, acquisition fee, cap-cost reduction, etc. */
+  dueAtSigningCents: number;
+  termMonths: number;
+}
+
+export interface BuyVsLeaseResult {
+  comparisonMonths: number;
+  buyTotalCostCents: number;
+  leaseTotalCostCents: number;
+  /** Positive when buying is cheaper, negative when leasing is cheaper. */
+  costDifferenceCents: number;
+  cheaperOption: 'buy' | 'lease' | 'tie';
+}
+
+/** Linearly prorate resale value at `atMonth` between full price (month 0) and the
+ *  estimated resale value at the end of `ownershipMonths`. */
+function proratedResaleValueCents(
+  priceCents: number,
+  estimatedResaleValueCents: number,
+  ownershipMonths: number,
+  atMonth: number,
+): number {
+  if (ownershipMonths <= 0) return priceCents;
+  const depreciation = priceCents - estimatedResaleValueCents;
+  const fraction = Math.min(1, Math.max(0, atMonth / ownershipMonths));
+  return Math.round(priceCents - depreciation * fraction);
+}
+
+/**
+ * Compares buying (via `tco`'s financing terms) against leasing over the lease
+ * term. Insurance/maintenance/fuel are assumed equal for both options (the same
+ * vehicle, the same driving) and are intentionally excluded from the comparison so
+ * it isolates the financing + resale difference between the two paths.
+ */
+export function compareBuyVsLease(
+  tcoInput: Pick<
+    TcoInput,
+    'priceCents' | 'downPaymentCents' | 'loanTermMonths' | 'loanAprBps' | 'estimatedResaleValueCents' | 'ownershipYears'
+  >,
+  lease: LeaseInput,
+): BuyVsLeaseResult {
+  const comparisonMonths = Math.max(0, lease.termMonths);
+  const principalCents = Math.max(0, tcoInput.priceCents - tcoInput.downPaymentCents);
+  const monthlyLoanPaymentCents = amortizedMonthlyPaymentCents(
+    principalCents,
+    tcoInput.loanAprBps,
+    tcoInput.loanTermMonths,
+  );
+  const monthsFinanced = Math.min(comparisonMonths, tcoInput.loanTermMonths);
+  const ownershipMonths = Math.max(0, Math.round(tcoInput.ownershipYears * 12));
+  const resaleAtComparisonEnd = proratedResaleValueCents(
+    tcoInput.priceCents,
+    tcoInput.estimatedResaleValueCents,
+    ownershipMonths,
+    comparisonMonths,
+  );
+
+  const buyTotalCostCents =
+    tcoInput.downPaymentCents +
+    monthlyLoanPaymentCents * monthsFinanced -
+    resaleAtComparisonEnd;
+
+  const leaseTotalCostCents =
+    lease.dueAtSigningCents + lease.monthlyPaymentCents * comparisonMonths;
+
+  const costDifferenceCents = leaseTotalCostCents - buyTotalCostCents;
+  const cheaperOption: BuyVsLeaseResult['cheaperOption'] =
+    costDifferenceCents > 0 ? 'buy' : costDifferenceCents < 0 ? 'lease' : 'tie';
+
+  return {
+    comparisonMonths,
+    buyTotalCostCents,
+    leaseTotalCostCents,
+    costDifferenceCents,
+    cheaperOption,
+  };
+}
+
+// ── Aggregate ──────────────────────────────────────────────────────────
+
+export interface CarAffordabilityInput {
+  priceCents: number;
+  downPaymentCents: number;
+  loanTermMonths: number;
+  loanAprBps: number;
+  grossMonthlyIncomeCents: number;
+  insurance: RecurringCost;
+  maintenance: RecurringCost;
+  annualMileage: number;
+  mpg: number;
+  gasPriceCentsPerGallon: number;
+  ownershipYears: number;
+  estimatedResaleValueCents: number;
+  lease?: LeaseInput;
+}
+
+export interface CarAffordabilityResult {
+  version: number;
+  rule204010: Rule204010Result;
+  tco: TcoBreakdown;
+  buyVsLease: BuyVsLeaseResult | null;
+}
+
+export function calculateCarAffordability(
+  input: CarAffordabilityInput,
+): CarAffordabilityResult {
+  const tco = calculateTco(input);
+  const totalMonthlyVehicleCostCents =
+    tco.monthlyLoanPaymentCents +
+    tco.monthlyInsuranceCents +
+    tco.monthlyMaintenanceCents +
+    tco.monthlyFuelCents;
+
+  const rule204010 = evaluateRule204010({
+    priceCents: input.priceCents,
+    downPaymentCents: input.downPaymentCents,
+    loanTermMonths: input.loanTermMonths,
+    totalMonthlyVehicleCostCents,
+    grossMonthlyIncomeCents: input.grossMonthlyIncomeCents,
+  });
+
+  const buyVsLease = input.lease
+    ? compareBuyVsLease(
+        {
+          priceCents: input.priceCents,
+          downPaymentCents: input.downPaymentCents,
+          loanTermMonths: input.loanTermMonths,
+          loanAprBps: input.loanAprBps,
+          estimatedResaleValueCents: input.estimatedResaleValueCents,
+          ownershipYears: input.ownershipYears,
+        },
+        input.lease,
+      )
+    : null;
+
+  return { version: CAR_AFFORDABILITY_CALCULATION_VERSION, rule204010, tco, buyVsLease };
+}

--- a/apps/mcp-server/src/tools/get-car-affordability.ts
+++ b/apps/mcp-server/src/tools/get-car-affordability.ts
@@ -101,10 +101,13 @@ export function registerGetCarAffordability(server: McpServer) {
         };
       }
 
-      const hasLease =
-        params.lease_monthly_payment_dollars != null &&
-        params.lease_due_at_signing_dollars != null &&
-        params.lease_term_months != null;
+      const leaseFieldsGiven = [
+        params.lease_monthly_payment_dollars,
+        params.lease_due_at_signing_dollars,
+        params.lease_term_months,
+      ].filter((v) => v != null).length;
+      const hasLease = leaseFieldsGiven === 3;
+      const partialLease = leaseFieldsGiven > 0 && leaseFieldsGiven < 3;
 
       const result = calculateCarAffordability({
         priceCents: toCents(params.price_dollars),
@@ -178,6 +181,11 @@ export function registerGetCarAffordability(server: McpServer) {
         lines.push(`  Lease total cash cost: ${dollars(buyVsLease.leaseTotalCostCents)}`);
         lines.push(
           `  ${buyVsLease.cheaperOption === 'tie' ? 'Buying and leasing cost the same' : `${buyVsLease.cheaperOption === 'buy' ? 'Buying' : 'Leasing'} is cheaper by ${dollars(Math.abs(buyVsLease.costDifferenceCents))}`}`,
+        );
+      } else if (partialLease) {
+        lines.push('');
+        lines.push(
+          'Buy vs. lease comparison skipped: lease_monthly_payment_dollars, lease_due_at_signing_dollars, and lease_term_months must all be provided together.',
         );
       }
 

--- a/apps/mcp-server/src/tools/get-car-affordability.ts
+++ b/apps/mcp-server/src/tools/get-car-affordability.ts
@@ -1,0 +1,187 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { query, getUserId } from '../db.js';
+import { calculateCarAffordability } from '../lib/car-affordability.js';
+
+const PAY_PERIODS_PER_YEAR: Record<string, number> = {
+  weekly: 52,
+  biweekly: 26,
+  semi_monthly: 24,
+  monthly: 12,
+};
+
+/** Resolve gross monthly income the same way `BudgetPlanService.budgetPlan` does:
+ *  most recent paycheck profile (as of today), gross pay smoothed to a monthly
+ *  figure via its pay frequency. Returns null (never 0) when no profile exists yet,
+ *  so the affordability rule can fail closed instead of falsely passing. */
+async function resolveGrossMonthlyIncomeCents(userId: string): Promise<number | null> {
+  const row = await query<{ gross_pay_cents: string; pay_frequency: string }>(
+    `SELECT gross_pay_cents, pay_frequency
+     FROM paycheck_profiles
+     WHERE user_id = $1 AND deleted_at IS NULL AND effective_date <= CURRENT_DATE
+     ORDER BY effective_date DESC
+     LIMIT 1`,
+    [userId],
+  );
+  if (row.length === 0) return null;
+  const periodsPerYear = PAY_PERIODS_PER_YEAR[row[0].pay_frequency] ?? 12;
+  return Math.round((Number(row[0].gross_pay_cents) * periodsPerYear) / 12);
+}
+
+/** Latest EIA regular-gasoline retail price, in cents/gallon. Null (never a fake
+ *  default) when the market-data refresh hasn't populated it yet — the caller must
+ *  supply `gas_price_dollars_per_gallon` explicitly in that case. */
+async function resolveGasPriceCentsPerGallon(): Promise<number | null> {
+  const row = await query<{ value: string }>(
+    `SELECT value::text AS value
+     FROM market_metrics
+     WHERE metric_key = 'gas_retail_regular'
+     ORDER BY period_date DESC
+     LIMIT 1`,
+  );
+  if (row.length === 0) return null;
+  return Math.round(Number(row[0].value) * 100);
+}
+
+export function registerGetCarAffordability(server: McpServer) {
+  server.tool(
+    'get_car_affordability',
+    'Evaluates whether a car purchase clears the 20/4/10 affordability rule (≥20% down, ≤4yr loan, total monthly vehicle cost ≤10% of gross monthly income), a full total-cost-of-ownership breakdown (financing + insurance + maintenance + fuel − resale), and an optional buy-vs-lease comparison. All price/insurance/maintenance/mileage/MPG figures are user-entered — this tool does not look up or guess a car\'s price. Gross income is pulled from the user\'s paycheck profile; gas price defaults to the latest tracked EIA price unless overridden.',
+    {
+      price_dollars: z.number().positive().describe('Purchase price of the vehicle, in dollars'),
+      down_payment_dollars: z.number().min(0).describe('Cash down payment, in dollars'),
+      loan_term_months: z.number().int().positive().describe('Loan term in months'),
+      loan_apr_percent: z
+        .number()
+        .min(0)
+        .describe('Loan APR as a percent (e.g. 6.5 for 6.5%) — no current auto-loan rate feed exists yet, so this must be user-entered'),
+      insurance_amount_dollars: z.number().min(0).describe('Estimated insurance cost, in dollars'),
+      insurance_frequency: z.enum(['annual', 'monthly']).default('annual'),
+      maintenance_amount_dollars: z.number().min(0).describe('Estimated maintenance cost, in dollars'),
+      maintenance_frequency: z.enum(['annual', 'monthly']).default('annual'),
+      annual_mileage: z.number().min(0).describe('Expected miles driven per year'),
+      mpg: z.number().min(0).describe('Expected miles per gallon'),
+      gas_price_dollars_per_gallon: z
+        .number()
+        .positive()
+        .optional()
+        .describe('Overrides the latest tracked EIA gas price ($/gal), if provided'),
+      ownership_years: z.number().positive().describe('Holding period to compute total cost of ownership over'),
+      estimated_resale_value_dollars: z
+        .number()
+        .min(0)
+        .describe('Estimated resale/trade-in value at the end of the ownership period, in dollars'),
+      lease_monthly_payment_dollars: z
+        .number()
+        .min(0)
+        .optional()
+        .describe('Lease monthly payment, in dollars — omit to skip the buy-vs-lease comparison'),
+      lease_due_at_signing_dollars: z.number().min(0).optional().describe('Lease due-at-signing cash, in dollars'),
+      lease_term_months: z.number().int().positive().optional().describe('Lease term in months'),
+    },
+    async (params) => {
+      const userId = await getUserId();
+      const dollars = (c: number) => `$${(c / 100).toFixed(2)}`;
+      const toCents = (d: number) => Math.round(d * 100);
+
+      const grossMonthlyIncomeCents = await resolveGrossMonthlyIncomeCents(userId);
+      const gasPriceCentsPerGallon =
+        params.gas_price_dollars_per_gallon != null
+          ? toCents(params.gas_price_dollars_per_gallon)
+          : await resolveGasPriceCentsPerGallon();
+
+      if (gasPriceCentsPerGallon === null) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: 'No gas price is available yet (EIA market data hasn\'t been fetched) — pass gas_price_dollars_per_gallon explicitly to run this calculation.',
+            },
+          ],
+        };
+      }
+
+      const hasLease =
+        params.lease_monthly_payment_dollars != null &&
+        params.lease_due_at_signing_dollars != null &&
+        params.lease_term_months != null;
+
+      const result = calculateCarAffordability({
+        priceCents: toCents(params.price_dollars),
+        downPaymentCents: toCents(params.down_payment_dollars),
+        loanTermMonths: params.loan_term_months,
+        loanAprBps: Math.round(params.loan_apr_percent * 100),
+        grossMonthlyIncomeCents: grossMonthlyIncomeCents ?? 0,
+        insurance: {
+          amountCents: toCents(params.insurance_amount_dollars),
+          frequency: params.insurance_frequency,
+        },
+        maintenance: {
+          amountCents: toCents(params.maintenance_amount_dollars),
+          frequency: params.maintenance_frequency,
+        },
+        annualMileage: params.annual_mileage,
+        mpg: params.mpg,
+        gasPriceCentsPerGallon,
+        ownershipYears: params.ownership_years,
+        estimatedResaleValueCents: toCents(params.estimated_resale_value_dollars),
+        lease: hasLease
+          ? {
+              monthlyPaymentCents: toCents(params.lease_monthly_payment_dollars!),
+              dueAtSigningCents: toCents(params.lease_due_at_signing_dollars!),
+              termMonths: params.lease_term_months!,
+            }
+          : undefined,
+      });
+
+      const { rule204010, tco, buyVsLease } = result;
+
+      const lines: string[] = [];
+
+      lines.push('20/4/10 rule:');
+      lines.push(
+        `  Down payment: ${dollars(toCents(params.down_payment_dollars))} of ${dollars(toCents(params.price_dollars))} = ${(rule204010.downPaymentPercent * 100).toFixed(1)}% (need ≥20%, i.e. ≥${dollars(rule204010.downPaymentRequiredCents)}) — ${rule204010.downPaymentPassed ? 'PASS' : 'FAIL'}`,
+      );
+      lines.push(
+        `  Loan term: ${rule204010.loanTermMonths} months (need ≤${rule204010.maxLoanTermMonths}) — ${rule204010.loanTermPassed ? 'PASS' : 'FAIL'}`,
+      );
+      if (grossMonthlyIncomeCents === null) {
+        lines.push(
+          '  Monthly vehicle cost vs. income: no paycheck profile on file — cannot verify the 10% test, treated as FAIL',
+        );
+      } else {
+        const totalMonthly =
+          tco.monthlyLoanPaymentCents +
+          tco.monthlyInsuranceCents +
+          tco.monthlyMaintenanceCents +
+          tco.monthlyFuelCents;
+        lines.push(
+          `  Monthly vehicle cost: ${dollars(totalMonthly)} (loan ${dollars(tco.monthlyLoanPaymentCents)} + insurance ${dollars(tco.monthlyInsuranceCents)} + maintenance ${dollars(tco.monthlyMaintenanceCents)} + fuel ${dollars(tco.monthlyFuelCents)}) = ${((rule204010.monthlyCostPercent ?? 0) * 100).toFixed(1)}% of ${dollars(grossMonthlyIncomeCents)} gross monthly income (need ≤10%, i.e. ≤${dollars(rule204010.maxMonthlyCostCents!)}) — ${rule204010.monthlyCostPassed ? 'PASS' : 'FAIL'}`,
+        );
+      }
+      lines.push(`  Overall: ${rule204010.passed ? 'PASSES the 20/4/10 rule' : 'FAILS the 20/4/10 rule'}`);
+
+      lines.push('');
+      lines.push(`Total cost of ownership over ${params.ownership_years} year(s):`);
+      lines.push(`  Financing cash out (down payment + loan payments): ${dollars(tco.totalFinancingCashOutCents)}`);
+      lines.push(`    of which loan interest: ${dollars(tco.ownershipLoanInterestCents)}`);
+      lines.push(`  Insurance: ${dollars(tco.totalInsuranceCents)}`);
+      lines.push(`  Maintenance: ${dollars(tco.totalMaintenanceCents)}`);
+      lines.push(`  Fuel: ${dollars(tco.totalFuelCents)} (at ${(gasPriceCentsPerGallon / 100).toFixed(2)}/gal)`);
+      lines.push(`  Less estimated resale value: -${dollars(tco.estimatedResaleValueCents)}`);
+      lines.push(`  Total cost of ownership: ${dollars(tco.totalCostOfOwnershipCents)}`);
+
+      if (buyVsLease) {
+        lines.push('');
+        lines.push(`Buy vs. lease over ${buyVsLease.comparisonMonths} months:`);
+        lines.push(`  Buy total cash cost (net of resale): ${dollars(buyVsLease.buyTotalCostCents)}`);
+        lines.push(`  Lease total cash cost: ${dollars(buyVsLease.leaseTotalCostCents)}`);
+        lines.push(
+          `  ${buyVsLease.cheaperOption === 'tie' ? 'Buying and leasing cost the same' : `${buyVsLease.cheaperOption === 'buy' ? 'Buying' : 'Leasing'} is cheaper by ${dollars(Math.abs(buyVsLease.costDifferenceCents))}`}`,
+        );
+      }
+
+      return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
+    },
+  );
+}


### PR DESCRIPTION
Committed successfully.

## Summary

Implemented issue #216 (40.2 — Car affordability engine):

- **`apps/api/src/car-affordability/car-affordability.service.ts`** — pure, DB-free calculator mirroring the #160/13.2 monthly-close-calculator pattern. Computes the 20/4/10 rule (≥20% down, ≤4yr loan, total monthly vehicle cost ≤10% of gross monthly income, fails closed when income is unknown), a total-cost-of-ownership breakdown (amortized loan financing + interest, insurance, maintenance, EIA-derived fuel cost, less resale value) over a user-chosen holding period, and an optional buy-vs-lease comparison over the lease term with linear resale-value proration. 22 fixture/edge-case tests (hand-worked amortization figure, 0-mile/0-mpg divide-by-zero guard, all-cash purchase, shorter-than-loan ownership window, lease-cheaper/buy-cheaper scenarios) — all passing.
- **`apps/mcp-server/src/lib/car-affordability.ts`** — mirrored copy of the calculator (mcp-server has no dependency on the api app, same pattern as the existing `amortization.ts`).
- **`apps/mcp-server/src/tools/get-car-affordability.ts`** — new `get_car_affordability` MCP tool. Resolves gross monthly income the same way `BudgetPlanService` does (latest paycheck profile, smoothed to monthly) and defaults the fuel-cost input to the latest stored EIA gas price, falling back to an explicit override or a clear "no data yet" message rather than guessing. All TCO inputs (price, insurance, maintenance, mileage, MPG, resale estimate) are user-entered params, per the epic's decision to reject scraped car prices. Returns a fully narrated breakdown with the underlying math shown, so the advisor never has to do arithmetic itself.
- Registered the new tool in `index.ts` and added it to the cloud advisor's `AGGREGATE_TOOL_ALLOWLIST` in `mcp-client.service.ts`, since its inputs/outputs are all user-entered or aggregate figures, no row-level data — updated the corresponding allowlist test fixture.

Verified via `vitest run` in bot

_(summary truncated)_

---
### Test evidence
**22 new test case(s) added** (heuristic count):
```
 .../advisor/__tests__/mcp-client.service.spec.ts   |   1 +
 .../__tests__/car-affordability.service.spec.ts    | 267 +++++++++++++++
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
@moneypulse/api:test:  [32m✓[39m src/advisor/__tests__/mcp-client.service.spec.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 4[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/analytics/__tests__/budget-plan.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 4[2mms[22m[39m
@moneypulse/api:test: [90mstdout[2m | src/embeddings/__tests__/embedding-categorizer.service.spec.ts[2m > [22m[2mEmbeddingCategorizerService.voteFromNeighbors (pure NN vote logic)[2m > [22m[2mNN accuracy report: predicts the correct category for a held-out slice
@moneypulse/api:test: [22m[39m[11.10 NN categorization accuracy] held-out=4 predicted=3 correct=3 precision=100%
@moneypulse/api:test: 
@moneypulse/api:test:  [32m✓[39m src/embeddings/__tests__/embedding-categorizer.service.spec.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/categorization/__tests__/learning.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m97 passed[39m[22m[90m (97)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m849 passed[39m[22m[90m (849)[39m
@moneypulse/api:test: [2m   Start at [22m 01:16:36
@moneypulse/api:test: [2m   Duration [22m 10.22s[2m (transform 3.05s, setup 0ms, import 53.42s, tests 2.09s, environment 12ms)[22m
@moneypulse/api:test: 

 Tasks:    3 successful, 3 total
Cached:    1 cached, 3 total
  Time:    10.706s
```
</details>

### Review
**Review verdict:** approve

Findings (advisory — did not block landing):
- [low/advisory] apps/mcp-server/src/lib/car-affordability.ts:301 — Buy-vs-lease credits the full prorated resale value to the buy side without subtracting the outstanding loan balance when the lease/comparison term is shorter than the loan term, biasing the comparison toward 'buy'. This is intentional per the docstring but understates true buy cost at the horizon.
- [low/advisory] apps/mcp-server/src/tools/get-car-affordability.ts:122 — hasLease requires all three lease fields; if the caller supplies e.g. monthly payment and term but omits due-at-signing, the buy-vs-lease comparison is silently skipped with no feedback, unlike the explicit gas-price-missing message.
- [low/advisory] apps/mcp-server/src/lib/car-affordability.ts:1 — The entire engine is duplicated verbatim between apps/api and apps/mcp-server with only a comment enforcing sync; any future math change must be applied in two places or the two copies will drift.

---
Dispatched via coxd (`MyMoney-40-2-car-affordability-engin-1785287406`) · cost $2.128 · 🤖 coxd