### PR TITLE
Setup tracker 4/4: dashboard banner when setup incomplete

### DIFF
--- a/apps/web/src/__tests__/dashboard-setup-banner.spec.tsx
+++ b/apps/web/src/__tests__/dashboard-setup-banner.spec.tsx
@@ -1,0 +1,98 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { SetupProgress } from '@moneypulse/shared';
+import { DashboardSetupBanner } from '@/components/DashboardSetupBanner';
+
+// ── Synthetic fixtures (no real financial data) ──────────────
+
+const mockUseSetupProgress = vi.fn();
+const mockMutate = vi.fn();
+
+vi.mock('@/lib/hooks/useSettings', () => ({
+  useSetupProgress: () => mockUseSetupProgress(),
+  useDismissSetupTracker: () => ({ mutate: mockMutate, isPending: false }),
+}));
+
+function renderWithQuery(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
+
+function makeProgress(overrides: Partial<SetupProgress> = {}): SetupProgress {
+  return {
+    percent: 40,
+    completed: 2,
+    total: 5,
+    dismissedAt: null,
+    steps: [],
+    ...overrides,
+  };
+}
+
+describe('DashboardSetupBanner', () => {
+  beforeEach(() => {
+    mockMutate.mockClear();
+  });
+
+  it('shows the banner with progress summary when incomplete and not dismissed', () => {
+    mockUseSetupProgress.mockReturnValue({
+      data: { data: makeProgress() },
+      isLoading: false,
+      isError: false,
+    });
+    renderWithQuery(<DashboardSetupBanner />);
+
+    expect(screen.getByTestId('dashboard-setup-banner')).toBeInTheDocument();
+    expect(
+      screen.getByText('Finish setting up MoneyPulse — 2 of 5 steps done (40%)'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Finish setup' })).toHaveAttribute(
+      'href',
+      '/settings',
+    );
+  });
+
+  it('renders nothing when setup is 100% complete', () => {
+    mockUseSetupProgress.mockReturnValue({
+      data: { data: makeProgress({ percent: 100, completed: 5, total: 5 }) },
+      isLoading: false,
+      isError: false,
+    });
+    const { container } = renderWithQuery(<DashboardSetupBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when the tracker has been dismissed', () => {
+    mockUseSetupProgress.mockReturnValue({
+      data: { data: makeProgress({ dismissedAt: '2026-01-01T00:00:00.000Z' }) },
+      isLoading: false,
+      isError: false,
+    });
+    const { container } = renderWithQuery(<DashboardSetupBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing while loading or on error', () => {
+    mockUseSetupProgress.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+    const { container: loadingContainer } = renderWithQuery(<DashboardSetupBanner />);
+    expect(loadingContainer).toBeEmptyDOMElement();
+
+    mockUseSetupProgress.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+    const { container: errorContainer } = renderWithQuery(<DashboardSetupBanner />);
+    expect(errorContainer).toBeEmptyDOMElement();
+  });
+
+  it('calls the dismiss mutation when the × is clicked', () => {
+    mockUseSetupProgress.mockReturnValue({
+      data: { data: makeProgress() },
+      isLoading: false,
+      isError: false,
+    });
+    renderWithQuery(<DashboardSetupBanner />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss setup reminder' }));
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/app/(protected)/page.tsx
+++ b/apps/web/src/app/(protected)/page.tsx
@@ -44,6 +44,7 @@ import { useUpcomingBills } from '@/lib/hooks/useBills';
 import { useSubscriptions } from '@/lib/hooks/useSubscriptions';
 import { formatCents } from '@/lib/format';
 import { Repeat } from 'lucide-react';
+import { DashboardSetupBanner } from '@/components/DashboardSetupBanner';
 
 /** Dashboard page — main financial overview with KPI cards and charts. */
 export default function DashboardPage() {
@@ -140,6 +141,8 @@ export default function DashboardPage() {
           onChange={(f, t) => { setFrom(f); setTo(t); }}
         />
       </div>
+
+      <DashboardSetupBanner />
 
       {/* Net Worth — hero metric, clickable Assets & Liabilities */}
       {nw && (

--- a/apps/web/src/components/DashboardSetupBanner.tsx
+++ b/apps/web/src/components/DashboardSetupBanner.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import Link from 'next/link';
+import { X } from 'lucide-react';
+import { useDismissSetupTracker, useSetupProgress } from '@/lib/hooks/useSettings';
+
+/**
+ * Slim dashboard banner nudging the user toward the settings-page setup
+ * tracker (#224/#230/#229/#235 — final sub-issue of the setup-completeness
+ * epic). Shows only while setup is incomplete and not dismissed; dismissing
+ * here reuses the same `setupTrackerDismissed` PATCH as the settings card, so
+ * either surface dismissing hides both (they share the same query cache key).
+ */
+export function DashboardSetupBanner() {
+  const { data, isLoading, isError } = useSetupProgress();
+  const dismissMutation = useDismissSetupTracker();
+
+  if (isLoading || isError || !data) return null;
+
+  const { percent, completed, total, dismissedAt } = data.data;
+
+  if (percent === 100 || dismissedAt) return null;
+
+  return (
+    <div
+      data-testid="dashboard-setup-banner"
+      className="flex flex-col gap-2 rounded-xl border border-[var(--border)] bg-[var(--card)] px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4"
+    >
+      <div className="flex flex-1 items-center gap-3 min-w-0">
+        <div
+          className="h-1.5 w-16 shrink-0 overflow-hidden rounded-full bg-[var(--border)]"
+          role="progressbar"
+          aria-valuenow={percent}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        >
+          <div
+            className="h-full rounded-full bg-[var(--primary)]"
+            style={{ width: `${percent}%` }}
+          />
+        </div>
+        <p className="truncate text-sm text-[var(--muted-foreground)]">
+          Finish setting up MoneyPulse — {completed} of {total} steps done ({percent}%)
+        </p>
+      </div>
+
+      <div className="flex shrink-0 items-center gap-3 self-end sm:self-auto">
+        <Link
+          href="/settings"
+          className="text-sm font-medium text-[var(--primary)] hover:underline"
+        >
+          Finish setup
+        </Link>
+        <button
+          type="button"
+          aria-label="Dismiss setup reminder"
+          onClick={() => dismissMutation.mutate()}
+          disabled={dismissMutation.isPending}
+          className="text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+        >
+          <X className="h-4 w-4" aria-hidden />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/hooks/useSettings.ts
+++ b/apps/web/src/lib/hooks/useSettings.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { api } from '../api';
 import type { SetupProgress } from '@moneypulse/shared';
 
@@ -12,5 +12,21 @@ export function useSetupProgress() {
   return useQuery({
     queryKey: ['settings', 'setup-progress'],
     queryFn: () => api.get<{ data: SetupProgress }>('/settings/setup-progress'),
+  });
+}
+
+/**
+ * Dismiss the setup-completeness tracker (#224/#229/#235). Shared by every
+ * surface that can dismiss it (settings card, dashboard banner) so they stay
+ * in sync — both read the same `['settings', 'setup-progress']` query, which
+ * this invalidates on success.
+ */
+export function useDismissSetupTracker() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.patch('/users/settings', { setupTrackerDismissed: true }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['settings', 'setup-progress'] });
+    },
   });
 }


### PR DESCRIPTION
Committed successfully.

## Summary

Implemented the final sub-issue (4/4) of the setup-completeness epic (#224/#235): a slim, dismissable banner on the main dashboard (`apps/web/src/app/(protected)/page.tsx`) that nudges users toward the settings-page setup tracker when their setup is incomplete.

**Changes:**
- `apps/web/src/components/DashboardSetupBanner.tsx` (new): single-row banner with a progress bar, "Finish setting up MoneyPulse — {completed} of {total} steps done ({percent}%)" copy, a `next/link` to `/settings`, and a "×" dismiss control. Renders nothing while loading, on error, at 100%, or once `dismissedAt` is set. Uses `var(--card)`/`var(--border)`/`var(--primary)` tokens to stay theme-aware, and collapses to a stacked layout on narrow screens.
- `apps/web/src/lib/hooks/useSettings.ts`: added `useDismissSetupTracker()`, a mutation that PATCHes `/users/settings` with `setupTrackerDismissed: true` (the same field the settings-page card mechanism from #229 uses) and invalidates the shared `['settings', 'setup-progress']` query key, so a dismissal from either surface stays consistent.
- Wired the banner into the primary dashboard page (`/`, the actual landing route per the nav config — `/overview` is a separate secondary accounts page).
- Added `apps/web/src/__tests__/dashboard-setup-banner.spec.tsx` covering: shows with correct copy/link when incomplete and not dismissed, hides at 100%, hides when `dismissedAt` is set, hides on loading/error, and the dismiss button triggers the mutation — following the same mocking conventions as the existing `setup-progress.spec.tsx`.

**Verification:** ran the new and existing web test suites (`vitest run`, 97 passed/3 skipped, none newly failing), `tsc --noEmit` (no new errors introduced — pre-existing unrelated errors in the repo are untouched), and `eslint` on all touched files (clean).

---
### Test evidence
**5 new test case(s) added** (heuristic count):
```
 .../src/__tests__/dashboard-setup-banner.spec.tsx  | 98 ++++++++++++++++++++++
```

### Gate results
- ✅ `migrations`
- ✅ `test`
- ✅ `lint`
- ✅ `build`

<details><summary>Test run output (tail)</summary>

```
eb:test:  [32m✓[39m src/__tests__/split-transaction.spec.tsx [2m([22m[2m10 tests[22m[2m)[22m[33m 1283[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/monthly-close.spec.tsx [2m([22m[2m9 tests[22m[2m)[22m[32m 179[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/pwa.spec.tsx [2m([22m[2m5 tests[22m[2m)[22m[32m 13[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/mobile-card.spec.tsx [2m([22m[2m8 tests[22m[2m)[22m[32m 221[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/add-transaction.spec.tsx [2m([22m[2m9 tests[22m[2m)[22m[33m 1339[2mms[22m[39m
@moneypulse/web:test: Not implemented: navigation to another Document
@moneypulse/web:test:  [32m✓[39m src/__tests__/api.spec.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 8[2mms[22m[39m
@moneypulse/web:test:  [32m✓[39m src/__tests__/accountGrouping.spec.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 3[2mms[22m[39m
@moneypulse/web:test: 
@moneypulse/web:test: [2m Test Files [22m [1m[32m13 passed[39m[22m[90m (13)[39m
@moneypulse/web:test: [2m      Tests [22m [1m[32m97 passed[39m[22m[2m | [22m[33m3 skipped[39m[90m (100)[39m
@moneypulse/web:test: [2m   Start at [22m 11:02:43
@moneypulse/web:test: [2m   Duration [22m 3.22s[2m (transform 718ms, setup 839ms, import 3.33s, tests 4.60s, environment 9.40s)[22m
@moneypulse/web:test: 

 Tasks:    2 successful, 2 total
Cached:    1 cached, 2 total
  Time:    3.737s
```
</details>

### Review
**Review verdict:** approve

---
Dispatched via coxd (`MyMoney-setup-tracker-4-4-dashboard-1785682696`) · cost $1.246 · 🤖 coxd