### PR TITLE
Setup tracker 3/4: web SetupProgress card on settings page (v1)

### DIFF
--- a/apps/web/src/__tests__/setup-progress.spec.tsx
+++ b/apps/web/src/__tests__/setup-progress.spec.tsx
@@ -1,0 +1,139 @@
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { SetupProgress } from '@moneypulse/shared';
+import { SetupProgressCard } from '@/components/SetupProgressCard';
+
+// ── Synthetic fixtures (no real financial data) ──────────────
+
+const mockUseSetupProgress = vi.fn();
+
+vi.mock('@/lib/hooks/useSettings', () => ({
+  useSetupProgress: () => mockUseSetupProgress(),
+}));
+
+function renderWithQuery(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
+
+function makeProgress(overrides: Partial<SetupProgress> = {}): SetupProgress {
+  return {
+    percent: 40,
+    completed: 2,
+    total: 5,
+    steps: [
+      {
+        id: 'accounts',
+        label: 'Add your first account',
+        done: true,
+        unlocks: 'Overview + analytics',
+        href: '/accounts',
+        kind: 'user-data',
+      },
+      {
+        id: 'import',
+        label: 'Import a statement',
+        done: true,
+        unlocks: 'Transactions',
+        href: '/imports',
+        kind: 'user-data',
+      },
+      {
+        id: 'paycheck',
+        label: 'Set your take-home pay',
+        done: false,
+        unlocks: '50/30/20 dashboard',
+        href: '/settings/paycheck-profiles',
+        kind: 'user-data',
+      },
+      {
+        id: 'advisor',
+        label: 'Configure the AI advisor',
+        done: false,
+        unlocks: 'AI recap + reviews',
+        href: '/settings',
+        kind: 'server-config',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('SetupProgressCard', () => {
+  it('renders percent and completed/total summary', () => {
+    mockUseSetupProgress.mockReturnValue({
+      data: { data: makeProgress() },
+      isLoading: false,
+      isError: false,
+    });
+    renderWithQuery(<SetupProgressCard />);
+    expect(screen.getByText('40%')).toBeInTheDocument();
+    expect(screen.getByText('2 of 5 steps done')).toBeInTheDocument();
+  });
+
+  it('renders done steps as struck-through and pending user-data steps as deep-links', () => {
+    mockUseSetupProgress.mockReturnValue({
+      data: { data: makeProgress() },
+      isLoading: false,
+      isError: false,
+    });
+    renderWithQuery(<SetupProgressCard />);
+
+    const doneLabel = screen.getByText('Add your first account');
+    expect(doneLabel.closest('span')).toHaveClass('line-through');
+
+    const pendingLink = screen.getByRole('link', { name: 'Set your take-home pay' });
+    expect(pendingLink).toHaveAttribute('href', '/settings/paycheck-profiles');
+    expect(screen.getByText(/unlocks: 50\/30\/20 dashboard/)).toBeInTheDocument();
+  });
+
+  it('shows server-config steps informationally, visually separated from countable steps', () => {
+    mockUseSetupProgress.mockReturnValue({
+      data: { data: makeProgress() },
+      isLoading: false,
+      isError: false,
+    });
+    renderWithQuery(<SetupProgressCard />);
+
+    expect(screen.getByText('server setup')).toBeInTheDocument();
+    expect(screen.getByText('Configure the AI advisor')).toBeInTheDocument();
+    // Server-config steps must not be a deep-link (user can't complete from web UI).
+    expect(
+      screen.queryByRole('link', { name: 'Configure the AI advisor' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('collapses the checklist and shows a complete state at 100%', () => {
+    mockUseSetupProgress.mockReturnValue({
+      data: {
+        data: makeProgress({
+          percent: 100,
+          completed: 5,
+          total: 5,
+          steps: makeProgress().steps.map((s) => ({ ...s, done: true })),
+        }),
+      },
+      isLoading: false,
+      isError: false,
+    });
+    renderWithQuery(<SetupProgressCard />);
+
+    expect(screen.getByTestId('setup-progress-complete')).toHaveTextContent(
+      'Setup complete ✓',
+    );
+    expect(screen.queryByText('Add your first account')).not.toBeInTheDocument();
+    expect(screen.queryByText('server setup')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing while loading or on error', () => {
+    mockUseSetupProgress.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+    const { container: loadingContainer } = renderWithQuery(<SetupProgressCard />);
+    expect(loadingContainer).toBeEmptyDOMElement();
+
+    mockUseSetupProgress.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+    const { container: errorContainer } = renderWithQuery(<SetupProgressCard />);
+    expect(errorContainer).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/src/app/(protected)/settings/page.tsx
+++ b/apps/web/src/app/(protected)/settings/page.tsx
@@ -6,6 +6,7 @@ import { api } from '@/lib/api';
 import { ThemeToggle } from '@/components/ThemeToggle';
 import { AdvisorSettingsSection } from '@/components/AdvisorSettingsSection';
 import { SuitabilitySettingsSection } from '@/components/SuitabilitySettingsSection';
+import { SetupProgressCard } from '@/components/SetupProgressCard';
 import { useSendTestNotification } from '@/lib/hooks/useNotifications';
 
 export default function SettingsPage() {
@@ -88,6 +89,8 @@ export default function SettingsPage() {
         <h1 className="text-4xl font-extrabold tracking-tight">Settings</h1>
         <p className="text-[var(--muted-foreground)]">Manage your preferences and integrations</p>
       </div>
+
+      <SetupProgressCard />
 
       {/* Theme */}
       <section className="space-y-3 rounded-2xl bg-[var(--surface-container-low)] p-6">

--- a/apps/web/src/components/SetupProgressCard.tsx
+++ b/apps/web/src/components/SetupProgressCard.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { Check, Server } from 'lucide-react';
+import { useSetupProgress } from '@/lib/hooks/useSettings';
+import type { SetupProgressStep } from '@moneypulse/shared';
+
+/**
+ * Setup-completeness card shown at the top of Settings (#224/#230, web half of
+ * the setup-tracker epic — server half is #225's `GET /settings/setup-progress`).
+ *
+ * `kind: 'user-data'` steps are the ones the % is computed from and get an
+ * actionable deep-link when pending. `kind: 'server-config'` steps (e.g. the AI
+ * advisor's API key) are shown for visibility only — the user can't complete
+ * them from the web UI, so they're visually separated and excluded from the math.
+ */
+export function SetupProgressCard() {
+  const { data, isLoading, isError } = useSetupProgress();
+
+  if (isLoading || isError || !data) return null;
+
+  const { percent, completed, total, steps } = data.data;
+  const isComplete = percent === 100;
+
+  const userDataSteps = steps.filter((s: SetupProgressStep) => s.kind === 'user-data');
+  const serverConfigSteps = steps.filter((s: SetupProgressStep) => s.kind === 'server-config');
+
+  return (
+    <section
+      data-testid="setup-progress-card"
+      className="space-y-4 rounded-2xl bg-[var(--surface-container-low)] p-6"
+    >
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-bold">Setup Progress</h2>
+          {isComplete ? (
+            <p className="text-sm text-[var(--primary)]" data-testid="setup-progress-complete">
+              Setup complete ✓
+            </p>
+          ) : (
+            <p className="text-sm text-[var(--muted-foreground)]">
+              {completed} of {total} steps done
+            </p>
+          )}
+        </div>
+        <div
+          className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full text-sm font-bold"
+          style={{
+            background: `conic-gradient(var(--primary) ${percent}%, var(--border) 0)`,
+          }}
+          role="progressbar"
+          aria-valuenow={percent}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        >
+          <span className="flex h-11 w-11 items-center justify-center rounded-full bg-[var(--surface-container-low)] text-xs">
+            {percent}%
+          </span>
+        </div>
+      </div>
+
+      {!isComplete && (
+        <ul className="space-y-2">
+          {userDataSteps.map((step: SetupProgressStep) => (
+            <li
+              key={step.id}
+              className="flex flex-col gap-0.5 sm:flex-row sm:items-center sm:justify-between"
+            >
+              {step.done ? (
+                <span className="flex items-center gap-2 text-sm text-[var(--muted-foreground)] line-through">
+                  <Check className="h-4 w-4 shrink-0 text-[var(--primary)]" aria-hidden />
+                  {step.label}
+                </span>
+              ) : (
+                <div className="flex flex-col gap-0.5">
+                  <a
+                    href={step.href}
+                    className="text-sm font-medium text-[var(--primary)] hover:underline"
+                  >
+                    {step.label}
+                  </a>
+                  <span className="text-xs text-[var(--muted-foreground)]">
+                    unlocks: {step.unlocks}
+                  </span>
+                </div>
+              )}
+            </li>
+          ))}
+
+          {serverConfigSteps.length > 0 && (
+            <li className="mt-2 space-y-2 border-t border-[var(--border)] pt-2">
+              {serverConfigSteps.map((step: SetupProgressStep) => (
+                <div
+                  key={step.id}
+                  className="flex flex-col gap-0.5 sm:flex-row sm:items-center sm:gap-2"
+                >
+                  <span className="inline-flex w-fit items-center gap-1 rounded-full bg-[var(--muted)] px-2 py-0.5 text-xs font-medium text-[var(--muted-foreground)]">
+                    <Server className="h-3 w-3" aria-hidden />
+                    server setup
+                  </span>
+                  <span className="text-sm text-[var(--muted-foreground)]">
+                    {step.label}
+                    {!step.done && (
+                      <span className="ml-1 text-xs">— Configured on the server</span>
+                    )}
+                  </span>
+                </div>
+              ))}
+            </li>
+          )}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/SetupProgressCard.tsx
+++ b/apps/web/src/components/SetupProgressCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { Check, Server } from 'lucide-react';
 import { useSetupProgress } from '@/lib/hooks/useSettings';
 import type { SetupProgressStep } from '@moneypulse/shared';
@@ -72,12 +73,12 @@ export function SetupProgressCard() {
                 </span>
               ) : (
                 <div className="flex flex-col gap-0.5">
-                  <a
+                  <Link
                     href={step.href}
                     className="text-sm font-medium text-[var(--primary)] hover:underline"
                   >
                     {step.label}
-                  </a>
+                  </Link>
                   <span className="text-xs text-[var(--muted-foreground)]">
                     unlocks: {step.unlocks}
                   </span>

--- a/apps/web/src/lib/hooks/useSettings.ts
+++ b/apps/web/src/lib/hooks/useSettings.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../api';
+import type { SetupProgress } from '@moneypulse/shared';
+
+/**
+ * Fetch the authenticated user's setup-completeness (#224/#225/#230). Computed
+ * on the fly server-side — no local caching beyond react-query's default.
+ */
+export function useSetupProgress() {
+  return useQuery({
+    queryKey: ['settings', 'setup-progress'],
+    queryFn: () => api.get<{ data: SetupProgress }>('/settings/setup-progress'),
+  });
+}


### PR DESCRIPTION
Committed successfully.

## Summary

Implemented the web half of the setup-tracker epic (#230), consuming the already-merged `GET /settings/setup-progress` endpoint (#225):

- **`useSetupProgress()`** hook (`apps/web/src/lib/hooks/useSettings.ts`) — mirrors the existing `useAnalytics.ts` react-query + `api.get` pattern.
- **`SetupProgressCard`** component — placed at the top of the settings page:
  - A percent ring (conic-gradient using `var(--primary)`) plus "`completed` of `total` steps done".
  - Done `user-data` steps render with a check icon and strikethrough/muted label.
  - Pending `user-data` steps render as deep-links (`<a href>`) styled like existing settings links, with an "unlocks: …" hint.
  - `server-config` steps are shown informationally in a visually distinct "server setup" chip group, excluded from the percent math, since they can't be completed from the web UI.
  - At `percent === 100`, the checklist collapses and a "Setup complete ✓" state is shown instead.
- Card reuses the existing settings-section card idiom (`rounded-2xl bg-[var(--surface-container-low)] p-6`) and is theme-aware via CSS variables only.
- Sub-2 (dismissal via `setup_tracker_dismissed_at`) hasn't landed in this checkout, so dismissal was intentionally left out per the issue's guidance — the card always shows while incomplete.

**Testing**: added `apps/web/src/__tests__/setup-progress.spec.tsx` (5 cases: percent/summary render, done-vs-pending row rendering, server-config separation, 100%-collapse state, loading/error no-render), following the existing convention of mocking the hook module directly. Full web test suite (92 tests) and lint pass; verified the new/changed source files typecheck cleanly against a built `@moneypulse/shared` (pre-existing unrelated typecheck gaps in the repo — unbuilt shared package, vitest globals under plain `tsc`, and prior lint debt in other files — were confirmed pre-existing via a stash-based diff, not introduced by this change).

---
### Test evidence
**5 new test case(s) added** (heuristic count):
```
 apps/web/src/__tests__/setup-progress.spec.tsx | 139 +++++++++++++++++++++++++
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
pulse/web:test:  [32m✓[39m src/__tests__/format.spec.ts [2m([22m[2m13 tests[22m[2m)[22m[32m 29[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/split-transaction.spec.tsx [2m([22m[2m10 tests[22m[2m)[22m[33m 1176[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/pwa.spec.tsx [2m([22m[2m5 tests[22m[2m)[22m[32m 15[2mms[22m[39m
@moneypulse/web:test: Not implemented: navigation to another Document
@moneypulse/web:test:  [32m✓[39m src/__tests__/api.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 8[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/add-transaction.spec.tsx [2m([22m[2m9 tests[22m[2m)[22m[33m 1255[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/accountGrouping.spec.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/monthly-close.spec.tsx [2m([22m[2m9 tests[22m[2m)[22m[32m 112[2mms[22m[39m
@moneypulse/web:test: 
@moneypulse/web:test: [2m Test Files [22m [1m[32m12 passed[39m[22m[90m (12)[39m
@moneypulse/web:test: [2m      Tests [22m [1m[32m92 passed[39m[22m[2m | [22m[33m3 skipped[39m[90m (95)[39m
@moneypulse/web:test: [2m   Start at [22m 08:04:14
@moneypulse/web:test: [2m   Duration [22m 2.89s[2m (transform 663ms, setup 819ms, import 2.94s, tests 4.28s, environment 9.04s)[22m
@moneypulse/web:test: 

 Tasks:    2 successful, 2 total
Cached:    0 cached, 2 total
  Time:    4.048s
```
</details>

### Review
**Review verdict:** approve

Findings (advisory — did not block landing):
- [low/advisory] apps/web/src/components/SetupProgressCard.tsx:74 — Pending user-data steps use a raw <a href> instead of Next.js <Link>, triggering full-page reloads on internal navigation (UX/perf nit, non-blocking).

---
Dispatched via coxd (`MyMoney-setup-tracker-3-4-web-setupp-1785585594`) · cost $1.398 · 🤖 coxd