### PR TITLE
Setup tracker 2/4: setup_tracker_dismissed_at column + dismissal wirin

### DIFF
--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -227,6 +227,11 @@ export const userSettings = pgTable('user_settings', {
   proactiveAdvisorEnabled: boolean('proactive_advisor_enabled')
     .notNull()
     .default(false),
+  /** #229 setup-completeness tracker (sub-issue 2/4) — set when the user dismisses the
+   *  setup-progress widget; null means "not dismissed" / "show it". The web card
+   *  re-surfaces the tracker once `percent`/`completed` has moved on since this was set,
+   *  so dismissal means "hide until something changes", not "hide forever". */
+  setupTrackerDismissedAt: timestamp('setup_tracker_dismissed_at', { withTimezone: true }),
   createdAt: timestamp('created_at', { withTimezone: true })
     .notNull()
     .defaultNow(),

--- a/apps/api/src/settings/__tests__/setup-progress.service.spec.ts
+++ b/apps/api/src/settings/__tests__/setup-progress.service.spec.ts
@@ -143,4 +143,34 @@ describe('SetupProgressService', () => {
     const ccFeesStep2 = result2.steps.find((s) => s.id === 'cc_fees');
     expect(ccFeesStep2?.done).toBe(true);
   });
+
+  describe('dismissedAt (#229, sub-issue 2/4)', () => {
+    it('is null when the user has never dismissed the tracker', async () => {
+      service = await build(mockDbWith(emptyRows()));
+      const result = await service.getSetupProgress(TEST_USER_ID);
+
+      expect(result.dismissedAt).toBeNull();
+    });
+
+    it('reflects the stored setupTrackerDismissedAt timestamp as an ISO string', async () => {
+      const rows = emptyRows();
+      const dismissedAt = new Date('2026-01-01T00:00:00.000Z');
+      rows[3] = [{ setupTrackerDismissedAt: dismissedAt }]; // userSettings
+
+      service = await build(mockDbWith(rows));
+      const result = await service.getSetupProgress(TEST_USER_ID);
+
+      expect(result.dismissedAt).toBe(dismissedAt.toISOString());
+    });
+
+    it('is null once the dismissal has been cleared (setupTrackerDismissedAt: null)', async () => {
+      const rows = emptyRows();
+      rows[3] = [{ setupTrackerDismissedAt: null }]; // userSettings
+
+      service = await build(mockDbWith(rows));
+      const result = await service.getSetupProgress(TEST_USER_ID);
+
+      expect(result.dismissedAt).toBeNull();
+    });
+  });
 });

--- a/apps/api/src/settings/setup-progress.service.ts
+++ b/apps/api/src/settings/setup-progress.service.ts
@@ -278,11 +278,17 @@ export class SetupProgressService {
     const completed = countable.filter((s) => s.done).length;
     const percent = total > 0 ? Math.round((completed / total) * 100) : 0;
 
+    const dismissedAtRaw = userSettings?.setupTrackerDismissedAt ?? null;
+    const dismissedAt = dismissedAtRaw
+      ? new Date(dismissedAtRaw).toISOString()
+      : null;
+
     return {
       percent,
       completed,
       total,
       steps: steps.map(({ applicable: _applicable, ...step }) => step),
+      dismissedAt,
     };
   }
 }

--- a/apps/api/src/users/users.service.spec.ts
+++ b/apps/api/src/users/users.service.spec.ts
@@ -107,4 +107,38 @@ describe('UsersService', () => {
       );
     });
   });
+
+  describe('updateSettings — setup tracker dismissal (#229)', () => {
+    it('translates setupTrackerDismissed: true into a stored timestamp', async () => {
+      mockDb.where.mockReturnThis();
+
+      await service.updateSettings('user-1', { setupTrackerDismissed: true });
+
+      expect(mockDb.set).toHaveBeenCalledWith(
+        expect.objectContaining({ setupTrackerDismissedAt: expect.any(Date) }),
+      );
+      const setArg = mockDb.set.mock.calls.at(-1)?.[0];
+      expect(setArg).not.toHaveProperty('setupTrackerDismissed');
+    });
+
+    it('translates setupTrackerDismissed: false into null, clearing the dismissal', async () => {
+      mockDb.where.mockReturnThis();
+
+      await service.updateSettings('user-1', { setupTrackerDismissed: false });
+
+      expect(mockDb.set).toHaveBeenCalledWith(
+        expect.objectContaining({ setupTrackerDismissedAt: null }),
+      );
+    });
+
+    it('leaves setupTrackerDismissedAt untouched when the field is absent', async () => {
+      mockDb.where.mockReturnThis();
+
+      await service.updateSettings('user-1', { timezone: 'America/Chicago' });
+
+      const setArg = mockDb.set.mock.calls.at(-1)?.[0];
+      expect(setArg).not.toHaveProperty('setupTrackerDismissedAt');
+      expect(setArg).not.toHaveProperty('setupTrackerDismissed');
+    });
+  });
 });

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -124,6 +124,13 @@ export class UsersService {
     const encrypted: any = { ...data, updatedAt: new Date() };
     if (data.haWebhookUrl) encrypted.haWebhookUrl = encryptField(data.haWebhookUrl);
     if (data.notificationEmail) encrypted.notificationEmail = encryptField(data.notificationEmail);
+    // #229: `setupTrackerDismissed` is a boolean over the wire but persists as a
+    // timestamp (or null to clear/re-surface) so we translate it here rather than
+    // storing a raw client-supplied timestamp.
+    if ('setupTrackerDismissed' in data) {
+      encrypted.setupTrackerDismissedAt = data.setupTrackerDismissed ? new Date() : null;
+      delete encrypted.setupTrackerDismissed;
+    }
     const rows = await this.db
       .update(schema.userSettings)
       .set(encrypted)

--- a/db/migrations/0034_setup_tracker_dismissed_at.sql
+++ b/db/migrations/0034_setup_tracker_dismissed_at.sql
@@ -1,0 +1,7 @@
+-- Add nullable setup_tracker_dismissed_at to user_settings so the setup-progress
+-- widget (#224 epic, sub-issue 2/4 #229) can be dismissed by the user without
+-- hiding it forever: the web card re-surfaces the tracker once progress moves
+-- on since the dismissal timestamp. Additive-only: nullable column, no
+-- backfill, existing rows get NULL (= not dismissed).
+
+ALTER TABLE "user_settings" ADD COLUMN IF NOT EXISTS "setup_tracker_dismissed_at" timestamp with time zone;

--- a/db/migrations/meta/_journal.json
+++ b/db/migrations/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1784561100000,
       "tag": "0033_notification_type_digest_advisor_coach",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1784561200000,
+      "tag": "0034_setup_tracker_dismissed_at",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/src/validation/index.ts
+++ b/packages/shared/src/validation/index.ts
@@ -229,6 +229,9 @@ export const updateUserSettingsSchema = z.object({
   dailyBriefEnabled: z.boolean().optional(),
   dailyBriefHour: z.number().int().min(0).max(23).optional(),
   proactiveAdvisorEnabled: z.boolean().optional(),
+  // #229 (sub-issue 2/4): true dismisses the setup-progress widget (stores "now" server-side),
+  // false/null clears the dismissal so the widget re-surfaces immediately.
+  setupTrackerDismissed: z.boolean().nullable().optional(),
 });
 
 export const sendDigestSchema = z.object({
@@ -561,6 +564,11 @@ export const setupProgressSchema = z.object({
   completed: z.int().min(0),
   total: z.int().min(0),
   steps: z.array(setupProgressStepSchema),
+  // #229 (sub-issue 2/4): when the user last dismissed the setup-progress widget, or
+  // null if it's never been dismissed / the dismissal has been cleared server-side.
+  // The web card (sub-3/4) decides whether to still honor this — e.g. it should stop
+  // honoring it once `completed`/`percent` has increased since this timestamp.
+  dismissedAt: z.iso.datetime().nullable(),
 });
 
 export type SetupProgressStepKind = z.infer<typeof setupProgressStepKindSchema>;


### PR DESCRIPTION
Committed successfully.

## Summary

Implemented setup-tracker sub-issue 2/4 (dismissal persistence, #229):

- **Schema**: added nullable `setup_tracker_dismissed_at timestamptz` to `user_settings` in `schema.ts`, plus a new additive-only Drizzle migration (`0034_setup_tracker_dismissed_at.sql`) registered in `db/migrations/meta/_journal.json`.
- **API — read side**: `SetupProgressService.getSetupProgress` now returns `dismissedAt` (ISO string or `null`) alongside the existing percent/steps data; extended the shared `setupProgressSchema` type accordingly.
- **API — write side**: reused the existing `PATCH /users/settings` endpoint rather than adding a new one. `updateUserSettingsSchema` gained an optional `setupTrackerDismissed: boolean | null` field; `UsersService.updateSettings` translates `true` → `new Date()` and `false`/absent-check → `null`, so clients can't inject an arbitrary timestamp and the field name never leaks into the raw DB `set()` call.
- Server side deliberately stays simple (store/expose the timestamp only) — the "hide until progress changes" re-surface logic is left for the web card in sub-issue 3, per the ticket's scope.

**Testing**: added unit tests — `setup-progress.service.spec.ts` covers `dismissedAt` being `null` by default, reflecting a stored timestamp as ISO, and reverting to `null` once cleared; `users.service.spec.ts` covers the PATCH translating `true`→timestamp, `false`→`null`, and leaving the column untouched when the field is omitted. Verified via `vitest run` (17/17 passing) and a full `tsc --noEmit` pass on the API package.

---
### Test evidence
**6 new test case(s) added** (heuristic count):
```
 .../__tests__/setup-progress.service.spec.ts       | 30 +++++++++++++++++++
 apps/api/src/users/users.service.spec.ts           | 34 ++++++++++++++++++++++
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
m[2m2 tests[22m[2m)[22m[32m 8[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/sync/__tests__/sync-payload.util.spec.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 10[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/next-loan-due-date.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/categorization/__tests__/learning.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test: [32m[Nest] 83950  - [39m08/01/2026, 12:04:03 PM [32m    LOG[39m [38;5;3m[AlertCronProcessor] [39m[32mProcessing alert job: monthly-close-auto-draft[39m
@moneypulse/api:test: [32m[Nest] 83950  - [39m08/01/2026, 12:04:03 PM [32m    LOG[39m [38;5;3m[AlertCronProcessor] [39m[32mMonthly-close auto-draft: 3 user(s) processed, 2 close(s) created[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/monthly-close-cron.spec.ts [2m([22m[2m1 test[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m102 passed[39m[22m[90m (102)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m887 passed[39m[22m[90m (887)[39m
@moneypulse/api:test: [2m   Start at [22m 12:03:52
@moneypulse/api:test: [2m   Duration [22m 11.05s[2m (transform 3.41s, setup 0ms, import 58.36s, tests 2.17s, environment 6ms)[22m
@moneypulse/api:test: 

 Tasks:    2 successful, 2 total
Cached:    0 cached, 2 total
  Time:    12.211s
```
</details>

### Review
**Review verdict:** approve

---
Dispatched via coxd (`MyMoney-setup-tracker-2-4-setup-trac-1785585593`) · cost $1.165 · 🤖 coxd