### PR TITLE
Monthly-close investment total can silently read ~$0 when historical p

### DIFF
--- a/apps/api/src/monthly-close/__tests__/monthly-close-calculator.spec.ts
+++ b/apps/api/src/monthly-close/__tests__/monthly-close-calculator.spec.ts
@@ -42,7 +42,7 @@ function baseInput(
     emergencyFundMonths: 3,
     hasHighInterestDebt: false,
     employerMatch: { available: false, captured: null },
-    freshness: { missingManualAssets: [], staleAccounts: [], unverifiedLoans: [] },
+    freshness: { missingManualAssets: [], staleAccounts: [], unverifiedLoans: [], missingInvestmentPrices: [] },
     ...overrides,
   };
 }
@@ -108,6 +108,7 @@ describe('calculateMonthlyClose', () => {
         missingManualAssets: [],
         staleAccounts: ['acct-checking'],
         unverifiedLoans: [],
+        missingInvestmentPrices: [],
       },
     });
 
@@ -284,10 +285,26 @@ describe('calculateMonthlyClose', () => {
           missingManualAssets: ['home'],
           staleAccounts: [],
           unverifiedLoans: [],
+          missingInvestmentPrices: [],
         },
       }),
     );
     expect(incomplete.freshness.isComplete).toBe(false);
+  });
+
+  it('marks freshness incomplete when holdings exist but a price is missing for the month (#213)', () => {
+    const incomplete = calculateMonthlyClose(
+      baseInput({
+        freshness: {
+          missingManualAssets: [],
+          staleAccounts: [],
+          unverifiedLoans: [],
+          missingInvestmentPrices: ['VTI'],
+        },
+      }),
+    );
+    expect(incomplete.freshness.isComplete).toBe(false);
+    expect(incomplete.freshness.missingInvestmentPrices).toEqual(['VTI']);
   });
 
   // ── FOO next-dollar priority ordering ────────────────────────

--- a/apps/api/src/monthly-close/__tests__/monthly-close.service.spec.ts
+++ b/apps/api/src/monthly-close/__tests__/monthly-close.service.spec.ts
@@ -24,6 +24,7 @@ describe('MonthlyCloseService', () => {
   let service: MonthlyCloseService;
   let mockDb: any;
   let notificationsService: { createAndDispatch: any };
+  let investmentsService: { getPortfolioValue: any; getPortfolioValueAsOf: any };
 
   const draftRow = { id: 'snap-1', userId: 'user-1', snapshotMonth: '2026-06-01', status: 'draft' };
 
@@ -40,19 +41,17 @@ describe('MonthlyCloseService', () => {
     };
 
     notificationsService = { createAndDispatch: vi.fn().mockResolvedValue({}) };
+    investmentsService = {
+      getPortfolioValue: vi.fn().mockResolvedValue({ totalCents: 0, holdings: [], staleFound: false, missingPriceFound: false }),
+      getPortfolioValueAsOf: vi.fn().mockResolvedValue({ totalCents: 0, holdings: [], staleFound: false, missingPriceFound: false }),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         MonthlyCloseService,
         { provide: DATABASE_CONNECTION, useValue: mockDb },
         { provide: ManualAssetsService, useValue: { findAll: vi.fn().mockResolvedValue([]) } },
-        {
-          provide: InvestmentsService,
-          useValue: {
-            getPortfolioValue: vi.fn().mockResolvedValue({ totalCents: 0, holdings: [], staleFound: false, missingPriceFound: false }),
-            getPortfolioValueAsOf: vi.fn().mockResolvedValue({ totalCents: 0, holdings: [], staleFound: false, missingPriceFound: false }),
-          },
-        },
+        { provide: InvestmentsService, useValue: investmentsService },
         { provide: LoansService, useValue: { getBalanceForMonth: vi.fn() } },
         { provide: NotificationsService, useValue: notificationsService },
       ],
@@ -67,12 +66,42 @@ describe('MonthlyCloseService', () => {
       expect(input.month).toBe('2026-06-01');
       expect(input.takeHomeIncomeCents).toBe(0);
       expect(input.transactions).toEqual([]);
-      expect(input.freshness).toEqual({ missingManualAssets: [], staleAccounts: [], unverifiedLoans: [] });
+      expect(input.freshness).toEqual({
+        missingManualAssets: [],
+        staleAccounts: [],
+        unverifiedLoans: [],
+        missingInvestmentPrices: [],
+      });
 
       const saved = await service.draft('user-1', '2026-06');
       expect(saved).toEqual(draftRow);
       // No existing row (select resolves []) -> insert path, not update.
       expect(mockDb.insert).toHaveBeenCalledWith(expect.anything());
+    });
+
+    it('flags missingInvestmentPrices instead of silently zeroing the total when a held ticker has no price for the month (#213)', async () => {
+      (investmentsService.getPortfolioValueAsOf as any).mockResolvedValue({
+        totalCents: 0,
+        holdings: [
+          {
+            investmentAccountId: 'acct-inv',
+            ticker: 'VTI',
+            shareCount: '10',
+            asOf: '2026-06-30',
+            isStale: false,
+            priceDate: null,
+            closeCents: null,
+            marketValueCents: null,
+          },
+        ],
+        staleFound: false,
+        missingPriceFound: true,
+        staleDays: 10,
+      });
+
+      const input = await service.gatherInputs('user-1', '2026-06');
+      expect(input.investmentAssetCents).toBe(0);
+      expect(input.freshness.missingInvestmentPrices).toEqual(['VTI']);
     });
   });
 

--- a/apps/api/src/monthly-close/ai-monthly-review.service.ts
+++ b/apps/api/src/monthly-close/ai-monthly-review.service.ts
@@ -164,6 +164,7 @@ export class AiMonthlyReviewService {
         ...(freshness.missingManualAssets ?? []),
         ...(freshness.staleAccounts ?? []),
         ...(freshness.unverifiedLoans ?? []),
+        ...(freshness.missingInvestmentPrices ?? []),
       ];
       bullets.push(
         `[${INCOMPLETE_CLOSE_CAVEAT_MARKER}] This close is missing or has stale data (${gaps.length} item(s)) — the figures below are provisional until it's completed.`,

--- a/apps/api/src/monthly-close/monthly-close-calculator.ts
+++ b/apps/api/src/monthly-close/monthly-close-calculator.ts
@@ -64,6 +64,10 @@ export interface MonthlyCloseFreshnessInput {
   missingManualAssets: string[];
   staleAccounts: string[];
   unverifiedLoans: string[];
+  /** Tickers held this month with no security_prices row on or before month-end
+   *  (issue #213): investmentAssetCents undercounts these holdings' value, so the
+   *  month is flagged incomplete rather than silently persisting a low total. */
+  missingInvestmentPrices: string[];
 }
 
 export interface MonthlyCloseCalculatorInput {
@@ -348,7 +352,8 @@ export function calculateMonthlyClose(
   const isComplete =
     input.freshness.missingManualAssets.length === 0 &&
     input.freshness.staleAccounts.length === 0 &&
-    input.freshness.unverifiedLoans.length === 0;
+    input.freshness.unverifiedLoans.length === 0 &&
+    input.freshness.missingInvestmentPrices.length === 0;
 
   return {
     month: input.month,

--- a/apps/api/src/monthly-close/monthly-close.service.ts
+++ b/apps/api/src/monthly-close/monthly-close.service.ts
@@ -305,6 +305,13 @@ export class MonthlyCloseService {
     // holdings/market prices. ──
     const portfolio = await this.investmentsService.getPortfolioValueAsOf(userId, lastDay);
     let investmentAssetCents = regularInvestmentAssetCents;
+    // Holdings with no security_prices row on or before month-end contribute
+    // marketValueCents: null and are excluded from portfolio.totalCents — flag
+    // them so the month is surfaced as incomplete instead of silently persisting
+    // an undercounted total (issue #213).
+    const missingInvestmentPrices: string[] = portfolio.holdings
+      .filter((h: any) => h.marketValueCents === null)
+      .map((h: any) => h.ticker);
     if (portfolio.holdings.length > 0) {
       investmentAssetCents += portfolio.totalCents;
     } else {
@@ -366,7 +373,7 @@ export class MonthlyCloseService {
       emergencyFundMonths,
       hasHighInterestDebt: false,
       employerMatch: { available: false, captured: null },
-      freshness: { missingManualAssets, staleAccounts, unverifiedLoans },
+      freshness: { missingManualAssets, staleAccounts, unverifiedLoans, missingInvestmentPrices },
     };
   }
 

--- a/apps/mcp-server/src/tools/get-monthly-close.ts
+++ b/apps/mcp-server/src/tools/get-monthly-close.ts
@@ -64,7 +64,7 @@ export function registerGetMonthlyClose(server: McpServer) {
         `  Close complete: ${freshness.isComplete ? 'yes' : 'NO — missing/stale data present'}`,
         freshness.isComplete
           ? undefined
-          : `  Freshness gaps: missing manual assets [${(freshness.missingManualAssets ?? []).join(', ')}], stale accounts [${(freshness.staleAccounts ?? []).length}], unverified loans [${(freshness.unverifiedLoans ?? []).join(', ')}]`,
+          : `  Freshness gaps: missing manual assets [${(freshness.missingManualAssets ?? []).join(', ')}], stale accounts [${(freshness.staleAccounts ?? []).length}], unverified loans [${(freshness.unverifiedLoans ?? []).join(', ')}], missing investment prices [${(freshness.missingInvestmentPrices ?? []).join(', ')}]`,
       ]
         .filter(Boolean)
         .join('\n');

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -628,6 +628,7 @@ export interface MonthlyCloseSummary {
     missingManualAssets: string[];
     staleAccounts: string[];
     unverifiedLoans: string[];
+    missingInvestmentPrices: string[];
   };
   notes: string | null;
   aiReview: string | null;


### PR DESCRIPTION
Committed successfully.

## Summary

`MonthlyCloseService.gatherInputs` only checked `portfolio.holdings.length > 0` before adding `portfolio.totalCents` to the month's investment total, and suppressing the manual `investment_snapshots` fallback per decision #2. It never read the `missingPriceFound` flag that `getPortfolioValueAsOf` already computes for holdings with no `security_prices` row on/before the as-of date — so a month with holdings but missing price history (most likely for historical backfilled months predating EOD ingestion) would silently persist an undercounted total instead of surfacing the gap.

**Fix**: extended the existing freshness/`isComplete` mechanism (decision #11) with a new `missingInvestmentPrices` field. `gatherInputs` now collects the tickers whose `marketValueCents` came back `null` and includes them in the freshness payload, so `calculateMonthlyClose` marks the month incomplete instead of quietly presenting a low total as final. Also threaded the new field through the AI monthly-review fallback caveat text and the `get_monthly_close` MCP tool's freshness-gaps summary, and updated the shared `MonthlyCloseSummary` type accordingly.

Verified by adding/extending unit tests in the calculator and service test suites (synthetic ticker literals, no real data) confirming: (1) `isComplete` flips to `false` when `missingInvestmentPrices` is non-empty, and (2) `gatherInputs` populates the field correctly when a mocked `getPortfolioValueAsOf` result includes a holding with `marketValueCents: null`. Full API test suite (869 tests) and web test suite pass; `tsc --noEmit` clean on both `apps/api` and `apps/mcp-server`.

---
### Test evidence
**2 new test case(s) added** (heuristic count):
```
 .../__tests__/monthly-close-calculator.spec.ts     | 19 ++++++++-
 .../__tests__/monthly-close.service.spec.ts        | 45 ++++++++++++++++++----
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
2m6 tests[22m[2m)[22m[32m 5[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/transactions/__tests__/business-date.spec.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/categorization/__tests__/learning.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/next-loan-due-date.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test: [32m[Nest] 62910  - [39m08/01/2026, 11:31:30 AM [32m    LOG[39m [38;5;3m[AlertCronProcessor] [39m[32mProcessing alert job: monthly-close-auto-draft[39m
@moneypulse/api:test: [32m[Nest] 62910  - [39m08/01/2026, 11:31:30 AM [32m    LOG[39m [38;5;3m[AlertCronProcessor] [39m[32mMonthly-close auto-draft: 3 user(s) processed, 2 close(s) created[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/monthly-close-cron.spec.ts [2m([22m[2m1 test[22m[2m)[22m[32m 4[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m100 passed[39m[22m[90m (100)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m869 passed[39m[22m[90m (869)[39m
@moneypulse/api:test: [2m   Start at [22m 11:31:19
@moneypulse/api:test: [2m   Duration [22m 10.80s[2m (transform 3.22s, setup 0ms, import 56.88s, tests 1.96s, environment 6ms)[22m
@moneypulse/api:test: 

 Tasks:    3 successful, 3 total
Cached:    0 cached, 3 total
  Time:    12.193s
```
</details>

### Review
**Review verdict:** approve

---
Dispatched via coxd (`MyMoney-monthly-close-investment-tot-1785583610`) · cost $1.457 · 🤖 coxd