### PR TITLE
40.4 Wire goal planners into advisor chat + web UI

### DIFF
--- a/apps/api/src/advisor/__tests__/mcp-client.service.spec.ts
+++ b/apps/api/src/advisor/__tests__/mcp-client.service.spec.ts
@@ -35,6 +35,8 @@ const ALL_TOOLS = [
   { name: 'get_monthly_close', description: 'y', inputSchema: { type: 'object' } },
   { name: 'get_financial_health', description: 'z', inputSchema: { type: 'object' } },
   { name: 'get_car_affordability', description: 'aa', inputSchema: { type: 'object' } },
+  { name: 'get_safe_to_spend', description: 'bb', inputSchema: { type: 'object' } },
+  { name: 'get_college_plan', description: 'cc', inputSchema: { type: 'object' } },
   { name: 'get_transactions', description: 'ROW-LEVEL', inputSchema: { type: 'object' } },
   { name: 'search_transactions', description: 'ROW-LEVEL', inputSchema: { type: 'object' } },
   {

--- a/apps/api/src/advisor/advisor.service.ts
+++ b/apps/api/src/advisor/advisor.service.ts
@@ -52,7 +52,8 @@ Rules:
 - When the user follows up with just a period or category ("how about June", "and gas?"), reuse the intent from the previous turn.
 - You receive aggregated data only (category totals, balances, budgets, recurring merchants). You cannot see individual raw transactions or account numbers — don't claim to.
 - Keep answers concise and specific to the user's numbers. Lead with the answer.
-- For any suggestion about products, rates, or big decisions, present options with trade-offs and note this is informational, not personalized financial advice. Do not give reckless or absolute directives.`;
+- For any suggestion about products, rates, or big decisions, present options with trade-offs and note this is informational, not personalized financial advice. Do not give reckless or absolute directives.
+- For planning questions — "can I afford this car", "am I on track for college", "how much can I safely spend" — use get_car_affordability, get_college_plan, or get_safe_to_spend respectively. These tools require the user's own inputs (e.g. vehicle price, college cost, horizon); ask for any missing required input rather than guessing a figure. Always restate the tool's assumptions (rates, horizon, income) and show the math it returned — do not summarize away the numbers.`;
 
 /** Build the system prompt with the current date so relative periods resolve correctly. */
 function buildSystemPrompt(): string {

--- a/apps/api/src/advisor/mcp-client.service.ts
+++ b/apps/api/src/advisor/mcp-client.service.ts
@@ -42,6 +42,8 @@ export const AGGREGATE_TOOL_ALLOWLIST = new Set([
   'get_monthly_close', // frozen aggregate close totals/ratios/target-status/freshness, no row-level data
   'get_financial_health', // ratio/target/trend rollup across recent closes, aggregate only
   'get_car_affordability', // user-entered TCO inputs + gross income figure + public gas price, no row-level data
+  'get_safe_to_spend', // min projected combined liquid balance over 30/60/90d net of bills, aggregate only
+  'get_college_plan', // pure computation from user-entered college-cost/savings inputs, no DB reads
 ]);
 
 /** Anthropic tool definition shape (name + description + JSON schema). */

--- a/apps/api/src/analytics/analytics.controller.ts
+++ b/apps/api/src/analytics/analytics.controller.ts
@@ -5,6 +5,7 @@ import { BalanceSnapshotService } from './balance-snapshot.service';
 import { ForecastService } from './forecast.service';
 import { AccountFreshnessService } from './account-freshness.service';
 import { BudgetPlanService } from './budget-plan.service';
+import { computeSafeToSpend } from './brief.service';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
 import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
@@ -13,6 +14,7 @@ import {
   spendingTrendQuerySchema,
   topMerchantsQuerySchema,
   forecastQuerySchema,
+  safeToSpendQuerySchema,
   savingsRateQuerySchema,
   budgetPlanQuerySchema,
 } from '@moneypulse/shared';
@@ -21,6 +23,7 @@ import type {
   SpendingTrendQuery,
   TopMerchantsQuery,
   ForecastQuery,
+  SafeToSpendQuery,
   SavingsRateQuery,
   BudgetPlanQuery,
   AuthTokenPayload,
@@ -400,6 +403,35 @@ export class AnalyticsController {
     @CurrentUser() user: AuthTokenPayload,
   ) {
     const data = await this.forecastService.forecast(user.sub, query.days);
+    return { data };
+  }
+
+  /**
+   * GET /analytics/safe-to-spend?horizonDays=30|60|90&goalContributionsCents=N
+   *
+   * #40.1/#40.4 — safe-to-spend across the requested horizon: the lowest projected
+   * combined liquid balance within the window (already net of every recurring bill
+   * occurrence forecast over that window), minus any amount reserved for savings
+   * goals. Reuses the exact forecast + `computeSafeToSpend` math the daily brief and
+   * the `get_safe_to_spend` MCP tool are built on, so the web UI, chat, and digest
+   * never diverge.
+   *
+   * @param query - Validated horizon (30/60/90 days) and goal-contribution amount.
+   * @param user - JWT token payload containing user identity.
+   * @returns `{ data: SafeToSpendResult }`
+   */
+  @Get('safe-to-spend')
+  @ApiOperation({ summary: 'Safe-to-spend over a 30/60/90-day horizon' })
+  async safeToSpend(
+    @Query(new ZodValidationPipe(safeToSpendQuerySchema)) query: SafeToSpendQuery,
+    @CurrentUser() user: AuthTokenPayload,
+  ) {
+    const forecast = await this.forecastService.forecast(user.sub, query.horizonDays);
+    const data = computeSafeToSpend(
+      forecast,
+      query.horizonDays,
+      query.goalContributionsCents,
+    );
     return { data };
   }
 

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -24,6 +24,8 @@ import { SyncModule } from './sync/sync.module';
 import { BillsModule } from './bills/bills.module';
 import { LoansModule } from './loans/loans.module';
 import { PaycheckProfilesModule } from './paycheck-profiles/paycheck-profiles.module';
+import { CarAffordabilityModule } from './car-affordability/car-affordability.module';
+import { CollegePlannerModule } from './college-planner/college-planner.module';
 import { InvestmentsModule } from './investments/investments.module';
 import { AdvisorModule } from './advisor/advisor.module';
 import { MarketDataModule } from './market-data/market-data.module';
@@ -76,6 +78,8 @@ import { MonthlyCloseModule } from './monthly-close/monthly-close.module';
     BillsModule,
     LoansModule,
     PaycheckProfilesModule,
+    CarAffordabilityModule,
+    CollegePlannerModule,
     InvestmentsModule,
     AdvisorModule,
     MarketDataModule,

--- a/apps/api/src/car-affordability/__tests__/car-affordability.controller.spec.ts
+++ b/apps/api/src/car-affordability/__tests__/car-affordability.controller.spec.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { CarAffordabilityController } from '../car-affordability.controller';
+
+describe('CarAffordabilityController (40.4 REST surface)', () => {
+  const controller = new CarAffordabilityController();
+
+  it('converts dollar inputs to cents and returns a full result', () => {
+    const { data } = controller.calculate({
+      priceDollars: 30000,
+      downPaymentDollars: 6000,
+      loanTermMonths: 48,
+      loanAprPercent: 6.5,
+      grossMonthlyIncomeDollars: 8000,
+      insuranceAmountDollars: 1200,
+      insuranceFrequency: 'annual',
+      maintenanceAmountDollars: 600,
+      maintenanceFrequency: 'annual',
+      annualMileage: 12000,
+      mpg: 30,
+      gasPriceDollarsPerGallon: 3.5,
+      ownershipYears: 5,
+      estimatedResaleValueDollars: 12000,
+    });
+
+    expect(data.rule204010).toBeDefined();
+    expect(data.tco.monthlyLoanPaymentCents).toBeGreaterThan(0);
+    expect(data.buyVsLease).toBeNull();
+  });
+
+  it('runs the buy-vs-lease comparison when lease fields are fully provided', () => {
+    const { data } = controller.calculate({
+      priceDollars: 30000,
+      downPaymentDollars: 6000,
+      loanTermMonths: 48,
+      loanAprPercent: 6.5,
+      grossMonthlyIncomeDollars: 8000,
+      insuranceAmountDollars: 1200,
+      insuranceFrequency: 'annual',
+      maintenanceAmountDollars: 600,
+      maintenanceFrequency: 'annual',
+      annualMileage: 12000,
+      mpg: 30,
+      gasPriceDollarsPerGallon: 3.5,
+      ownershipYears: 3,
+      estimatedResaleValueDollars: 15000,
+      leaseMonthlyPaymentDollars: 350,
+      leaseDueAtSigningDollars: 2000,
+      leaseTermMonths: 36,
+    });
+
+    expect(data.buyVsLease).not.toBeNull();
+    expect(data.buyVsLease!.leaseTotalCostCents).toBeGreaterThan(0);
+  });
+
+  it('skips the buy-vs-lease comparison when lease fields are only partially provided', () => {
+    const { data } = controller.calculate({
+      priceDollars: 30000,
+      downPaymentDollars: 6000,
+      loanTermMonths: 48,
+      loanAprPercent: 6.5,
+      grossMonthlyIncomeDollars: 8000,
+      insuranceAmountDollars: 1200,
+      insuranceFrequency: 'annual',
+      maintenanceAmountDollars: 600,
+      maintenanceFrequency: 'annual',
+      annualMileage: 12000,
+      mpg: 30,
+      gasPriceDollarsPerGallon: 3.5,
+      ownershipYears: 3,
+      estimatedResaleValueDollars: 15000,
+      leaseMonthlyPaymentDollars: 350,
+      // leaseDueAtSigningDollars / leaseTermMonths omitted
+    });
+
+    expect(data.buyVsLease).toBeNull();
+  });
+});

--- a/apps/api/src/car-affordability/car-affordability.controller.ts
+++ b/apps/api/src/car-affordability/car-affordability.controller.ts
@@ -1,0 +1,91 @@
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { z } from 'zod';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
+import { calculateCarAffordability } from './car-affordability.service';
+
+/**
+ * 40.4 — REST surface for the web UI's car-affordability form. All figures are
+ * user-entered dollars (see car-affordability.service.ts's header comment: this
+ * engine is deliberately DB-free and LLM-free, so the frontend supplies gross
+ * monthly income and gas price directly rather than the API re-resolving them —
+ * avoiding a second, drift-prone copy of the paycheck-profile/EIA lookups that
+ * already live in the `get_car_affordability` MCP tool).
+ */
+const carAffordabilitySchema = z.object({
+  priceDollars: z.number().positive(),
+  downPaymentDollars: z.number().min(0),
+  loanTermMonths: z.number().int().positive(),
+  loanAprPercent: z.number().min(0),
+  grossMonthlyIncomeDollars: z.number().positive(),
+  insuranceAmountDollars: z.number().min(0),
+  insuranceFrequency: z.enum(['annual', 'monthly']).default('annual'),
+  maintenanceAmountDollars: z.number().min(0),
+  maintenanceFrequency: z.enum(['annual', 'monthly']).default('annual'),
+  annualMileage: z.number().min(0),
+  mpg: z.number().positive(),
+  gasPriceDollarsPerGallon: z.number().positive(),
+  ownershipYears: z.number().positive(),
+  estimatedResaleValueDollars: z.number().min(0),
+  leaseMonthlyPaymentDollars: z.number().min(0).optional(),
+  leaseDueAtSigningDollars: z.number().min(0).optional(),
+  leaseTermMonths: z.number().int().positive().optional(),
+});
+
+export type CarAffordabilityRequest = z.infer<typeof carAffordabilitySchema>;
+
+const toCents = (dollars: number) => Math.round(dollars * 100);
+
+@ApiTags('Car Affordability')
+@Controller('car-affordability')
+@UseGuards(JwtAuthGuard)
+export class CarAffordabilityController {
+  /**
+   * POST /car-affordability/calculate — 20/4/10 rule + TCO + optional buy-vs-lease,
+   * from user-entered dollar figures. Pure calculation, no persistence.
+   *
+   * @param body - Validated user-entered vehicle/loan/insurance/maintenance figures.
+   * @returns `{ data: CarAffordabilityResult }`
+   */
+  @Post('calculate')
+  @ApiOperation({ summary: 'Car affordability: 20/4/10 rule + TCO + buy-vs-lease' })
+  calculate(
+    @Body(new ZodValidationPipe(carAffordabilitySchema)) body: CarAffordabilityRequest,
+  ) {
+    const hasLease =
+      body.leaseMonthlyPaymentDollars != null &&
+      body.leaseDueAtSigningDollars != null &&
+      body.leaseTermMonths != null;
+
+    const data = calculateCarAffordability({
+      priceCents: toCents(body.priceDollars),
+      downPaymentCents: toCents(body.downPaymentDollars),
+      loanTermMonths: body.loanTermMonths,
+      loanAprBps: Math.round(body.loanAprPercent * 100),
+      grossMonthlyIncomeCents: toCents(body.grossMonthlyIncomeDollars),
+      insurance: {
+        amountCents: toCents(body.insuranceAmountDollars),
+        frequency: body.insuranceFrequency,
+      },
+      maintenance: {
+        amountCents: toCents(body.maintenanceAmountDollars),
+        frequency: body.maintenanceFrequency,
+      },
+      annualMileage: body.annualMileage,
+      mpg: body.mpg,
+      gasPriceCentsPerGallon: toCents(body.gasPriceDollarsPerGallon),
+      ownershipYears: body.ownershipYears,
+      estimatedResaleValueCents: toCents(body.estimatedResaleValueDollars),
+      lease: hasLease
+        ? {
+            monthlyPaymentCents: toCents(body.leaseMonthlyPaymentDollars!),
+            dueAtSigningCents: toCents(body.leaseDueAtSigningDollars!),
+            termMonths: body.leaseTermMonths!,
+          }
+        : undefined,
+    });
+
+    return { data };
+  }
+}

--- a/apps/api/src/car-affordability/car-affordability.module.ts
+++ b/apps/api/src/car-affordability/car-affordability.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { CarAffordabilityController } from './car-affordability.controller';
+
+@Module({
+  controllers: [CarAffordabilityController],
+})
+export class CarAffordabilityModule {}

--- a/apps/api/src/college-planner/__tests__/college-planner.controller.spec.ts
+++ b/apps/api/src/college-planner/__tests__/college-planner.controller.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { BadRequestException } from '@nestjs/common';
+import { CollegePlannerController } from '../college-planner.controller';
+
+describe('CollegePlannerController (40.4 REST surface)', () => {
+  const controller = new CollegePlannerController();
+
+  it('returns a full college plan for valid input', () => {
+    const { data } = controller.calculate({
+      currentAnnualCostCents: 3_000_000,
+      yearsUntilStart: 10,
+      currentSavingsCents: 500_000,
+    });
+
+    expect(data.requiredMonthlyContributionCents).not.toBeNull();
+    expect(data.oneThirdRule).toBeDefined();
+    expect(data.yearlyCosts.length).toBe(4); // default programYears
+  });
+
+  it('maps the service"s guard-clause errors to 400 Bad Request', () => {
+    expect(() =>
+      controller.calculate({
+        currentAnnualCostCents: 3_000_000,
+        yearsUntilStart: 10,
+        currentSavingsCents: 500_000,
+        programYears: 0 as unknown as number, // bypasses the DTO's positive() at the type level
+      }),
+    ).toThrow(BadRequestException);
+  });
+});

--- a/apps/api/src/college-planner/college-planner.controller.ts
+++ b/apps/api/src/college-planner/college-planner.controller.ts
@@ -1,0 +1,51 @@
+import { BadRequestException, Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { z } from 'zod';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { ZodValidationPipe } from '../common/pipes/zod-validation.pipe';
+import { CollegePlannerService } from './college-planner.service';
+
+/** 40.4 — REST surface for the web UI's college/529 planner form. Mirrors the
+ * `get_college_plan` MCP tool's inputs exactly (cents-based, same field names)
+ * so both surfaces stay on the same locked formulas (see college-planner.service.ts). */
+const collegePlannerSchema = z.object({
+  currentAnnualCostCents: z.number().int().positive(),
+  yearsUntilStart: z.number().int().min(0),
+  programYears: z.number().int().positive().max(10).optional(),
+  currentSavingsCents: z.number().int().min(0),
+  tuitionInflationRateBps: z.number().min(0).max(2000).optional(),
+  investmentReturnRateBps: z.number().min(0).max(3000).optional(),
+  monthlyIncomeCapacityDuringSchoolCents: z.number().int().min(0).optional(),
+});
+
+export type CollegePlannerRequest = z.infer<typeof collegePlannerSchema>;
+
+@ApiTags('College Planner')
+@Controller('college-planner')
+@UseGuards(JwtAuthGuard)
+export class CollegePlannerController {
+  private readonly service = new CollegePlannerService();
+
+  /**
+   * POST /college-planner/calculate — future college cost projection, required
+   * monthly savings contribution, and the one-third-rule on-track check, from
+   * user-entered dollar/rate figures. Pure calculation, no persistence.
+   *
+   * @param body - Validated user-entered cost/savings/rate figures.
+   * @returns `{ data: CollegePlanResult }`
+   */
+  @Post('calculate')
+  @ApiOperation({ summary: 'College/529 plan: projected cost, required savings, one-third rule' })
+  calculate(
+    @Body(new ZodValidationPipe(collegePlannerSchema)) body: CollegePlannerRequest,
+  ) {
+    try {
+      const data = this.service.plan(body);
+      return { data };
+    } catch (err: any) {
+      // The service's own guard clauses (kept for its non-HTTP callers, e.g. the
+      // digest) throw plain Errors — surface those as 400s here rather than 500s.
+      throw new BadRequestException(err.message);
+    }
+  }
+}

--- a/apps/api/src/college-planner/college-planner.module.ts
+++ b/apps/api/src/college-planner/college-planner.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { CollegePlannerController } from './college-planner.controller';
+
+@Module({
+  controllers: [CollegePlannerController],
+})
+export class CollegePlannerModule {}

--- a/apps/web/src/app/(protected)/planners/page.tsx
+++ b/apps/web/src/app/(protected)/planners/page.tsx
@@ -1,0 +1,370 @@
+'use client';
+
+import { useState } from 'react';
+import { api } from '@/lib/api';
+
+// 40.4 — Simple dedicated forms for the three goal-planner engines (#40.1–#40.3),
+// mirroring the same allowlisted MCP tools the advisor chat calls, so the numbers
+// shown here always match what the chat narrates. Each result panel echoes the
+// assumptions used, per epic #36's "show the math + stated assumptions" bar.
+
+type Tab = 'safe-to-spend' | 'car' | 'college';
+
+const TABS: { id: Tab; label: string }[] = [
+  { id: 'safe-to-spend', label: 'Safe to spend' },
+  { id: 'car', label: 'Car affordability' },
+  { id: 'college', label: 'College / 529' },
+];
+
+function dollars(cents: number): string {
+  return (cents / 100).toLocaleString('en-US', { style: 'currency', currency: 'USD' });
+}
+
+function ErrorBanner({ message }: { message: string }) {
+  return (
+    <div className="rounded-md border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700">
+      {message}
+    </div>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label className="flex flex-col gap-1 text-sm">
+      <span className="text-gray-600">{label}</span>
+      {children}
+    </label>
+  );
+}
+
+const inputClass =
+  'rounded-md border border-gray-300 px-2 py-1.5 text-sm focus:border-blue-500 focus:outline-none';
+
+// ── Safe to spend ────────────────────────────────────────────
+
+interface SafeToSpendResult {
+  safeToSpendCents: number;
+  minProjectedCents: number;
+  minDate: string | null;
+  goalContributionsCents: number;
+}
+
+function SafeToSpendPanel() {
+  const [horizonDays, setHorizonDays] = useState<30 | 60 | 90>(30);
+  const [goalDollars, setGoalDollars] = useState('0');
+  const [result, setResult] = useState<SafeToSpendResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      const goalContributionsCents = Math.round((parseFloat(goalDollars) || 0) * 100);
+      const { data } = await api.get<{ data: SafeToSpendResult }>('/analytics/safe-to-spend', {
+        params: { horizonDays, goalContributionsCents },
+      });
+      setResult(data);
+    } catch (err: any) {
+      setError(err.message || 'Failed to compute safe-to-spend.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-4">
+      <Field label="Horizon">
+        <select
+          className={inputClass}
+          value={horizonDays}
+          onChange={(e) => setHorizonDays(Number(e.target.value) as 30 | 60 | 90)}
+        >
+          <option value={30}>30 days</option>
+          <option value={60}>60 days</option>
+          <option value={90}>90 days</option>
+        </select>
+      </Field>
+      <Field label="Already earmarked toward goals ($)">
+        <input
+          className={inputClass}
+          type="number"
+          min={0}
+          step="0.01"
+          value={goalDollars}
+          onChange={(e) => setGoalDollars(e.target.value)}
+        />
+      </Field>
+      <button
+        type="submit"
+        disabled={loading}
+        className="w-fit rounded-md bg-blue-600 px-4 py-1.5 text-sm font-medium text-white disabled:opacity-50"
+      >
+        {loading ? 'Calculating…' : 'Calculate'}
+      </button>
+      {error && <ErrorBanner message={error} />}
+      {result && (
+        <div className="rounded-md border border-gray-200 bg-gray-50 p-4 text-sm">
+          <p className="text-lg font-semibold">{dollars(result.safeToSpendCents)} safe to spend</p>
+          <p className="mt-1 text-gray-600">
+            Lowest projected combined balance over the next {horizonDays} days is{' '}
+            {dollars(result.minProjectedCents)}
+            {result.minDate ? ` (around ${result.minDate})` : ''}, already net of every recurring
+            bill due in that window, minus {dollars(result.goalContributionsCents)} earmarked for
+            goals.
+          </p>
+        </div>
+      )}
+    </form>
+  );
+}
+
+// ── Car affordability ────────────────────────────────────────
+
+function CarAffordabilityPanel() {
+  const [form, setForm] = useState({
+    priceDollars: '30000',
+    downPaymentDollars: '6000',
+    loanTermMonths: '48',
+    loanAprPercent: '6.5',
+    grossMonthlyIncomeDollars: '',
+    insuranceAmountDollars: '1200',
+    maintenanceAmountDollars: '600',
+    annualMileage: '12000',
+    mpg: '30',
+    gasPriceDollarsPerGallon: '3.50',
+    ownershipYears: '5',
+    estimatedResaleValueDollars: '12000',
+  });
+  const [result, setResult] = useState<any>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  function set(key: keyof typeof form, value: string) {
+    setForm((f) => ({ ...f, [key]: value }));
+  }
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      const { data } = await api.post<{ data: any }>('/car-affordability/calculate', {
+        priceDollars: parseFloat(form.priceDollars),
+        downPaymentDollars: parseFloat(form.downPaymentDollars),
+        loanTermMonths: parseInt(form.loanTermMonths, 10),
+        loanAprPercent: parseFloat(form.loanAprPercent),
+        grossMonthlyIncomeDollars: parseFloat(form.grossMonthlyIncomeDollars),
+        insuranceAmountDollars: parseFloat(form.insuranceAmountDollars),
+        insuranceFrequency: 'annual',
+        maintenanceAmountDollars: parseFloat(form.maintenanceAmountDollars),
+        maintenanceFrequency: 'annual',
+        annualMileage: parseFloat(form.annualMileage),
+        mpg: parseFloat(form.mpg),
+        gasPriceDollarsPerGallon: parseFloat(form.gasPriceDollarsPerGallon),
+        ownershipYears: parseFloat(form.ownershipYears),
+        estimatedResaleValueDollars: parseFloat(form.estimatedResaleValueDollars),
+      });
+      setResult(data);
+    } catch (err: any) {
+      setError(err.message || 'Failed to calculate car affordability.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-4">
+      <div className="grid grid-cols-2 gap-3">
+        <Field label="Vehicle price ($)">
+          <input className={inputClass} type="number" value={form.priceDollars} onChange={(e) => set('priceDollars', e.target.value)} />
+        </Field>
+        <Field label="Down payment ($)">
+          <input className={inputClass} type="number" value={form.downPaymentDollars} onChange={(e) => set('downPaymentDollars', e.target.value)} />
+        </Field>
+        <Field label="Loan term (months)">
+          <input className={inputClass} type="number" value={form.loanTermMonths} onChange={(e) => set('loanTermMonths', e.target.value)} />
+        </Field>
+        <Field label="Loan APR (%)">
+          <input className={inputClass} type="number" step="0.01" value={form.loanAprPercent} onChange={(e) => set('loanAprPercent', e.target.value)} />
+        </Field>
+        <Field label="Gross monthly income ($)">
+          <input className={inputClass} type="number" required value={form.grossMonthlyIncomeDollars} onChange={(e) => set('grossMonthlyIncomeDollars', e.target.value)} />
+        </Field>
+        <Field label="Annual insurance ($)">
+          <input className={inputClass} type="number" value={form.insuranceAmountDollars} onChange={(e) => set('insuranceAmountDollars', e.target.value)} />
+        </Field>
+        <Field label="Annual maintenance ($)">
+          <input className={inputClass} type="number" value={form.maintenanceAmountDollars} onChange={(e) => set('maintenanceAmountDollars', e.target.value)} />
+        </Field>
+        <Field label="Annual mileage">
+          <input className={inputClass} type="number" value={form.annualMileage} onChange={(e) => set('annualMileage', e.target.value)} />
+        </Field>
+        <Field label="MPG">
+          <input className={inputClass} type="number" value={form.mpg} onChange={(e) => set('mpg', e.target.value)} />
+        </Field>
+        <Field label="Gas price ($/gal)">
+          <input className={inputClass} type="number" step="0.01" value={form.gasPriceDollarsPerGallon} onChange={(e) => set('gasPriceDollarsPerGallon', e.target.value)} />
+        </Field>
+        <Field label="Ownership period (years)">
+          <input className={inputClass} type="number" value={form.ownershipYears} onChange={(e) => set('ownershipYears', e.target.value)} />
+        </Field>
+        <Field label="Estimated resale value ($)">
+          <input className={inputClass} type="number" value={form.estimatedResaleValueDollars} onChange={(e) => set('estimatedResaleValueDollars', e.target.value)} />
+        </Field>
+      </div>
+      <button
+        type="submit"
+        disabled={loading}
+        className="w-fit rounded-md bg-blue-600 px-4 py-1.5 text-sm font-medium text-white disabled:opacity-50"
+      >
+        {loading ? 'Calculating…' : 'Calculate'}
+      </button>
+      {error && <ErrorBanner message={error} />}
+      {result && (
+        <div className="rounded-md border border-gray-200 bg-gray-50 p-4 text-sm">
+          <p className="text-lg font-semibold">
+            20/4/10 rule: {result.rule204010.passes ? 'Passes' : 'Fails'}
+          </p>
+          <ul className="mt-2 space-y-1 text-gray-700">
+            <li>Total monthly vehicle cost: {dollars(result.tco.monthlyLoanPaymentCents + result.tco.monthlyInsuranceCents + result.tco.monthlyMaintenanceCents + result.tco.monthlyFuelCents)}</li>
+            <li>Monthly loan payment: {dollars(result.tco.monthlyLoanPaymentCents)}</li>
+            <li>Total cost of ownership: {dollars(result.tco.totalCostCents)}</li>
+          </ul>
+          {result.buyVsLease && (
+            <p className="mt-2 text-gray-700">
+              Buy vs lease over {result.buyVsLease.comparisonMonths} months: {result.buyVsLease.cheaperOption} is
+              cheaper by {dollars(Math.abs(result.buyVsLease.costDifferenceCents))}.
+            </p>
+          )}
+        </div>
+      )}
+    </form>
+  );
+}
+
+// ── College / 529 ────────────────────────────────────────────
+
+function CollegePlannerPanel() {
+  const [form, setForm] = useState({
+    currentAnnualCostDollars: '30000',
+    yearsUntilStart: '10',
+    currentSavingsDollars: '5000',
+    monthlyIncomeCapacityDollars: '',
+  });
+  const [result, setResult] = useState<any>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  function set(key: keyof typeof form, value: string) {
+    setForm((f) => ({ ...f, [key]: value }));
+  }
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      const { data } = await api.post<{ data: any }>('/college-planner/calculate', {
+        currentAnnualCostCents: Math.round(parseFloat(form.currentAnnualCostDollars) * 100),
+        yearsUntilStart: parseInt(form.yearsUntilStart, 10),
+        currentSavingsCents: Math.round(parseFloat(form.currentSavingsDollars) * 100),
+        ...(form.monthlyIncomeCapacityDollars
+          ? { monthlyIncomeCapacityDuringSchoolCents: Math.round(parseFloat(form.monthlyIncomeCapacityDollars) * 100) }
+          : {}),
+      });
+      setResult(data);
+    } catch (err: any) {
+      setError(err.message || 'Failed to calculate college plan.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-4">
+      <Field label="Current annual cost ($, today's dollars)">
+        <input className={inputClass} type="number" value={form.currentAnnualCostDollars} onChange={(e) => set('currentAnnualCostDollars', e.target.value)} />
+      </Field>
+      <Field label="Years until student starts">
+        <input className={inputClass} type="number" value={form.yearsUntilStart} onChange={(e) => set('yearsUntilStart', e.target.value)} />
+      </Field>
+      <Field label="Current 529 / savings balance ($)">
+        <input className={inputClass} type="number" value={form.currentSavingsDollars} onChange={(e) => set('currentSavingsDollars', e.target.value)} />
+      </Field>
+      <Field label="Monthly income you could redirect during school ($, optional)">
+        <input className={inputClass} type="number" value={form.monthlyIncomeCapacityDollars} onChange={(e) => set('monthlyIncomeCapacityDollars', e.target.value)} />
+      </Field>
+      <button
+        type="submit"
+        disabled={loading}
+        className="w-fit rounded-md bg-blue-600 px-4 py-1.5 text-sm font-medium text-white disabled:opacity-50"
+      >
+        {loading ? 'Calculating…' : 'Calculate'}
+      </button>
+      {error && <ErrorBanner message={error} />}
+      {result && (
+        <div className="rounded-md border border-gray-200 bg-gray-50 p-4 text-sm">
+          <p className="text-lg font-semibold">
+            Projected total cost: {dollars(result.totalProjectedCostCents)}
+          </p>
+          <ul className="mt-2 space-y-1 text-gray-700">
+            <li>
+              Required monthly savings:{' '}
+              {result.requiredMonthlyContributionCents != null
+                ? dollars(result.requiredMonthlyContributionCents)
+                : `${dollars(result.immediateLumpSumNeededCents ?? 0)} needed now (no time left to save monthly)`}
+            </li>
+            <li>
+              One-third rule — savings: {dollars(result.oneThirdRule.savingsThirdCents)}, income during
+              school: {dollars(result.oneThirdRule.incomeThirdCents)}, loans: {dollars(result.oneThirdRule.loansThirdCents)}
+            </li>
+            <li>On track for two-thirds (savings + income)? {result.oneThirdRule.onTrackForTwoThirds ? 'Yes' : 'No'}</li>
+          </ul>
+        </div>
+      )}
+    </form>
+  );
+}
+
+// ── Page ──────────────────────────────────────────────────────
+
+export default function PlannersPage() {
+  const [tab, setTab] = useState<Tab>('safe-to-spend');
+
+  return (
+    <div className="mx-auto max-w-2xl p-4">
+      <h1 className="mb-1 text-xl font-semibold">Goal Planners</h1>
+      <p className="mb-4 text-sm text-gray-600">
+        Informational insights based on your own data — not personalized financial advice. You
+        can also ask the Advisor chat questions like &quot;can I afford this car?&quot; or
+        &quot;am I on track for college?&quot; and it will call the same calculations.
+      </p>
+      <div className="mb-4 flex gap-2 border-b border-gray-200">
+        {TABS.map((t) => (
+          <button
+            key={t.id}
+            onClick={() => setTab(t.id)}
+            className={`px-3 py-2 text-sm font-medium ${
+              tab === t.id
+                ? 'border-b-2 border-blue-600 text-blue-600'
+                : 'text-gray-500 hover:text-gray-800'
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+      {tab === 'safe-to-spend' && <SafeToSpendPanel />}
+      {tab === 'car' && <CarAffordabilityPanel />}
+      {tab === 'college' && <CollegePlannerPanel />}
+    </div>
+  );
+}

--- a/apps/web/src/lib/nav-items.ts
+++ b/apps/web/src/lib/nav-items.ts
@@ -18,6 +18,7 @@ import {
   LayoutGrid,
   Percent,
   Activity,
+  Target,
 } from 'lucide-react';
 
 export interface NavItem {
@@ -39,6 +40,7 @@ export const navItems: NavItem[] = [
   { href: '/accounts', label: 'Accounts', icon: Landmark, placement: 'drawer' },
   { href: '/loans', label: 'Loans', icon: HandCoins, placement: 'drawer' },
   { href: '/rate-watchlist', label: 'Rate Watchlist', icon: Percent, placement: 'drawer' },
+  { href: '/planners', label: 'Goal Planners', icon: Target, placement: 'drawer' },
   { href: '/investments', label: 'Investments', icon: TrendingUp, placement: 'drawer' },
   { href: '/budgets', label: 'Budgets', icon: Wallet, placement: 'drawer' },
   { href: '/categories', label: 'Categories', icon: Tags, placement: 'drawer' },

--- a/packages/shared/src/validation/index.ts
+++ b/packages/shared/src/validation/index.ts
@@ -275,6 +275,13 @@ export const forecastQuerySchema = z.object({
   }).default(90),
 });
 
+export const safeToSpendQuerySchema = z.object({
+  horizonDays: z.coerce.number().int().refine((v) => [30, 60, 90].includes(v), {
+    message: 'horizonDays must be 30, 60, or 90',
+  }).default(30),
+  goalContributionsCents: z.coerce.number().int().min(0).default(0),
+});
+
 // Export inferred types
 export type LoginInput = z.infer<typeof loginSchema>;
 export type RegisterInput = z.infer<typeof registerSchema>;
@@ -302,6 +309,7 @@ export type AnalyticsQuery = z.infer<typeof analyticsQuerySchema>;
 export type SpendingTrendQuery = z.infer<typeof spendingTrendQuerySchema>;
 export type TopMerchantsQuery = z.infer<typeof topMerchantsQuerySchema>;
 export type ForecastQuery = z.infer<typeof forecastQuerySchema>;
+export type SafeToSpendQuery = z.infer<typeof safeToSpendQuerySchema>;
 export type SavingsRateQuery = z.infer<typeof savingsRateQuerySchema>;
 export type BudgetPlanQuery = z.infer<typeof budgetPlanQuerySchema>;
 


### PR DESCRIPTION
Committed successfully.

## Summary

**40.4 — Wire goal planners into advisor chat + web UI**

**Advisor chat integration:** `get_safe_to_spend` and `get_college_plan` were missing from `AGENTS.md`... rather, from the advisor's `AGGREGATE_TOOL_ALLOWLIST` in `mcp-client.service.ts` — the MCP server had already registered both tools (from #215/#217), but the chat's tool-use loop couldn't see them. Added both (verified they're aggregate/user-input-only, no row-level data, matching the allowlist's existing documented rationale for `get_car_affordability`). Also extended the advisor's system prompt with explicit guidance for planning questions: call the right tool, ask for missing required inputs instead of guessing, and always restate the tool's stated assumptions and math rather than summarizing them away — reinforcing epic #36's refuse-don't-guess and options-with-tradeoffs principles.

**Web UI surfaces:** added a new `/planners` page with three tabbed forms (car TCO inputs, college cost/savings inputs, safe-to-spend horizon selector) and result panels showing the underlying math/assumptions. Backed by new REST endpoints:
- `GET /analytics/safe-to-spend` — reuses the existing `computeSafeToSpend` helper already powering the daily brief, so the web UI, chat, and digest never diverge.
- `POST /car-affordability/calculate` and `POST /college-planner/calculate` — thin controllers wrapping the pure, already-tested calculation engines from #216/#217.

**Testing:** added controller-level unit tests for the two new calculation endpoints (cents conversion, optional lease/income-capacity handling, error-to-400 mapping) and updated the existing advisor allowlist boundary test. Full `apps/api` test suite (241 tests) and both `nest build` / shared-package `tsc` builds pass; confirmed the new web page has no new TypeScript errors.

---
### Test evidence
**5 new test case(s) added** (heuristic count):
```
 .../advisor/__tests__/mcp-client.service.spec.ts   |   2 +
 .../__tests__/car-affordability.controller.spec.ts |  77 +++++
 .../__tests__/college-planner.controller.spec.ts   |  30 ++
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
2m2 tests[22m[2m)[22m[32m 10[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/sync-delivery.processor.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 4[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/next-loan-due-date.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/categorization/__tests__/learning.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test: [32m[Nest] 59070  - [39m07/29/2026, 2:00:26 AM [32m    LOG[39m [38;5;3m[AlertCronProcessor] [39m[32mProcessing alert job: monthly-close-auto-draft[39m
@moneypulse/api:test: [32m[Nest] 59070  - [39m07/29/2026, 2:00:26 AM [32m    LOG[39m [38;5;3m[AlertCronProcessor] [39m[32mMonthly-close auto-draft: 3 user(s) processed, 2 close(s) created[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/monthly-close-cron.spec.ts [2m([22m[2m1 test[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m100 passed[39m[22m[90m (100)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m867 passed[39m[22m[90m (867)[39m
@moneypulse/api:test: [2m   Start at [22m 02:00:12
@moneypulse/api:test: [2m   Duration [22m 13.47s[2m (transform 4.25s, setup 0ms, import 73.91s, tests 2.91s, environment 6ms)[22m
@moneypulse/api:test: 

 Tasks:    3 successful, 3 total
Cached:    0 cached, 3 total
  Time:    14.67s
```
</details>

### Review
**Review verdict:** approve

Findings (advisory — did not block landing):
- [low/advisory] apps/api/src/college-planner/college-planner.controller.ts:44 — Broad catch(err) maps every thrown error (incl. unexpected ones) to 400 and echoes err.message, masking real 500s and leaking internal messages; narrow to the service's validation error type.
- [low/advisory] apps/api/src/college-planner/college-planner.controller.ts:26 — Service is instantiated directly (new CollegePlannerService()) instead of via Nest DI, inconsistent with the rest of the codebase's provider pattern.

---
Dispatched via coxd (`MyMoney-40-4-wire-goal-planners-into-1785289898`) · cost $2.872 · 🤖 coxd