### PR TITLE
Add GET /settings/setup-progress setup-completeness API (#225)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -33,6 +33,7 @@ import { RateWatchlistModule } from './rate-watchlist/rate-watchlist.module';
 import { SuitabilitySettingsModule } from './suitability-settings/suitability-settings.module';
 import { ManualAssetsModule } from './monthly-close/manual-assets.module';
 import { MonthlyCloseModule } from './monthly-close/monthly-close.module';
+import { SettingsModule } from './settings/settings.module';
 
 @Module({
   imports: [
@@ -87,6 +88,7 @@ import { MonthlyCloseModule } from './monthly-close/monthly-close.module';
     SuitabilitySettingsModule,
     ManualAssetsModule,
     MonthlyCloseModule,
+    SettingsModule,
     HealthModule,
   ],
   providers: [

--- a/apps/api/src/settings/__tests__/setup-progress.service.spec.ts
+++ b/apps/api/src/settings/__tests__/setup-progress.service.spec.ts
@@ -1,0 +1,146 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { describe, it, expect, vi } from 'vitest';
+import { SetupProgressService } from '../setup-progress.service';
+import { DATABASE_CONNECTION } from '../../db/db.module';
+
+const TEST_USER_ID = 'test-user-id';
+
+/**
+ * Builds a chainable, awaitable query-result stub matching how the service
+ * calls the mocked db: `select().from(x)`, `select().from(x).where(y)`, or
+ * `select().from(x).innerJoin(y).where(z)`. Each resolves to `rows`.
+ */
+function makeChain(rows: unknown[]) {
+  const promise = Promise.resolve(rows);
+  const chain: any = {
+    from: () => chain,
+    innerJoin: () => chain,
+    where: () => promise,
+    then: promise.then.bind(promise),
+    catch: promise.catch.bind(promise),
+  };
+  return chain;
+}
+
+/**
+ * Queries are issued (via Promise.all) in this fixed order inside the service:
+ * accounts, fileUploads, paycheckProfiles, userSettings, advisorSettings,
+ * suitabilitySettings, loans, loanBalanceSnapshots, investmentAccounts,
+ * investmentHoldings, investmentSnapshots, manualAssets,
+ * notificationPreferences, pushSubscriptions.
+ */
+function mockDbWith(rowsInOrder: unknown[][]) {
+  let call = 0;
+  return {
+    select: vi.fn().mockImplementation(() => makeChain(rowsInOrder[call++] ?? [])),
+  };
+}
+
+const emptyRows = () => Array.from({ length: 14 }, () => [] as unknown[]);
+
+describe('SetupProgressService', () => {
+  let service: SetupProgressService;
+
+  async function build(mockDb: any) {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SetupProgressService,
+        { provide: DATABASE_CONNECTION, useValue: mockDb },
+      ],
+    }).compile();
+    return module.get<SetupProgressService>(SetupProgressService);
+  }
+
+  it('is defined', async () => {
+    service = await build(mockDbWith(emptyRows()));
+    expect(service).toBeDefined();
+  });
+
+  it('returns 0% with no data, still listing the advisor step as server-config', async () => {
+    service = await build(mockDbWith(emptyRows()));
+    const result = await service.getSetupProgress(TEST_USER_ID);
+
+    expect(result.completed).toBe(0);
+    // 9 always-applicable user-data steps (accounts, import, paycheck, digest,
+    // suitability, loans, investments, manual_assets, notifications); the three
+    // conditional steps are excluded since the user has no loans/investments/cc.
+    expect(result.total).toBe(9);
+    expect(result.percent).toBe(0);
+
+    const advisorStep = result.steps.find((s) => s.id === 'advisor');
+    expect(advisorStep).toMatchObject({ kind: 'server-config', done: false });
+
+    const loanBalances = result.steps.find((s) => s.id === 'loan_balances');
+    expect(loanBalances?.done).toBe(false);
+  });
+
+  it('excludes loan_balances from the denominator unless the user has a loan, and includes it once they do', async () => {
+    const rows = emptyRows();
+    rows[6] = [{ id: 'loan-1' }]; // loans
+
+    service = await build(mockDbWith(rows));
+    const result = await service.getSetupProgress(TEST_USER_ID);
+
+    // 9 base + loans-conditional loan_balances now applicable = 10
+    expect(result.total).toBe(10);
+    const loansStep = result.steps.find((s) => s.id === 'loans');
+    expect(loansStep?.done).toBe(true);
+    const loanBalancesStep = result.steps.find((s) => s.id === 'loan_balances');
+    expect(loanBalancesStep?.done).toBe(false);
+    expect(result.completed).toBe(1); // only `loans` is done
+  });
+
+  it('counts holdings only once the user has an investment account, and cc_fees only once they have a credit card', async () => {
+    const rows = emptyRows();
+    rows[8] = [{ id: 'inv-1' }]; // investmentAccounts
+    rows[9] = [{ id: 'holding-1' }]; // investmentHoldings
+
+    service = await build(mockDbWith(rows));
+    const result = await service.getSetupProgress(TEST_USER_ID);
+
+    const holdingsStep = result.steps.find((s) => s.id === 'holdings');
+    expect(holdingsStep?.done).toBe(true);
+    // 9 base + investments-conditional holdings = 10; cc_fees stays excluded (no cc account)
+    expect(result.total).toBe(10);
+
+    const ccFeesStep = result.steps.find((s) => s.id === 'cc_fees');
+    expect(ccFeesStep?.done).toBe(false);
+  });
+
+  it('computes percent from user-data steps only, even when the server-config advisor step is configured', async () => {
+    const rows = emptyRows();
+    rows[0] = [{ id: 'acc-1', accountType: 'checking', annualFeeCents: null }]; // accounts
+    rows[4] = [{ id: 1, apiKeyCiphertext: 'ciphertext' }]; // advisorSettings
+
+    service = await build(mockDbWith(rows));
+    const result = await service.getSetupProgress(TEST_USER_ID);
+
+    const advisorStep = result.steps.find((s) => s.id === 'advisor');
+    expect(advisorStep?.done).toBe(true);
+
+    // Only `accounts` (1 of 9 always-applicable user-data steps) is done;
+    // the configured advisor step must not inflate completed/total.
+    expect(result.total).toBe(9);
+    expect(result.completed).toBe(1);
+    expect(result.percent).toBe(Math.round((1 / 9) * 100));
+  });
+
+  it('requires an accounts-level annual fee before cc_fees counts as done', async () => {
+    const rows = emptyRows();
+    rows[0] = [{ id: 'acc-1', accountType: 'credit_card', annualFeeCents: null }];
+
+    service = await build(mockDbWith(rows));
+    const result = await service.getSetupProgress(TEST_USER_ID);
+
+    const ccFeesStep = result.steps.find((s) => s.id === 'cc_fees');
+    expect(ccFeesStep?.done).toBe(false);
+    // cc_fees is now applicable (user has a cc account) -> 10 total
+    expect(result.total).toBe(10);
+
+    rows[0] = [{ id: 'acc-1', accountType: 'credit_card', annualFeeCents: 9500 }];
+    service = await build(mockDbWith(rows));
+    const result2 = await service.getSetupProgress(TEST_USER_ID);
+    const ccFeesStep2 = result2.steps.find((s) => s.id === 'cc_fees');
+    expect(ccFeesStep2?.done).toBe(true);
+  });
+});

--- a/apps/api/src/settings/settings.module.ts
+++ b/apps/api/src/settings/settings.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { SetupProgressService } from './setup-progress.service';
+import { SetupProgressController } from './setup-progress.controller';
+
+@Module({
+  providers: [SetupProgressService],
+  controllers: [SetupProgressController],
+  exports: [SetupProgressService],
+})
+export class SettingsModule {}

--- a/apps/api/src/settings/setup-progress.controller.ts
+++ b/apps/api/src/settings/setup-progress.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import type { AuthTokenPayload } from '@moneypulse/shared';
+import { SetupProgressService } from './setup-progress.service';
+
+@ApiTags('Settings')
+@Controller('settings')
+@UseGuards(JwtAuthGuard)
+export class SetupProgressController {
+  constructor(private readonly setupProgress: SetupProgressService) {}
+
+  @Get('setup-progress')
+  @ApiOperation({ summary: "The authenticated user's setup completeness, computed on the fly" })
+  async getSetupProgress(@CurrentUser() user: AuthTokenPayload) {
+    return { data: await this.setupProgress.getSetupProgress(user.sub) };
+  }
+}

--- a/apps/api/src/settings/setup-progress.service.ts
+++ b/apps/api/src/settings/setup-progress.service.ts
@@ -1,0 +1,288 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { and, eq, sql } from 'drizzle-orm';
+import { DATABASE_CONNECTION } from '../db/db.module';
+import * as schema from '../db/schema';
+import type { SetupProgress, SetupProgressStep } from '@moneypulse/shared';
+
+/**
+ * Computes the user's setup-completeness on the fly from existing tables — no
+ * new persistence (#225, sub-issue 1/4 of the setup-tracker epic #224).
+ *
+ * `kind: 'user-data'` steps count toward `percent`'s denominator; `kind:
+ * 'server-config'` steps (API-key/env integrations, e.g. the advisor provider)
+ * are returned for the UI but excluded from the math so the bar can reach 100%.
+ *
+ * Conditional domains (`loan_balances`, `holdings`, `cc_fees`) only join the
+ * denominator once the user has at least one row in the relevant domain
+ * (a loan, an investment account, a credit-card account respectively) — a user
+ * who doesn't use a domain isn't stranded below 100%.
+ */
+@Injectable()
+export class SetupProgressService {
+  constructor(@Inject(DATABASE_CONNECTION) private readonly db: any) {}
+
+  async getSetupProgress(userId: string): Promise<SetupProgress> {
+    const [
+      activeAccounts,
+      fileUploadRows,
+      paycheckRows,
+      userSettingsRows,
+      advisorSettingsRows,
+      suitabilityRows,
+      loanRows,
+      loanBalanceRows,
+      investmentAccountRows,
+      investmentHoldingRows,
+      investmentSnapshotRows,
+      manualAssetRows,
+      notificationPrefRows,
+      pushSubRows,
+    ] = await Promise.all([
+      this.db
+        .select()
+        .from(schema.accounts)
+        .where(
+          and(
+            eq(schema.accounts.userId, userId),
+            sql`${schema.accounts.deletedAt} IS NULL`,
+          ),
+        ),
+      this.db
+        .select({ id: schema.fileUploads.id })
+        .from(schema.fileUploads)
+        .where(eq(schema.fileUploads.userId, userId)),
+      this.db
+        .select({ id: schema.paycheckProfiles.id })
+        .from(schema.paycheckProfiles)
+        .where(eq(schema.paycheckProfiles.userId, userId)),
+      this.db
+        .select()
+        .from(schema.userSettings)
+        .where(eq(schema.userSettings.userId, userId)),
+      this.db.select().from(schema.advisorSettings),
+      this.db
+        .select({ id: schema.suitabilitySettings.id })
+        .from(schema.suitabilitySettings)
+        .where(eq(schema.suitabilitySettings.userId, userId)),
+      this.db
+        .select({ id: schema.loans.id })
+        .from(schema.loans)
+        .where(eq(schema.loans.userId, userId)),
+      this.db
+        .select({ id: schema.loanBalanceSnapshots.id })
+        .from(schema.loanBalanceSnapshots)
+        .innerJoin(schema.loans, eq(schema.loanBalanceSnapshots.loanId, schema.loans.id))
+        .where(eq(schema.loans.userId, userId)),
+      this.db
+        .select({ id: schema.investmentAccounts.id })
+        .from(schema.investmentAccounts)
+        .where(
+          and(
+            eq(schema.investmentAccounts.userId, userId),
+            sql`${schema.investmentAccounts.deletedAt} IS NULL`,
+          ),
+        ),
+      this.db
+        .select({ id: schema.investmentHoldings.id })
+        .from(schema.investmentHoldings)
+        .innerJoin(
+          schema.investmentAccounts,
+          eq(schema.investmentHoldings.investmentAccountId, schema.investmentAccounts.id),
+        )
+        .where(eq(schema.investmentAccounts.userId, userId)),
+      this.db
+        .select({ id: schema.investmentSnapshots.id })
+        .from(schema.investmentSnapshots)
+        .innerJoin(
+          schema.investmentAccounts,
+          eq(schema.investmentSnapshots.investmentAccountId, schema.investmentAccounts.id),
+        )
+        .where(eq(schema.investmentAccounts.userId, userId)),
+      this.db
+        .select({ id: schema.manualAssets.id })
+        .from(schema.manualAssets)
+        .where(
+          and(
+            eq(schema.manualAssets.userId, userId),
+            sql`${schema.manualAssets.deletedAt} IS NULL`,
+          ),
+        ),
+      this.db
+        .select({ id: schema.notificationPreferences.id })
+        .from(schema.notificationPreferences)
+        .where(eq(schema.notificationPreferences.userId, userId)),
+      this.db
+        .select({ id: schema.pushSubscriptions.id })
+        .from(schema.pushSubscriptions)
+        .where(eq(schema.pushSubscriptions.userId, userId)),
+    ]);
+
+    const hasAny = (rows: unknown[]) => Array.isArray(rows) && rows.length > 0;
+
+    const userSettings = userSettingsRows?.[0];
+    const advisorSettings = advisorSettingsRows?.[0];
+
+    const creditCardAccounts = (activeAccounts ?? []).filter(
+      (a: { accountType: string }) => a.accountType === 'credit_card',
+    );
+    const hasCreditCard = creditCardAccounts.length > 0;
+    const hasLoans = hasAny(loanRows);
+    const hasInvestmentAccounts = hasAny(investmentAccountRows);
+
+    const digestDone =
+      !!userSettings?.weeklyDigestEnabled ||
+      !!userSettings?.dailyDigestEnabled ||
+      !!userSettings?.monthlyDigestEnabled;
+
+    const advisorDone = !!(
+      advisorSettings?.apiKeyCiphertext ||
+      advisorSettings?.anthropicKeyCiphertext ||
+      advisorSettings?.openaiKeyCiphertext ||
+      advisorSettings?.googleKeyCiphertext
+    );
+
+    const notificationsDone =
+      hasAny(notificationPrefRows) ||
+      hasAny(pushSubRows) ||
+      !!userSettings?.telegramNotificationsEnabled ||
+      !!userSettings?.haWebhookUrl;
+
+    const ccFeesDone =
+      hasCreditCard &&
+      creditCardAccounts.some(
+        (a: { annualFeeCents: number | null }) => a.annualFeeCents != null,
+      );
+
+    const steps: (SetupProgressStep & { applicable: boolean })[] = [
+      {
+        id: 'accounts',
+        label: 'Add your first account',
+        done: hasAny(activeAccounts),
+        unlocks: 'Overview + analytics',
+        href: '/accounts',
+        kind: 'user-data',
+        applicable: true,
+      },
+      {
+        id: 'import',
+        label: 'Import a statement',
+        done: hasAny(fileUploadRows),
+        unlocks: 'Transactions',
+        href: '/imports',
+        kind: 'user-data',
+        applicable: true,
+      },
+      {
+        id: 'paycheck',
+        label: 'Set your take-home pay',
+        done: hasAny(paycheckRows),
+        unlocks: '50/30/20 dashboard',
+        href: '/settings/paycheck-profiles',
+        kind: 'user-data',
+        applicable: true,
+      },
+      {
+        id: 'digest',
+        label: 'Enable a spending digest',
+        done: digestDone,
+        unlocks: 'Digests',
+        href: '/settings',
+        kind: 'user-data',
+        applicable: true,
+      },
+      {
+        id: 'advisor',
+        label: 'Configure the AI advisor',
+        done: advisorDone,
+        unlocks: 'AI recap + reviews',
+        href: '/settings',
+        kind: 'server-config',
+        applicable: false,
+      },
+      {
+        id: 'suitability',
+        label: 'Set your investment policy',
+        done: hasAny(suitabilityRows),
+        unlocks: 'Advisory recs',
+        href: '/settings',
+        kind: 'user-data',
+        applicable: true,
+      },
+      {
+        id: 'loans',
+        label: 'Track your loans',
+        done: hasLoans,
+        unlocks: 'Debt payoff + alerts',
+        href: '/loans',
+        kind: 'user-data',
+        applicable: true,
+      },
+      {
+        id: 'loan_balances',
+        label: 'Record a loan statement balance',
+        done: hasAny(loanBalanceRows),
+        unlocks: 'Net-worth accuracy',
+        href: '/loans',
+        kind: 'user-data',
+        applicable: hasLoans,
+      },
+      {
+        id: 'investments',
+        label: 'Add an investment account',
+        done: hasInvestmentAccounts,
+        unlocks: 'Portfolio value',
+        href: '/investments',
+        kind: 'user-data',
+        applicable: true,
+      },
+      {
+        id: 'holdings',
+        label: 'Declare holdings or a snapshot',
+        done: hasAny(investmentHoldingRows) || hasAny(investmentSnapshotRows),
+        unlocks: 'Portfolio breakdown',
+        href: '/investments',
+        kind: 'user-data',
+        applicable: hasInvestmentAccounts,
+      },
+      {
+        id: 'manual_assets',
+        label: 'Add manual assets (home/car)',
+        done: hasAny(manualAssetRows),
+        unlocks: 'Net worth',
+        href: '/health',
+        kind: 'user-data',
+        applicable: true,
+      },
+      {
+        id: 'cc_fees',
+        label: 'Set credit-card annual fees',
+        done: ccFeesDone,
+        unlocks: 'Is this card worth it',
+        href: '/accounts',
+        kind: 'user-data',
+        applicable: hasCreditCard,
+      },
+      {
+        id: 'notifications',
+        label: 'Set up a notification channel',
+        done: notificationsDone,
+        unlocks: 'Alerts',
+        href: '/settings',
+        kind: 'user-data',
+        applicable: true,
+      },
+    ];
+
+    const countable = steps.filter((s) => s.kind === 'user-data' && s.applicable);
+    const total = countable.length;
+    const completed = countable.filter((s) => s.done).length;
+    const percent = total > 0 ? Math.round((completed / total) * 100) : 0;
+
+    return {
+      percent,
+      completed,
+      total,
+      steps: steps.map(({ applicable: _applicable, ...step }) => step),
+    };
+  }
+}

--- a/packages/shared/src/validation/index.ts
+++ b/packages/shared/src/validation/index.ts
@@ -539,3 +539,30 @@ export const patchMonthlyCloseSchema = z.object({
 });
 
 export type PatchMonthlyCloseInput = z.infer<typeof patchMonthlyCloseSchema>;
+
+// ── Settings: Setup Progress (#225) ─────────────────────────
+// Response shape for `GET /settings/setup-progress` — on-the-fly setup-completeness
+// tracker. `kind: 'user-data'` steps count toward `percent`'s denominator;
+// `kind: 'server-config'` steps (API-key/env integrations) are informational only.
+
+export const setupProgressStepKindSchema = z.enum(['user-data', 'server-config']);
+
+export const setupProgressStepSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  done: z.boolean(),
+  unlocks: z.string(),
+  href: z.string(),
+  kind: setupProgressStepKindSchema,
+});
+
+export const setupProgressSchema = z.object({
+  percent: z.int().min(0).max(100),
+  completed: z.int().min(0),
+  total: z.int().min(0),
+  steps: z.array(setupProgressStepSchema),
+});
+
+export type SetupProgressStepKind = z.infer<typeof setupProgressStepKindSchema>;
+export type SetupProgressStep = z.infer<typeof setupProgressStepSchema>;
+export type SetupProgress = z.infer<typeof setupProgressSchema>;


### PR DESCRIPTION
## Summary
- Adds a read-only, JWT-guarded `GET /settings/setup-progress` endpoint that computes the authenticated user's setup completeness on the fly from 13 existing tables — no new persistence (part of the #224 setup-tracker epic, sub-issue 1/4).
- Only `kind: 'user-data'` steps count toward `percent`'s denominator; the `advisor` step is `kind: 'server-config'` (backed by the global singleton `advisor_settings` row) and is returned informationally but excluded from the math.
- Conditional domains (`loan_balances`, `holdings`, `cc_fees`) only join the denominator once the user has a loan / investment account / credit-card account respectively, so a user who doesn't use a domain isn't stranded below 100%.
- `loan_balances` uses "ever recorded" semantics (any snapshot ever, not freshness-filtered), matching the spec.
- Adds the `SetupProgress`/`SetupProgressStep` zod schemas + inferred types to `packages/shared`.
- New `settings` Nest module (service + controller), mirroring the `AccountFreshnessService` / `advisor.controller.ts` patterns, wired into `AppModule`.

## Test plan
- [x] `apps/api`: `nest build` succeeds, `eslint src/settings` clean.
- [x] `packages/shared`: `tsc` build succeeds.
- [x] New unit tests (mocked db) cover: zero-data baseline percent/step shape, conditional-domain exclusion/inclusion for loans and investments, server-config step excluded from percent math even when configured, and credit-card annual-fee detection — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)