### PR TITLE
Monthly-close freshness nudge fires for oldest backfilled month (2024-

### DIFF
--- a/apps/api/src/monthly-close/__tests__/monthly-close.service.spec.ts
+++ b/apps/api/src/monthly-close/__tests__/monthly-close.service.spec.ts
@@ -195,4 +195,35 @@ describe('MonthlyCloseService', () => {
       expect(notificationsService.createAndDispatch).not.toHaveBeenCalled();
     });
   });
+
+  describe('runAutoDraftForUser nudge targeting (#231)', () => {
+    it('first-run backfill sends at most one freshness nudge, and it targets targetMonth — never an older backfilled month', async () => {
+      // No prior closes -> first-run backfill path.
+      (service as any).findAll = vi.fn().mockResolvedValue([]);
+      // Activity goes back far enough to trigger a multi-month backfill.
+      (service as any).earliestActivityMonth = vi.fn().mockResolvedValue('2026-04-01');
+      (service as any).draftUnlessConfirmed = vi.fn().mockResolvedValue(true);
+      (service as any).findRow = vi.fn().mockResolvedValue(null);
+      const nudgeSpy = vi.spyOn(service as any, 'maybeNudgeFreshness').mockResolvedValue(true);
+
+      const targetMonth = '2026-06-01';
+      await (service as any).runAutoDraftForUser('user-1', targetMonth);
+
+      expect(nudgeSpy).toHaveBeenCalledTimes(1);
+      expect(nudgeSpy).toHaveBeenCalledWith('user-1', targetMonth);
+    });
+
+    it('non-first-run still nudges only targetMonth (unchanged behavior)', async () => {
+      (service as any).findAll = vi.fn().mockResolvedValue([draftRow]);
+      (service as any).draftUnlessConfirmed = vi.fn().mockResolvedValue(false);
+      (service as any).findRow = vi.fn().mockResolvedValue(draftRow);
+      const nudgeSpy = vi.spyOn(service as any, 'maybeNudgeFreshness').mockResolvedValue(true);
+
+      const targetMonth = '2026-06-01';
+      await (service as any).runAutoDraftForUser('user-1', targetMonth);
+
+      expect(nudgeSpy).toHaveBeenCalledTimes(1);
+      expect(nudgeSpy).toHaveBeenCalledWith('user-1', targetMonth);
+    });
+  });
 });

--- a/apps/api/src/monthly-close/monthly-close.service.ts
+++ b/apps/api/src/monthly-close/monthly-close.service.ts
@@ -603,9 +603,9 @@ export class MonthlyCloseService {
         const wasMissing = !(await this.findRow(userId, month));
         const drafted = await this.draftUnlessConfirmed(userId, month);
         if (drafted && wasMissing) created += 1;
-        await this.maybeNudgeFreshness(userId, month);
         month = addMonths(month, 1);
       }
+      await this.maybeNudgeFreshness(userId, targetMonth);
       return created;
     }
 


### PR DESCRIPTION
Committed successfully.

## Summary

**Root cause:** `MonthlyCloseService.runAutoDraftForUser`'s first-run backfill loop called `maybeNudgeFreshness(userId, month)` for *every* backfilled month, starting from the oldest month (`backfillStart`, up to 24 months back). The 2-month cooldown dedupe then suppressed all subsequent nudge attempts in that same run, so the one nudge that got through was for the oldest, least-actionable backfilled month rather than the current one.

**Fix:** Moved the `maybeNudgeFreshness` call out of the backfill loop in `runAutoDraftForUser` so it's invoked once, after backfilling, for `targetMonth` only — matching the existing (already-correct) non-first-run branch. Historical months are still drafted/backfilled as before; only nudge targeting changed.

**Tests:** Added two regression tests to `monthly-close.service.spec.ts`:
- First-run backfill across multiple incomplete months sends the freshness nudge exactly once, targeting `targetMonth` (never an older backfilled month).
- Non-first-run path still nudges only `targetMonth`, confirming no regression there.

Verified by running the full `monthly-close.service.spec.ts` suite (15 tests, all passing) after building the `@moneypulse/shared` workspace dependency.

---
### Test evidence
**2 new test case(s) added** (heuristic count):
```
 .../__tests__/monthly-close.service.spec.ts        | 31 ++++++++++++++++++++++
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
pec.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 11[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/audit/audit.service.spec.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 9[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/loans/__tests__/next-loan-due-date.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 2[2mms[22m[39m
@moneypulse/api:test:  [32m✓[39m src/categorization/__tests__/learning.service.spec.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test: [32m[Nest] 24498  - [39m08/02/2026, 2:50:52 PM [32m    LOG[39m [38;5;3m[AlertCronProcessor] [39m[32mProcessing alert job: monthly-close-auto-draft[39m
@moneypulse/api:test: [32m[Nest] 24498  - [39m08/02/2026, 2:50:52 PM [32m    LOG[39m [38;5;3m[AlertCronProcessor] [39m[32mMonthly-close auto-draft: 3 user(s) processed, 2 close(s) created[39m
@moneypulse/api:test:  [32m✓[39m src/jobs/__tests__/monthly-close-cron.spec.ts [2m([22m[2m1 test[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/api:test: 
@moneypulse/api:test: [2m Test Files [22m [1m[32m102 passed[39m[22m[90m (102)[39m
@moneypulse/api:test: [2m      Tests [22m [1m[32m883 passed[39m[22m[90m (883)[39m
@moneypulse/api:test: [2m   Start at [22m 14:50:40
@moneypulse/api:test: [2m   Duration [22m 12.10s[2m (transform 3.72s, setup 0ms, import 64.23s, tests 2.36s, environment 8ms)[22m
@moneypulse/api:test: 

 Tasks:    2 successful, 2 total
Cached:    1 cached, 2 total
  Time:    12.67s
```
</details>

### Review
**Review verdict:** approve

---
Dispatched via coxd (`MyMoney-monthly-close-freshness-nudg-1785585798`) · cost $0.537 · 🤖 coxd