### PR TITLE
Digests + advisor/coach notifications never reach Telegram/Home Assist

### DIFF
--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -92,6 +92,18 @@ export const notificationTypeEnum = pgEnum('notification_type', [
   'advisor_insight',
   'system_alert',
   'daily_brief',
+  // 40.x digests + advisor/coach notifications (#223) — cron- or event-delivered
+  // once each; must route through their own preference (not the generic
+  // system_alert default) so they can reach Telegram/HA per DEFAULT_PREFERENCES.
+  'digest',
+  'advisor_digest',
+  'advisor_review',
+  'bill_overdue',
+  'benchmark_rate_move',
+  'idle_cash',
+  'investment_coach_contribution',
+  'savings_coach',
+  'monthly_close_freshness_nudge',
 ]);
 export const notificationModeEnum = pgEnum('notification_mode', [
   'instant',

--- a/apps/api/src/notifications/notification-preferences.service.spec.ts
+++ b/apps/api/src/notifications/notification-preferences.service.spec.ts
@@ -1,0 +1,101 @@
+import fs from 'fs';
+import path from 'path';
+import { eq } from 'drizzle-orm';
+import * as schema from '../db/schema';
+import {
+  NotificationPreferencesService,
+  NOTIFICATION_TYPES,
+} from './notification-preferences.service';
+
+describe('NOTIFICATION_TYPES regression guard (#223)', () => {
+  it('the notification_type enum, DEFAULT_PREFERENCES, and NOTIFICATION_TYPES are all in sync', () => {
+    const enumValues = [...schema.notificationTypeEnum.enumValues].sort();
+    const defaultPrefKeys = [...NOTIFICATION_TYPES].sort();
+
+    expect(defaultPrefKeys).toEqual(enumValues);
+  });
+
+  // #223's nine digest/advisor/coach notification types (see PR description), keyed by
+  // the source file that dispatches them. This is a static guard scoped to those call
+  // sites specifically: it fails if any of them regresses (type string edited, or the
+  // enum/DEFAULT_PREFERENCES entry removed) without checking *every* notification type
+  // in the codebase — many pre-existing types (e.g. 'spending_anomaly', 'budget_alert')
+  // were never routed through the preference/channel system and are out of scope here
+  // (see issue's "Out of scope" section).
+  const DIGEST_ADVISOR_COACH_CALL_SITES: Array<{ file: string; type: string }> = [
+    { file: 'analytics/digest.service.ts', type: 'digest' },
+    { file: 'advisor/digest/advisor-digest.service.ts', type: 'advisor_digest' },
+    { file: 'advisor/review/advisor-review.service.ts', type: 'advisor_review' },
+    { file: 'bills/bills.service.ts', type: 'bill_overdue' },
+    { file: 'recommendations/cash-manager.service.ts', type: 'benchmark_rate_move' },
+    { file: 'recommendations/cash-manager.service.ts', type: 'idle_cash' },
+    { file: 'recommendations/investment-coach.service.ts', type: 'investment_coach_contribution' },
+    { file: 'recommendations/savings-coach.service.ts', type: 'savings_coach' },
+    { file: 'monthly-close/monthly-close.service.ts', type: 'monthly_close_freshness_nudge' },
+  ];
+
+  it('every #223 digest/advisor/coach type is registered in the enum, in DEFAULT_PREFERENCES, and still referenced by its dispatching source file', () => {
+    const srcRoot = path.join(__dirname, '..');
+    const registered = new Set(schema.notificationTypeEnum.enumValues as readonly string[]);
+    const defaultPrefTypes = new Set(NOTIFICATION_TYPES as readonly string[]);
+
+    for (const { file, type } of DIGEST_ADVISOR_COACH_CALL_SITES) {
+      expect(registered.has(type), `${type} missing from notification_type enum`).toBe(true);
+      expect(defaultPrefTypes.has(type), `${type} missing from DEFAULT_PREFERENCES`).toBe(true);
+
+      const content = fs.readFileSync(path.join(srcRoot, file), 'utf-8');
+      expect(
+        content.includes(`'${type}'`),
+        `expected ${file} to still reference '${type}'`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe('NotificationPreferencesService.getPreference — unregistered type fallback (#223)', () => {
+  let mockDb: any;
+  let service: NotificationPreferencesService;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockDb = {
+      select: vi.fn(),
+    };
+    service = new NotificationPreferencesService(mockDb);
+    warnSpy = vi.spyOn((service as any).logger, 'warn').mockImplementation(() => {});
+  });
+
+  it('falls back to a safe in-app-only default and logs a warning for an unregistered type, without querying the DB', async () => {
+    const pref = await service.getPreference('user-1', 'not_a_real_type' as any);
+
+    expect(pref.mode).toBe('instant');
+    expect(pref.enabledChannels).toEqual(['inApp']);
+    expect(mockDb.select).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('not_a_real_type'));
+  });
+
+  it('a registered type (e.g. digest) resolves via DEFAULT_PREFERENCES with telegram + haWebhook enabled', async () => {
+    const limitMock = vi.fn().mockResolvedValue([]);
+    const whereMock = vi.fn().mockReturnValue({ limit: limitMock });
+    const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+    mockDb.select.mockReturnValue({ from: fromMock });
+
+    const pref = await service.getPreference('user-1', 'digest' as any);
+
+    expect(pref.mode).toBe('instant');
+    expect(pref.enabledChannels).toEqual(['inApp', 'telegram', 'haWebhook']);
+    expect(mockDb.select).toHaveBeenCalled();
+  });
+
+  it('falls back gracefully (never throws) if the DB query itself errors on a registered type', async () => {
+    mockDb.select.mockImplementation(() => {
+      throw new Error('invalid input value for enum notification_type');
+    });
+
+    const pref = await service.getPreference('user-1', 'digest' as any);
+
+    expect(pref.mode).toBe('instant');
+    expect(pref.enabledChannels).toEqual(['inApp']);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/notifications/notification-preferences.service.ts
+++ b/apps/api/src/notifications/notification-preferences.service.ts
@@ -36,7 +36,26 @@ const DEFAULT_PREFERENCES: Record<NotificationType, {
   // The brief message itself always dispatches "instant" (at the user's configured hour) —
   // it IS the batched delivery, so it must never be re-deferred into another brief.
   daily_brief: { mode: 'instant', enabledChannels: ['inApp', 'telegram', 'webPush'] },
+
+  // #223: digests + advisor/coach notifications. These are all cron- or
+  // event-delivered once (a daily/weekly/monthly digest, a weekly advisor recap, a
+  // one-off coach nudge, etc.) — same reasoning as daily_brief above, they must
+  // dispatch "instant" and never be re-deferred into a brief. The user has asked
+  // for all alerts to also reach Home Assistant, so haWebhook is enabled by default
+  // alongside inApp + telegram.
+  digest: { mode: 'instant', enabledChannels: ['inApp', 'telegram', 'haWebhook'] },
+  advisor_digest: { mode: 'instant', enabledChannels: ['inApp', 'telegram', 'haWebhook'] },
+  advisor_review: { mode: 'instant', enabledChannels: ['inApp', 'telegram', 'haWebhook'] },
+  bill_overdue: { mode: 'instant', enabledChannels: ['inApp', 'telegram', 'haWebhook'] },
+  benchmark_rate_move: { mode: 'instant', enabledChannels: ['inApp', 'telegram', 'haWebhook'] },
+  idle_cash: { mode: 'instant', enabledChannels: ['inApp', 'telegram', 'haWebhook'] },
+  investment_coach_contribution: { mode: 'instant', enabledChannels: ['inApp', 'telegram', 'haWebhook'] },
+  savings_coach: { mode: 'instant', enabledChannels: ['inApp', 'telegram', 'haWebhook'] },
+  monthly_close_freshness_nudge: { mode: 'instant', enabledChannels: ['inApp', 'telegram', 'haWebhook'] },
 };
+
+/** Source-of-truth list of all registered notification types (mirrors the DB enum). */
+export const NOTIFICATION_TYPES = Object.keys(DEFAULT_PREFERENCES) as NotificationType[];
 
 @Injectable()
 export class NotificationPreferencesService {
@@ -93,29 +112,82 @@ export class NotificationPreferencesService {
     userId: string,
     notificationType: NotificationType,
   ): Promise<NotificationPreference> {
-    const rows = await this.db
-      .select()
-      .from(schema.notificationPreferences)
-      .where(
-        and(
-          eq(schema.notificationPreferences.userId, userId),
-          eq(schema.notificationPreferences.notificationType, notificationType),
-        ),
-      )
-      .limit(1);
+    // Guard the enum-comparison query: an unregistered/unseeded type would make
+    // Postgres reject `notification_type = '<type>'` (invalid enum input), which —
+    // upstream, inside dispatch()'s try/catch — used to be swallowed into total
+    // silence (in-app row created, but zero routing to Telegram/HA, no log at all).
+    // Validate against the known set *before* querying so a bad type degrades
+    // loudly and gracefully instead of throwing.
+    const isRegistered = (schema.notificationTypeEnum.enumValues as readonly string[]).includes(
+      notificationType,
+    );
+
+    if (!isRegistered) {
+      this.logger.warn(
+        `Notification type "${notificationType}" is not registered in the notification_type ` +
+          `enum / DEFAULT_PREFERENCES — falling back to in-app-only delivery. Register it in ` +
+          `db/schema.ts + a migration + DEFAULT_PREFERENCES to restore Telegram/HA routing.`,
+      );
+      return {
+        id: '',
+        userId,
+        notificationType,
+        mode: 'instant',
+        enabledChannels: ['inApp'],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+    }
+
+    let rows: any[];
+    try {
+      rows = await this.db
+        .select()
+        .from(schema.notificationPreferences)
+        .where(
+          and(
+            eq(schema.notificationPreferences.userId, userId),
+            eq(schema.notificationPreferences.notificationType, notificationType),
+          ),
+        )
+        .limit(1);
+    } catch (err) {
+      // Defense in depth: even a registered type could hit an unexpected DB error
+      // (e.g. enum drift between app + DB). Never let this throw out of dispatch().
+      this.logger.warn(
+        `Failed to load notification preference for type "${notificationType}": ` +
+          `${(err as Error).message} — falling back to in-app-only delivery.`,
+      );
+      return {
+        id: '',
+        userId,
+        notificationType,
+        mode: 'instant',
+        enabledChannels: ['inApp'],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+    }
 
     if (rows.length > 0) {
       return rows[0];
     }
 
-    // Return default
+    // Return default. `defaults` should always exist for a registered enum value, but
+    // guard against enum/DEFAULT_PREFERENCES drift rather than throwing on undefined.
     const defaults = DEFAULT_PREFERENCES[notificationType];
+    if (!defaults) {
+      this.logger.warn(
+        `Notification type "${notificationType}" is in the notification_type enum but has ` +
+          `no DEFAULT_PREFERENCES entry — falling back to in-app-only delivery.`,
+      );
+    }
     return {
       id: '', // Will be created on first update
       userId,
       notificationType,
-      mode: defaults.mode,
-      enabledChannels: defaults.enabledChannels,
+      mode: defaults?.mode ?? 'instant',
+      enabledChannels: defaults?.enabledChannels ?? ['inApp'],
       createdAt: new Date(),
       updatedAt: new Date(),
     };

--- a/apps/api/src/notifications/notifications.service.spec.ts
+++ b/apps/api/src/notifications/notifications.service.spec.ts
@@ -337,6 +337,45 @@ describe('NotificationsService', () => {
       // already the once-a-day batched delivery, not a candidate for further batching.
       expect(mockTelegramPush.sendToUser).toHaveBeenCalled();
     });
+
+    // #223: digest/advisor/coach notifications must route through their own
+    // per-type preference (haWebhook + telegram enabled) rather than silently
+    // collapsing onto the generic system_alert (in-app only) default.
+    it('routes a digest notification to the Home Assistant webhook when the type is not overridden', async () => {
+      mockPreferences.getPreference.mockResolvedValue({
+        id: 'pref-digest',
+        userId: TEST_USER,
+        notificationType: 'digest',
+        mode: 'instant',
+        enabledChannels: ['inApp', 'telegram', 'haWebhook'],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+      mockDb.update = vi.fn().mockReturnValue({
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+      mockWebhookService.sendWebhook.mockResolvedValue(true);
+
+      await service.createAndDispatch({
+        userId: TEST_USER,
+        type: 'digest',
+        title: 'Your weekly digest',
+        message: 'Here is what happened this week.',
+      });
+
+      // Give dispatch async a tick to settle
+      await new Promise((r) => setTimeout(r, 10));
+
+      // The preference lookup must key off the notification's own type ('digest'),
+      // not a hardcoded generic fallback.
+      expect(mockPreferences.getPreference).toHaveBeenCalledWith(TEST_USER, 'digest');
+      expect(mockWebhookService.sendWebhook).toHaveBeenCalledWith(
+        TEST_USER,
+        expect.objectContaining({ title: 'Your weekly digest', type: 'digest' }),
+      );
+    });
   });
 
   describe('getUnbriefedInsights / markBriefed', () => {

--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -326,8 +326,14 @@ export class NotificationsService {
       return notification;
     }
 
-    // Dispatch through preference-aware channels (best-effort, never blocks domain write)
-    void this.dispatch(notification.id, input.userId, input.notificationType ?? 'system_alert', {
+    // Dispatch through preference-aware channels (best-effort, never blocks domain write).
+    // Default the preference lookup key to the notification's own `type` (rather than a
+    // fixed 'system_alert') so each dispatched type routes through its own per-type
+    // preference (mode + channels) — see #223: previously every type without an explicit
+    // `notificationType` override silently collapsed onto the generic system_alert
+    // preference (in-app only), so digests/advisor/coach notifications never reached
+    // Telegram/HA even once their type existed in the DB enum.
+    void this.dispatch(notification.id, input.userId, input.notificationType ?? input.type, {
       title: input.title,
       message: input.message,
       voiceSummary: input.voiceSummary,

--- a/apps/api/src/recommendations/__tests__/cash-manager.service.spec.ts
+++ b/apps/api/src/recommendations/__tests__/cash-manager.service.spec.ts
@@ -239,7 +239,10 @@ describe('CashManagerService — notifyBenchmarkRateMove (market_event)', () => 
     expect(notifications.createAndDispatch).toHaveBeenCalledTimes(1);
     const payload = notifications.createAndDispatch.mock.calls[0][0];
     expect(payload.userId).toBe('user-1');
-    expect(payload.notificationType).toBe('market_event');
+    // #223: routes through its own 'benchmark_rate_move' preference (default
+    // instant + inApp/telegram/haWebhook) rather than 'market_event', whose
+    // DEFAULT_PREFERENCES mode is 'off' and was suppressing delivery entirely.
+    expect(payload.notificationType).toBe('benchmark_rate_move');
     expect(payload.message).toContain('32bps');
     expect(payload.message).toContain('4.50%');
     expect(payload.message).toContain('4.82%');

--- a/apps/api/src/recommendations/cash-manager.service.ts
+++ b/apps/api/src/recommendations/cash-manager.service.ts
@@ -147,7 +147,11 @@ export class CashManagerService {
         await this.notificationsService.createAndDispatch({
           userId: user.id,
           type: 'benchmark_rate_move',
-          notificationType: 'market_event',
+          // #223: route through its own 'benchmark_rate_move' preference (instant +
+          // inApp/telegram/haWebhook by default) rather than 'market_event', whose
+          // DEFAULT_PREFERENCES mode is 'off' — that was silently suppressing every
+          // benchmark-rate-move alert end-to-end (in-app included).
+          notificationType: 'benchmark_rate_move',
           source: 'market',
           severity: 'insight',
           title: `${BENCHMARK_RATE_METRIC_LABEL} moved ${move.deltaBps}bps`,

--- a/db/migrations/0033_notification_type_digest_advisor_coach.sql
+++ b/db/migrations/0033_notification_type_digest_advisor_coach.sql
@@ -1,0 +1,56 @@
+-- #223: digests + advisor/coach notifications never reach Telegram/Home Assistant.
+--
+-- Nine notification types are dispatched via NotificationsService.createAndDispatch
+-- but are missing from the notification_type enum, so the preference lookup in
+-- dispatch() throws (swallowed by its try/catch) and the notification is delivered
+-- in-app only. This registers the nine missing values.
+--
+-- NOTE: this repo's migrator (drizzle-orm's `migrate()`) runs ALL pending migration
+-- files inside a single wrapping transaction, and `ALTER TYPE ... ADD VALUE` is not
+-- safe to rely on inside any transaction block that a migration runner controls (in
+-- older Postgres it's outright forbidden in a transaction block at all; even where
+-- allowed, the new value can't be used later in that same transaction, and a runner
+-- can silently batch further migrations into the same transaction). To stay
+-- transaction-safe regardless of Postgres version or how the migrator batches
+-- files, we rebuild the enum type instead of appending to it in place (same
+-- approach as 0022_paycheck_new_account_types.sql):
+--   1. rename the existing type out of the way
+--   2. create a new type with the full value set (old + new)
+--   3. repoint the column(s) at the new type
+--   4. drop the old type
+-- This is fully transactional and idempotent-safe to re-run (guarded checks below).
+DO $$ BEGIN
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'notification_type_old') THEN
+    RAISE NOTICE 'notification_type_old already exists — migration already applied, skipping';
+  ELSE
+    ALTER TYPE "public"."notification_type" RENAME TO "notification_type_old";
+
+    CREATE TYPE "public"."notification_type" AS ENUM (
+      'loan_payment_due',
+      'loan_payment_missed',
+      'bill_due',
+      'budget_overage',
+      'anomaly_detected',
+      'data_freshness',
+      'market_event',
+      'advisor_insight',
+      'system_alert',
+      'daily_brief',
+      'digest',
+      'advisor_digest',
+      'advisor_review',
+      'bill_overdue',
+      'benchmark_rate_move',
+      'idle_cash',
+      'investment_coach_contribution',
+      'savings_coach',
+      'monthly_close_freshness_nudge'
+    );
+
+    ALTER TABLE "notification_preferences"
+      ALTER COLUMN "notification_type" TYPE "public"."notification_type"
+      USING "notification_type"::text::"public"."notification_type";
+
+    DROP TYPE "public"."notification_type_old";
+  END IF;
+END $$;

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1784561000000,
       "tag": "0032_account_annual_fee",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1784561100000,
+      "tag": "0033_notification_type_digest_advisor_coach",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Commit created successfully with pre-commit hooks passing.

## Summary

Root cause: nine notification types (`digest`, `advisor_digest`, `advisor_review`, `bill_overdue`, `benchmark_rate_move`, `idle_cash`, `investment_coach_contribution`, `savings_coach`, `monthly_close_freshness_nudge`) were dispatched via `NotificationsService.createAndDispatch` but were absent from the `notification_type` Postgres enum and `DEFAULT_PREFERENCES`. Since `dispatch()` swallows all errors, these notifications were created in-app but never routed to Telegram/Home Assistant. Separately, `dispatch()`'s preference lookup defaulted to a hardcoded `'system_alert'` key whenever a caller didn't set `notificationType`, which — even once types are registered — would keep routing them through the generic (in-app-only) preference instead of their own; and the `benchmark_rate_move` alert was explicitly pinned to the `market_event` preference, whose default mode is `off`, suppressing it entirely.

Fix:
1. **Migration** (`db/migrations/0033_...sql`, registered in `_journal.json`): rebuilds the `notification_type` enum (rename → recreate → repoint column → drop old) rather than using `ALTER TYPE ... ADD VALUE`, since this repo's migrator wraps all pending files in one transaction and that statement isn't safe there — matches the existing pattern used for `account_type` in migration 0022.
2. **`DEFAULT_PREFERENCES`**: added the nine types with `mode: 'instant'` and `enabledChannels: ['inApp', 'telegram', 'haWebhook']`.
3. **`dispatch()`**: now keys the preference lookup off `input.notificationType ?? input.type` instead of a fixed `'system_alert'` fallback, so each type routes through its own preference by default. Repointed the `benchmark_rate_move` call site to its own preference instead of the suppressed `market_event` one.
4. **`getPreference()`**: validates the type against the known enum before querying and wraps the query in try/catch; an unregistered type (or an unexpected DB error) now logs

_(summary truncated)_

---
### Test evidence
**6 new test case(s) added** (heuristic count):
```
 .../notification-preferences.service.spec.ts       | 101 +++++++++++++++++++++
 .../notifications/notifications.service.spec.ts    |  39 ++++++++
 .../__tests__/cash-manager.service.spec.ts         |   5 +-
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
s/__tests__/suitability-gate.spec.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 7[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/ai-logs/__tests__/model-pricing.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 5[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/suitability-settings/__tests__/suitability-settings.service.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 6[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/notifications/notifications.controller.spec.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 4[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/car-affordability/__tests__/car-affordability.controller.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/transactions/__tests__/business-date.spec.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/categorization/__tests__/learning.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m101 passed[39m[22m[90m (101)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m873 passed[39m[22m[90m (873)[39m
@moneypulse/api:test: [2m   Start at [22m 11:34:32
@moneypulse/api:test: [2m   Duration [22m 10.71s[2m (transform 3.33s, setup 0ms, import 56.71s, tests 2.41s, environment 7ms)[22m
@moneypulse/api:test: 

 Tasks:    2 successful, 2 total
Cached:    1 cached, 2 total
  Time:    11.189s
```
</details>

### Review
**Review verdict:** approve

Findings (advisory — did not block landing):
- [low/advisory] db/migrations/0033_notification_type_digest_advisor_coach.sql:49 — The enum rebuild only repoints notification_preferences.notification_type; if any other table/column ever adopts the notification_type enum, DROP TYPE notification_type_old will fail on dependency. Diff evidence (pre-existing insert of unregistered type 'benchmark_rate_move' into notifications.type) indicates only notification_preferences uses the enum, so this is fine today — worth a comment to protect future changes.

---
Dispatched via coxd (`MyMoney-digests-advisor-coach-notifi-1785583608`) · cost $2.191 · 🤖 coxd