### PR TITLE
40.3 College/529 planner (tuition inflation + savings annuity + one-th

### DIFF
--- a/apps/api/src/college-planner/__tests__/college-planner.service.spec.ts
+++ b/apps/api/src/college-planner/__tests__/college-planner.service.spec.ts
@@ -1,0 +1,166 @@
+import {
+  CollegePlannerService,
+  COLLEGE_PLANNER_CALCULATION_VERSION,
+} from '../college-planner.service';
+
+describe('CollegePlannerService', () => {
+  const planner = new CollegePlannerService();
+
+  // ── Hand-computed full scenario ──────────────────────────────
+  // $30,000/year today's cost, student starts in 10 years, a 4-year program,
+  // $20,000 already saved, 5% tuition inflation, 6% return, and $500/month of
+  // stated income capacity during the school years.
+  it('hand-computes future cost, required monthly contribution, and the one-third breakdown', () => {
+    const result = planner.plan({
+      currentAnnualCostCents: 3_000_000,
+      yearsUntilStart: 10,
+      programYears: 4,
+      currentSavingsCents: 2_000_000,
+      tuitionInflationRateBps: 500,
+      investmentReturnRateBps: 600,
+      monthlyIncomeCapacityDuringSchoolCents: 50_000,
+    });
+
+    expect(result.status).toBe('ok');
+    expect(result.yearlyCosts).toEqual([
+      { yearIndex: 0, yearsFromNow: 10, costCents: 4_886_684 },
+      { yearIndex: 1, yearsFromNow: 11, costCents: 5_131_018 },
+      { yearIndex: 2, yearsFromNow: 12, costCents: 5_387_569 },
+      { yearIndex: 3, yearsFromNow: 13, costCents: 5_656_947 },
+    ]);
+    expect(result.firstYearAnnualCostCents).toBe(4_886_684);
+    expect(result.totalProjectedCostCents).toBe(21_062_218);
+    expect(result.monthsUntilStart).toBe(120);
+    expect(result.requiredMonthlyContributionCents).toBe(106_319);
+    expect(result.immediateLumpSumNeededCents).toBeNull();
+
+    expect(result.oneThirdRule).toEqual({
+      totalProjectedCostCents: 21_062_218,
+      savingsThirdCents: 7_020_739,
+      incomeThirdCents: 7_020_739,
+      loansThirdCents: 7_020_740,
+      projectedSavingsAtStartCents: 3_638_793,
+      projectedIncomeCapacityCents: 2_400_000,
+      twoThirdsTargetCents: 14_041_478,
+      onTrackForTwoThirds: false,
+      twoThirdsGapCents: 8_002_685,
+      incomeCapacityProvided: true,
+    });
+    expect(result.calculationVersion).toBe(COLLEGE_PLANNER_CALCULATION_VERSION);
+    expect(result.assumptions.length).toBeGreaterThan(0);
+  });
+
+  // ── Student starts this year — no time left to dollar-cost-average ───
+  it('falls back to an immediate lump-sum figure when yearsUntilStart is 0', () => {
+    const result = planner.plan({
+      currentAnnualCostCents: 2_000_000,
+      yearsUntilStart: 0,
+      programYears: 1,
+      currentSavingsCents: 500_000,
+      tuitionInflationRateBps: 500,
+      investmentReturnRateBps: 600,
+    });
+
+    expect(result.totalProjectedCostCents).toBe(2_000_000);
+    expect(result.monthsUntilStart).toBe(0);
+    expect(result.requiredMonthlyContributionCents).toBeNull();
+    expect(result.immediateLumpSumNeededCents).toBe(1_500_000);
+
+    // No income capacity provided — defaults to $0 and flags it in assumptions.
+    expect(result.oneThirdRule.incomeCapacityProvided).toBe(false);
+    expect(result.oneThirdRule.projectedIncomeCapacityCents).toBe(0);
+    expect(result.oneThirdRule.onTrackForTwoThirds).toBe(false);
+    expect(result.assumptions.some((a) => a.includes('assumed $0'))).toBe(true);
+  });
+
+  // ── Already fully funded — required contribution floors at 0, never negative ──
+  it('returns a $0 required contribution when current savings already cover the projected cost', () => {
+    const result = planner.plan({
+      currentAnnualCostCents: 1_000_000,
+      yearsUntilStart: 5,
+      programYears: 1,
+      currentSavingsCents: 2_000_000,
+      tuitionInflationRateBps: 0,
+      investmentReturnRateBps: 0,
+    });
+
+    expect(result.totalProjectedCostCents).toBe(1_000_000);
+    expect(result.requiredMonthlyContributionCents).toBe(0);
+    expect(result.immediateLumpSumNeededCents).toBeNull();
+  });
+
+  // ── 0% return rate uses simple linear division, not annuity math (avoids /0) ──
+  it('divides evenly across months when the return rate is 0%', () => {
+    const result = planner.plan({
+      currentAnnualCostCents: 1_200_000,
+      yearsUntilStart: 2,
+      programYears: 1,
+      currentSavingsCents: 0,
+      tuitionInflationRateBps: 0,
+      investmentReturnRateBps: 0,
+    });
+
+    expect(result.totalProjectedCostCents).toBe(1_200_000);
+    expect(result.monthsUntilStart).toBe(24);
+    expect(result.requiredMonthlyContributionCents).toBe(50_000);
+  });
+
+  // ── Defaults apply when inflation/return/programYears are omitted ────
+  it('applies the documented defaults (5% inflation, 6% return, 4-year program) when omitted', () => {
+    const withDefaults = planner.plan({
+      currentAnnualCostCents: 3_000_000,
+      yearsUntilStart: 10,
+      currentSavingsCents: 2_000_000,
+    });
+    const explicit = planner.plan({
+      currentAnnualCostCents: 3_000_000,
+      yearsUntilStart: 10,
+      programYears: 4,
+      currentSavingsCents: 2_000_000,
+      tuitionInflationRateBps: 500,
+      investmentReturnRateBps: 600,
+    });
+    expect(withDefaults).toEqual(explicit);
+  });
+
+  // ── Input validation — fail closed on nonsensical inputs ─────
+  it('rejects a non-positive current annual cost', () => {
+    expect(() =>
+      planner.plan({ currentAnnualCostCents: 0, yearsUntilStart: 5, currentSavingsCents: 0 }),
+    ).toThrow(/currentAnnualCostCents/);
+  });
+
+  it('rejects a negative years-until-start', () => {
+    expect(() =>
+      planner.plan({ currentAnnualCostCents: 1_000_000, yearsUntilStart: -1, currentSavingsCents: 0 }),
+    ).toThrow(/yearsUntilStart/);
+  });
+
+  it('rejects a non-positive program length', () => {
+    expect(() =>
+      planner.plan({
+        currentAnnualCostCents: 1_000_000,
+        yearsUntilStart: 5,
+        programYears: 0,
+        currentSavingsCents: 0,
+      }),
+    ).toThrow(/programYears/);
+  });
+
+  it('rejects negative current savings', () => {
+    expect(() =>
+      planner.plan({ currentAnnualCostCents: 1_000_000, yearsUntilStart: 5, currentSavingsCents: -1 }),
+    ).toThrow(/currentSavingsCents/);
+  });
+
+  it('rejects negative inflation or return rates', () => {
+    expect(() =>
+      planner.plan({
+        currentAnnualCostCents: 1_000_000,
+        yearsUntilStart: 5,
+        currentSavingsCents: 0,
+        tuitionInflationRateBps: -100,
+      }),
+    ).toThrow(/must be >= 0/);
+  });
+});

--- a/apps/api/src/college-planner/college-planner.service.ts
+++ b/apps/api/src/college-planner/college-planner.service.ts
@@ -1,0 +1,212 @@
+/**
+ * 40.3 — College/529 Planner's deterministic core. Pure, DB-free, LLM-free:
+ * given a user-entered current annual college cost (per epic #36's rejection of
+ * cost scraping — see PLANNER-SCOPE), years until the student starts, a current
+ * 529/manual-savings balance, and two adjustable assumptions (tuition-inflation
+ * rate `g` and investment-return rate `r`), computes:
+ *
+ *   1. The projected future annual cost (and total cost across the program)
+ *      after compounding at `g`.
+ *   2. The required level monthly contribution — on top of the current
+ *      balance's own growth at `r` — to fully fund that total by the time the
+ *      student starts (an ordinary, end-of-month annuity).
+ *   3. The locked one-third-rule breakdown: total cost split into
+ *      savings / current-income / loans thirds, and whether current savings
+ *      (grown at `r`) plus the household's stated income capacity during the
+ *      school years are on track to cover their combined two-thirds share.
+ *
+ * Mirrors 13.2's monthly-close-calculator.ts pattern: no NestJS decorators, no
+ * DB reads — all resolved inputs are passed in by the caller (a controller/MCP
+ * tool), and this module is exhaustively fixture-tested in isolation.
+ */
+
+export const COLLEGE_PLANNER_CALCULATION_VERSION = 'college-planner-v1';
+
+/** 5% — the epic's stated tuition-inflation assumption. */
+export const DEFAULT_TUITION_INFLATION_RATE_BPS = 500;
+/** 6% — no existing household return assumption is modeled elsewhere in the
+ *  app (grepped suitability-settings and monthly-close), so this is a
+ *  reasonable, adjustable default for a 529/education-savings horizon. */
+export const DEFAULT_INVESTMENT_RETURN_RATE_BPS = 600;
+/** Standard 4-year undergraduate program, adjustable by the caller. */
+export const DEFAULT_PROGRAM_YEARS = 4;
+
+export interface CollegePlannerInput {
+  /** User-entered current (today's-dollars) annual cost of attendance, in cents. */
+  currentAnnualCostCents: number;
+  /** Whole years from now until the student starts. 0 = starting this year. */
+  yearsUntilStart: number;
+  /** Number of years the student will be enrolled. Defaults to 4. */
+  programYears?: number;
+  /** Current 529 balance or manual-asset snapshot earmarked for this goal, in cents. */
+  currentSavingsCents: number;
+  /** Assumed annual tuition-inflation rate, in basis points. Defaults to 500 (5%). */
+  tuitionInflationRateBps?: number;
+  /** Assumed annual investment-return rate, in basis points. Defaults to 600 (6%). */
+  investmentReturnRateBps?: number;
+  /** Household's stated monthly income they could redirect toward tuition
+   *  *during* the school years (the "current income" third). Optional —
+   *  when omitted, the two-thirds on-track check assumes $0 and flags it. */
+  monthlyIncomeCapacityDuringSchoolCents?: number;
+}
+
+export interface CollegePlannerYearCost {
+  /** 0-indexed year of enrollment (0 = first year). */
+  yearIndex: number;
+  /** Calendar years from now this year of enrollment falls in. */
+  yearsFromNow: number;
+  costCents: number;
+}
+
+export interface OneThirdRuleBreakdown {
+  totalProjectedCostCents: number;
+  savingsThirdCents: number;
+  incomeThirdCents: number;
+  loansThirdCents: number;
+  /** Current savings, grown at the assumed return rate to the start date (no
+   *  further contributions assumed here — this isolates "what you already have"). */
+  projectedSavingsAtStartCents: number;
+  /** monthlyIncomeCapacityDuringSchoolCents * 12 * programYears (0 if not provided). */
+  projectedIncomeCapacityCents: number;
+  twoThirdsTargetCents: number;
+  onTrackForTwoThirds: boolean;
+  twoThirdsGapCents: number;
+  incomeCapacityProvided: boolean;
+}
+
+export interface CollegePlanResult {
+  status: 'ok';
+  firstYearAnnualCostCents: number;
+  yearlyCosts: CollegePlannerYearCost[];
+  totalProjectedCostCents: number;
+  monthsUntilStart: number;
+  /** Required level monthly contribution to fully fund totalProjectedCostCents
+   *  by the start date, given currentSavingsCents' own growth. Null when
+   *  yearsUntilStart <= 0 (no time left to accumulate via monthly contributions). */
+  requiredMonthlyContributionCents: number | null;
+  /** Lump-sum still needed today (undiscounted) when there's no time left to
+   *  accumulate monthly, or 0 when the current balance's projected growth
+   *  already covers the total. Only meaningful when monthsUntilStart <= 0. */
+  immediateLumpSumNeededCents: number | null;
+  oneThirdRule: OneThirdRuleBreakdown;
+  assumptions: string[];
+  calculationVersion: string;
+}
+
+function round(n: number): number {
+  return Math.round(n);
+}
+
+export class CollegePlannerService {
+  plan(input: CollegePlannerInput): CollegePlanResult {
+    if (input.currentAnnualCostCents <= 0) {
+      throw new Error('currentAnnualCostCents must be > 0');
+    }
+    if (input.yearsUntilStart < 0) {
+      throw new Error('yearsUntilStart must be >= 0');
+    }
+    const programYears = input.programYears ?? DEFAULT_PROGRAM_YEARS;
+    if (programYears <= 0) {
+      throw new Error('programYears must be > 0');
+    }
+    if (input.currentSavingsCents < 0) {
+      throw new Error('currentSavingsCents must be >= 0');
+    }
+
+    const g = (input.tuitionInflationRateBps ?? DEFAULT_TUITION_INFLATION_RATE_BPS) / 10_000;
+    const r = (input.investmentReturnRateBps ?? DEFAULT_INVESTMENT_RETURN_RATE_BPS) / 10_000;
+    if (g < 0 || r < 0) {
+      throw new Error('tuitionInflationRateBps and investmentReturnRateBps must be >= 0');
+    }
+
+    // ── 1. Future cost projection ──────────────────────────────
+    const yearlyCosts: CollegePlannerYearCost[] = [];
+    let totalProjectedCostCents = 0;
+    for (let i = 0; i < programYears; i++) {
+      const yearsFromNow = input.yearsUntilStart + i;
+      const costCents = round(input.currentAnnualCostCents * Math.pow(1 + g, yearsFromNow));
+      yearlyCosts.push({ yearIndex: i, yearsFromNow, costCents });
+      totalProjectedCostCents += costCents;
+    }
+    const firstYearAnnualCostCents = yearlyCosts[0].costCents;
+
+    // ── 2. Savings-to-goal annuity ─────────────────────────────
+    const monthsUntilStart = input.yearsUntilStart * 12;
+    const monthlyRate = r / 12;
+    const futureValueOfCurrentSavingsCents =
+      monthsUntilStart > 0
+        ? input.currentSavingsCents * Math.pow(1 + monthlyRate, monthsUntilStart)
+        : input.currentSavingsCents;
+    const remainingGoalCents = Math.max(0, totalProjectedCostCents - futureValueOfCurrentSavingsCents);
+
+    let requiredMonthlyContributionCents: number | null = null;
+    let immediateLumpSumNeededCents: number | null = null;
+    if (monthsUntilStart > 0) {
+      if (remainingGoalCents === 0) {
+        requiredMonthlyContributionCents = 0;
+      } else if (monthlyRate === 0) {
+        requiredMonthlyContributionCents = round(remainingGoalCents / monthsUntilStart);
+      } else {
+        // Ordinary (end-of-month) annuity: FV = PMT * ((1+i)^n - 1) / i
+        const annuityFactor = (Math.pow(1 + monthlyRate, monthsUntilStart) - 1) / monthlyRate;
+        requiredMonthlyContributionCents = round(remainingGoalCents / annuityFactor);
+      }
+    } else {
+      // Student starts this year or already started — no time left to
+      // dollar-cost-average via monthly contributions.
+      immediateLumpSumNeededCents = round(remainingGoalCents);
+    }
+
+    // ── 3. One-third rule ───────────────────────────────────────
+    const savingsThirdCents = round(totalProjectedCostCents / 3);
+    const incomeThirdCents = round(totalProjectedCostCents / 3);
+    const loansThirdCents = totalProjectedCostCents - savingsThirdCents - incomeThirdCents;
+
+    const incomeCapacityProvided = input.monthlyIncomeCapacityDuringSchoolCents !== undefined;
+    const projectedIncomeCapacityCents = incomeCapacityProvided
+      ? round((input.monthlyIncomeCapacityDuringSchoolCents ?? 0) * 12 * programYears)
+      : 0;
+    const projectedSavingsAtStartCents = round(futureValueOfCurrentSavingsCents);
+    const twoThirdsTargetCents = savingsThirdCents + incomeThirdCents;
+    const combinedProjectedCents = projectedSavingsAtStartCents + projectedIncomeCapacityCents;
+    const onTrackForTwoThirds = combinedProjectedCents >= twoThirdsTargetCents;
+    const twoThirdsGapCents = Math.max(0, twoThirdsTargetCents - combinedProjectedCents);
+
+    const oneThirdRule: OneThirdRuleBreakdown = {
+      totalProjectedCostCents,
+      savingsThirdCents,
+      incomeThirdCents,
+      loansThirdCents,
+      projectedSavingsAtStartCents,
+      projectedIncomeCapacityCents,
+      twoThirdsTargetCents,
+      onTrackForTwoThirds,
+      twoThirdsGapCents,
+      incomeCapacityProvided,
+    };
+
+    const dollars = (c: number) => `$${(c / 100).toFixed(2)}`;
+    const assumptions: string[] = [
+      `Tuition inflation assumed at ${(g * 100).toFixed(1)}%/year, compounded annually from today's cost of ${dollars(input.currentAnnualCostCents)}/year.`,
+      `Investment return assumed at ${(r * 100).toFixed(1)}%/year, compounded monthly, applied to both the existing balance and future contributions.`,
+      `Program length assumed at ${programYears} year(s); total projected cost sums each enrollment year's separately-inflated cost.`,
+      'One-third rule (locked definition): 1/3 of total projected cost from savings, 1/3 from current income during school years, 1/3 from loans — not a net-of-aid framing.',
+      incomeCapacityProvided
+        ? `Income capacity during school = ${dollars(input.monthlyIncomeCapacityDuringSchoolCents ?? 0)}/month, projected over ${programYears} year(s).`
+        : 'No monthly income capacity during school was provided — assumed $0 for the two-thirds on-track check.',
+    ];
+
+    return {
+      status: 'ok',
+      firstYearAnnualCostCents,
+      yearlyCosts,
+      totalProjectedCostCents,
+      monthsUntilStart,
+      requiredMonthlyContributionCents,
+      immediateLumpSumNeededCents,
+      oneThirdRule,
+      assumptions,
+      calculationVersion: COLLEGE_PLANNER_CALCULATION_VERSION,
+    };
+  }
+}

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -33,6 +33,7 @@ import { registerGetAllocation } from './tools/get-allocation.js';
 import { registerGetMonthlyClose } from './tools/get-monthly-close.js';
 import { registerGetFinancialHealth } from './tools/get-financial-health.js';
 import { registerGetSafeToSpend } from './tools/get-safe-to-spend.js';
+import { registerGetCollegePlan } from './tools/get-college-plan.js';
 import { close } from './db.js';
 import http from 'node:http';
 
@@ -73,6 +74,7 @@ registerGetAllocation(server);
 registerGetMonthlyClose(server);
 registerGetFinancialHealth(server);
 registerGetSafeToSpend(server);
+registerGetCollegePlan(server);
 
 const mode = process.argv.includes('--sse') ? 'sse' : 'stdio';
 

--- a/apps/mcp-server/src/tools/__tests__/get-college-plan.spec.ts
+++ b/apps/mcp-server/src/tools/__tests__/get-college-plan.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { registerGetCollegePlan } from '../get-college-plan.js';
+
+function makeServer() {
+  let handler: (params: any) => Promise<any>;
+  const server = {
+    tool: (_name: string, _desc: string, _schema: any, fn: any) => {
+      handler = fn;
+    },
+  } as any;
+  registerGetCollegePlan(server);
+  return (params: any) => handler(params);
+}
+
+describe('get_college_plan', () => {
+  it('matches the api college-planner service fixture: $30k/year, 10y out, 4y program, $20k saved, 5%/6%, $500/mo income capacity', async () => {
+    const call = makeServer();
+    const result = await call({
+      currentAnnualCostCents: 3_000_000,
+      yearsUntilStart: 10,
+      programYears: 4,
+      currentSavingsCents: 2_000_000,
+      tuitionInflationRateBps: 500,
+      investmentReturnRateBps: 600,
+      monthlyIncomeCapacityDuringSchoolCents: 50_000,
+    });
+    const text = result.content[0].text as string;
+
+    expect(text).toContain('Projected annual cost in year 1: $48866.84');
+    expect(text).toContain('Projected total cost across 4 year(s): $210622.18');
+    expect(text).toContain('Required monthly savings contribution: $1063.19');
+    expect(text).toContain('Savings third: $70207.39, Income third: $70207.39, Loans third: $70207.40');
+    expect(text).toContain('NOT on track (gap $80026.85)');
+  });
+
+  it('reports an immediate lump sum with no monthly contribution when the student starts this year', async () => {
+    const call = makeServer();
+    const result = await call({
+      currentAnnualCostCents: 2_000_000,
+      yearsUntilStart: 0,
+      programYears: 1,
+      currentSavingsCents: 500_000,
+    });
+    const text = result.content[0].text as string;
+
+    expect(text).toContain('Student starts this year — no time left to save monthly.');
+    expect(text).toContain('Lump sum still needed today: $15000.00');
+    expect(text).toContain('No income capacity during school provided — assumed $0 for the on-track check.');
+  });
+
+  it('applies the documented defaults (5% inflation, 6% return, 4-year program) when omitted', async () => {
+    const call = makeServer();
+    const result = await call({
+      currentAnnualCostCents: 3_000_000,
+      yearsUntilStart: 10,
+      currentSavingsCents: 2_000_000,
+    });
+    const text = result.content[0].text as string;
+    expect(text).toContain('tuition inflation 5.0%/year, investment return 6.0%/year');
+    expect(text).toContain('Projected total cost across 4 year(s): $210622.18');
+  });
+});

--- a/apps/mcp-server/src/tools/get-college-plan.ts
+++ b/apps/mcp-server/src/tools/get-college-plan.ts
@@ -1,0 +1,151 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+/**
+ * 40.3 — College/529 planner. Pure computation from the caller's own
+ * user-entered inputs (per epic #36, this app never scrapes tuition costs) —
+ * no DB reads, so it's safe under the aggregates-only advisor allowlist and
+ * needs no per-user scoping.
+ *
+ * Mirrors apps/api/src/college-planner/college-planner.service.ts's formulas
+ * exactly (future-cost compounding, ordinary end-of-month savings annuity, and
+ * the locked one-third-rule definition: 1/3 savings, 1/3 current income during
+ * school years, 1/3 loans — not a net-of-aid framing). Kept as a
+ * self-contained duplicate here because apps/mcp-server intentionally has no
+ * dependency on apps/api (see its package.json) — if the formulas above ever
+ * change, update both and bump both calculation-version strings together.
+ */
+
+export const COLLEGE_PLAN_MCP_CALCULATION_VERSION = 'college-planner-v1';
+
+const DEFAULT_TUITION_INFLATION_RATE_BPS = 500; // 5%/year
+const DEFAULT_INVESTMENT_RETURN_RATE_BPS = 600; // 6%/year
+const DEFAULT_PROGRAM_YEARS = 4;
+
+function round(n: number): number {
+  return Math.round(n);
+}
+
+export function registerGetCollegePlan(server: McpServer) {
+  server.tool(
+    'get_college_plan',
+    'College/529 savings plan: given a current (today\'s-dollars) annual college cost, years until the student starts, an optional program length, a current 529/savings balance, and adjustable tuition-inflation and investment-return assumptions, projects the future annual and total cost, the required level monthly savings contribution to fully fund it, and the locked one-third-rule breakdown (1/3 savings, 1/3 current income during school, 1/3 loans) with an on-track check against a stated monthly income capacity during the school years. Answers "how much do I need to save monthly for college" and "am I on track for the one-third rule".',
+    {
+      currentAnnualCostCents: z
+        .number()
+        .int()
+        .positive()
+        .describe("Today's annual cost of attendance (tuition + room/board etc), in cents, as entered by the user."),
+      yearsUntilStart: z
+        .number()
+        .int()
+        .min(0)
+        .describe('Whole years from now until the student starts college. 0 = starting this year.'),
+      programYears: z
+        .number()
+        .int()
+        .positive()
+        .max(10)
+        .optional()
+        .describe('Years the student will be enrolled. Defaults to 4.'),
+      currentSavingsCents: z
+        .number()
+        .int()
+        .min(0)
+        .describe('Current 529 balance or earmarked manual-asset/savings snapshot for this goal, in cents.'),
+      tuitionInflationRateBps: z
+        .number()
+        .min(0)
+        .max(2000)
+        .optional()
+        .describe('Assumed annual tuition-inflation rate, in basis points. Defaults to 500 (5%), the epic-stated assumption. Adjustable.'),
+      investmentReturnRateBps: z
+        .number()
+        .min(0)
+        .max(3000)
+        .optional()
+        .describe('Assumed annual investment-return rate, in basis points. Defaults to 600 (6%). Adjustable.'),
+      monthlyIncomeCapacityDuringSchoolCents: z
+        .number()
+        .int()
+        .min(0)
+        .optional()
+        .describe('Household\'s stated monthly income they could redirect toward tuition during the school years, in cents. Omit if unknown — the two-thirds on-track check will assume $0 and flag it.'),
+    },
+    async (params) => {
+      const g = (params.tuitionInflationRateBps ?? DEFAULT_TUITION_INFLATION_RATE_BPS) / 10_000;
+      const r = (params.investmentReturnRateBps ?? DEFAULT_INVESTMENT_RETURN_RATE_BPS) / 10_000;
+      const programYears = params.programYears ?? DEFAULT_PROGRAM_YEARS;
+
+      let totalProjectedCostCents = 0;
+      const yearlyCosts: { yearIndex: number; yearsFromNow: number; costCents: number }[] = [];
+      for (let i = 0; i < programYears; i++) {
+        const yearsFromNow = params.yearsUntilStart + i;
+        const costCents = round(params.currentAnnualCostCents * Math.pow(1 + g, yearsFromNow));
+        yearlyCosts.push({ yearIndex: i, yearsFromNow, costCents });
+        totalProjectedCostCents += costCents;
+      }
+      const firstYearAnnualCostCents = yearlyCosts[0].costCents;
+
+      const monthsUntilStart = params.yearsUntilStart * 12;
+      const monthlyRate = r / 12;
+      const futureValueOfCurrentSavingsCents =
+        monthsUntilStart > 0
+          ? params.currentSavingsCents * Math.pow(1 + monthlyRate, monthsUntilStart)
+          : params.currentSavingsCents;
+      const remainingGoalCents = Math.max(0, totalProjectedCostCents - futureValueOfCurrentSavingsCents);
+
+      let requiredMonthlyContributionCents: number | null = null;
+      let immediateLumpSumNeededCents: number | null = null;
+      if (monthsUntilStart > 0) {
+        if (remainingGoalCents === 0) {
+          requiredMonthlyContributionCents = 0;
+        } else if (monthlyRate === 0) {
+          requiredMonthlyContributionCents = round(remainingGoalCents / monthsUntilStart);
+        } else {
+          const annuityFactor = (Math.pow(1 + monthlyRate, monthsUntilStart) - 1) / monthlyRate;
+          requiredMonthlyContributionCents = round(remainingGoalCents / annuityFactor);
+        }
+      } else {
+        immediateLumpSumNeededCents = round(remainingGoalCents);
+      }
+
+      const savingsThirdCents = round(totalProjectedCostCents / 3);
+      const incomeThirdCents = round(totalProjectedCostCents / 3);
+      const loansThirdCents = totalProjectedCostCents - savingsThirdCents - incomeThirdCents;
+
+      const incomeCapacityProvided = params.monthlyIncomeCapacityDuringSchoolCents !== undefined;
+      const projectedIncomeCapacityCents = incomeCapacityProvided
+        ? round((params.monthlyIncomeCapacityDuringSchoolCents ?? 0) * 12 * programYears)
+        : 0;
+      const projectedSavingsAtStartCents = round(futureValueOfCurrentSavingsCents);
+      const twoThirdsTargetCents = savingsThirdCents + incomeThirdCents;
+      const combinedProjectedCents = projectedSavingsAtStartCents + projectedIncomeCapacityCents;
+      const onTrackForTwoThirds = combinedProjectedCents >= twoThirdsTargetCents;
+      const twoThirdsGapCents = Math.max(0, twoThirdsTargetCents - combinedProjectedCents);
+
+      const dollars = (c: number) => `$${(c / 100).toFixed(2)}`;
+
+      const lines = [
+        `College plan (calculation ${COLLEGE_PLAN_MCP_CALCULATION_VERSION}):`,
+        `  Today's annual cost: ${dollars(params.currentAnnualCostCents)}, ${params.yearsUntilStart} year(s) until start, ${programYears}-year program.`,
+        `  Assumptions (adjustable): tuition inflation ${(g * 100).toFixed(1)}%/year, investment return ${(r * 100).toFixed(1)}%/year.`,
+        `  Projected annual cost in year 1: ${dollars(firstYearAnnualCostCents)}`,
+        `  Projected total cost across ${programYears} year(s): ${dollars(totalProjectedCostCents)}`,
+        monthsUntilStart > 0
+          ? `  Required monthly savings contribution: ${dollars(requiredMonthlyContributionCents ?? 0)} (current balance ${dollars(params.currentSavingsCents)} projected to grow to ${dollars(projectedSavingsAtStartCents)} by start date).`
+          : `  Student starts this year — no time left to save monthly. Lump sum still needed today: ${dollars(immediateLumpSumNeededCents ?? 0)}.`,
+        '  One-third rule (1/3 savings, 1/3 current income during school, 1/3 loans — not net-of-aid):',
+        `    Savings third: ${dollars(savingsThirdCents)}, Income third: ${dollars(incomeThirdCents)}, Loans third: ${dollars(loansThirdCents)}`,
+        incomeCapacityProvided
+          ? `    Income capacity during school: ${dollars(params.monthlyIncomeCapacityDuringSchoolCents ?? 0)}/month → ${dollars(projectedIncomeCapacityCents)} projected.`
+          : '    No income capacity during school provided — assumed $0 for the on-track check.',
+        `    Projected savings + income capacity (${dollars(combinedProjectedCents)}) vs the two-thirds target (${dollars(twoThirdsTargetCents)}): ${
+          onTrackForTwoThirds ? 'ON TRACK' : `NOT on track (gap ${dollars(twoThirdsGapCents)})`
+        }`,
+      ];
+
+      return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
+    },
+  );
+}


### PR DESCRIPTION
Committed successfully.

## Summary

Implements #217 (40.3 — College/529 planner), confirmed via research to be fully net-new (no existing 529/tuition-planning logic in the codebase besides an unrelated account-type enum).

**`apps/api/src/college-planner/college-planner.service.ts`** — a pure, DB-free calculator mirroring 13.2's `monthly-close-calculator.ts` pattern:
- Projects future college cost by compounding a user-entered current annual cost at an adjustable tuition-inflation rate (default 5%, per the epic), summed across each enrollment year of the program.
- Derives the required level monthly savings contribution via an ordinary end-of-month annuity, netting out the current 529/savings balance's own projected growth at an adjustable investment-return rate (default 6%, since no existing household return-assumption field exists elsewhere in the app).
- Applies the locked one-third-rule definition (1/3 savings, 1/3 current income during school years, 1/3 loans — not net-of-aid) and flags whether projected savings plus a stated monthly income capacity are on track for their combined two-thirds share.
- Handles edge cases: student starting immediately (falls back to a lump-sum figure instead of a monthly rate), already-fully-funded goals (floors at $0, never negative), and a 0% return rate (linear division instead of annuity math to avoid divide-by-zero).
- Fails closed with explicit validation errors on non-positive costs/program lengths or negative rates/balances.
- 10 fixture tests, including one hand-computed end-to-end scenario verified against an independent Node calculation.

**`apps/mcp-server/src/tools/get-college-plan.ts`** — new `get_college_plan` MCP tool exposing the same math (duplicated rather than imported, since `apps/mcp-server` intentionally carries no dependency on `apps/api`) with zod-validated, bounded parameters and a narrated response showing all assumptions explicitly. Registered in `index.ts`; 3 tests verified against the same fixture nu

_(summary truncated)_

---
### Test evidence
**13 new test case(s) added** (heuristic count):
```
 .../__tests__/college-planner.service.spec.ts      | 166 ++++++++++++++++
 .../src/tools/__tests__/get-college-plan.spec.ts   |  62 ++++++
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
s/__tests__/agent-runner.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 5[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/suitability-settings/__tests__/suitability-gate.spec.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/notifications/__tests__/telegram-push.service.spec.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/ai-logs/__tests__/model-pricing.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/transactions/__tests__/business-date.spec.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/suitability-settings/__tests__/suitability-settings.service.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/categorization/__tests__/learning.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m97 passed[39m[22m[90m (97)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m837 passed[39m[22m[90m (837)[39m
@moneypulse/api:test: [2m   Start at [22m 01:24:44
@moneypulse/api:test: [2m   Duration [22m 11.23s[2m (transform 3.33s, setup 0ms, import 58.63s, tests 2.52s, environment 6ms)[22m
@moneypulse/api:test: 

 Tasks:    3 successful, 3 total
Cached:    1 cached, 3 total
  Time:    11.782s
```
</details>

### Review
**Review verdict:** approve

---
Dispatched via coxd (`MyMoney-40-3-college-529-planner-tui-1785287407`) · cost $1.590 · 🤖 coxd